### PR TITLE
👌 IMPROVE: Add SLF4J logging configurator class

### DIFF
--- a/runtime/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/runtime/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
+import ortus.boxlang.runtime.logging.SLF4JConfigurator;
+
 /**
  * The BoxRunner class is an entry point for the BoxLang runtime. It is responsible for
  * executing a single incoming script template or class
@@ -34,6 +36,8 @@ public class BoxRunner {
 	 * @param args The command-line arguments
 	 */
 	public static void main( String[] args ) {
+		SLF4JConfigurator.configure();
+
 		// Verify incoming arguments
 		if ( args.length == 0 ) {
 			logger.error( "No script specified. We need a script or class to execute!" );

--- a/runtime/src/main/java/ortus/boxlang/runtime/logging/SLF4JConfigurator.java
+++ b/runtime/src/main/java/ortus/boxlang/runtime/logging/SLF4JConfigurator.java
@@ -1,0 +1,39 @@
+package ortus.boxlang.runtime.logging;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.LogManager;
+
+/**
+ * Configures the bundled SLF4J provider.
+ * 
+ * This class serves as a single endpoint for configuring the slf4j logging provider, whether it is:
+ * 
+ * <ul>
+ * <li>java.util.logging</li>
+ * <li>logback</li>
+ * <li>Apache Commons Logging</li>
+ * </ul>
+ * 
+ * or anything else, this class will ensure the provider logs according to the defined configuration.
+ */
+public class SLF4JConfigurator {
+
+	/**
+	 * Read and apply configuration for the currently installed SLF4J provider
+	 */
+	public static void configure() {
+		try {
+			LogManager.getLogManager().readConfiguration( loadFromPropertiesFile() );
+		} catch ( IOException e ) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Read logging configuration from the `logging.properties` file
+	 */
+	private static InputStream loadFromPropertiesFile() {
+		return SLF4JConfigurator.class.getClassLoader().getResourceAsStream( "logging.properties" );
+	}
+}

--- a/runtime/src/main/resources/logging.properties
+++ b/runtime/src/main/resources/logging.properties
@@ -1,0 +1,8 @@
+# JUL-specific logging configuration.
+# If we switch to a different slf4j provider, such as logback,
+# we'll need to drop this file in favor of a `logback.xml` config file
+handlers= java.util.logging.ConsoleHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %n


### PR DESCRIPTION
Add a configuration class which is in charge of configuring the slf4j provider at runtime. Later we can add a standard configuration format which will hopefully apply across whatever slf4j provider we have installed.

For now, we're using the `logging.properties` to configure the runtime logging:

```bash
handlers= java.util.logging.ConsoleHandler
.level= INFO
java.util.logging.ConsoleHandler.level = INFO
java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %n
```