### PR TITLE
Fix double-hash detection within single quotes mode

### DIFF
--- a/src/main/antlr/CFLexer.g4
+++ b/src/main/antlr/CFLexer.g4
@@ -184,7 +184,7 @@ CLOSE_SQUOTE
     ;
 
 SHASHHASH
-	: '##'
+	: '##' -> type(HASHHASH)
     ;
 
 SSTRING_LITERAL


### PR DESCRIPTION
This fixes double-hash detection in strings such as `message = "idea ##20";`

Previously, 
1. `var foo = '##';` threw a parse error
2. `var foo = "##";` did not throw a parse error

This PR fixes 1 above, without breaking 2.