### PR TITLE
Move Logger instantiation in transformers to Abstract class

### DIFF
--- a/src/main/java/ortus/boxlang/transpiler/transformer/AbstractTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/AbstractTransformer.java
@@ -19,6 +19,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.Node;
@@ -53,8 +56,14 @@ public abstract class AbstractTransformer implements Transformer {
 	protected static JavaParser				javaParser		= new JavaParser();
 	protected static BoxLangCrossReferencer	crossReferencer	= new BoxLangCrossReferencerDefault();
 
+	/**
+	 * Logger
+	 */
+	protected Logger						logger;
+
 	public AbstractTransformer( Transpiler transpiler ) {
-		this.transpiler = transpiler;
+		this.transpiler	= transpiler;
+		this.logger		= LoggerFactory.getLogger( this.getClass() );
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxAccessTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxAccessTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -19,8 +16,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxAccessTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxAccessTransformer.class );
 
 	public BoxAccessTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxArgumentTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxArgumentTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -19,8 +16,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxArgument Node the equivalent Java Parser AST nodes
  */
 public class BoxArgumentTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxArgumentTransformer.class );
 
 	public BoxArgumentTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxArrayLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxArrayLiteralTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -35,8 +32,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * </pre>
  */
 public class BoxArrayLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxArrayLiteralTransformer.class );
 
 	public BoxArrayLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxAssignmentTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxAssignmentTransformer.java
@@ -6,9 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -28,8 +25,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxAssignmentTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxAssignmentTransformer.class );
 
 	public BoxAssignmentTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxBinaryOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxBinaryOperationTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -34,8 +31,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxBinaryOperation Node the equivalent Java Parser AST nodes
  */
 public class BoxBinaryOperationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxBinaryOperationTransformer.class );
 
 	public BoxBinaryOperationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxBooleanLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxBooleanLiteralTransformer.java
@@ -16,8 +16,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxBooleanLiteral;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -28,8 +26,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxBooleanLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxBooleanLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxBooleanLiteralTransformer.class );
 
 	public BoxBooleanLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxComparisonOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxComparisonOperationTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -20,8 +17,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxComparisonOperation Node the equivalent Java Parser AST nodes
  */
 public class BoxComparisonOperationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxComparisonOperationTransformer.class );
 
 	public BoxComparisonOperationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxDecimalLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxDecimalLiteralTransformer.java
@@ -17,8 +17,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxDecimalLiteral;
 import ortus.boxlang.ast.expression.BoxIntegerLiteral;
@@ -30,8 +28,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxBooleanLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxDecimalLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxDecimalLiteralTransformer.class );
 
 	public BoxDecimalLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxExpressionInvocationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxExpressionInvocationTransformer.java
@@ -4,9 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -17,8 +14,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxExpressionInvocationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxExpressionInvocationTransformer.class );
 
 	public BoxExpressionInvocationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxFQNTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxFQNTransformer.java
@@ -2,8 +2,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.NameExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxFQN;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -11,8 +9,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxFQNTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxFQNTransformer.class );
 
 	public BoxFQNTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxFunctionInvocationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxFunctionInvocationTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -30,8 +27,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxFunctionInvocationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxFunctionInvocationTransformer.class );
 
 	public BoxFunctionInvocationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxIdentifierTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxIdentifierTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 
 import ortus.boxlang.ast.BoxNode;
@@ -32,8 +29,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxIdentifier Node the equivalent Java Parser AST nodes
  */
 public class BoxIdentifierTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxIdentifierTransformer.class );
 
 	public BoxIdentifierTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxIntegerLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxIntegerLiteralTransformer.java
@@ -16,8 +16,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxIntegerLiteral;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -28,8 +26,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxIntegerLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxIntegerLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxIntegerLiteralTransformer.class );
 
 	public BoxIntegerLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxLambdaTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxLambdaTransformer.java
@@ -16,9 +16,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -45,7 +42,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  */
 public class BoxLambdaTransformer extends AbstractTransformer {
 
-	Logger			logger		= LoggerFactory.getLogger( BoxLambdaTransformer.class );
 	// @formatter:off
 	private String template = """
 		package ${packageName};

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxMethodInvocationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxMethodInvocationTransformer.java
@@ -4,9 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -18,8 +15,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxMethodInvocationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxMethodInvocationTransformer.class );
 
 	public BoxMethodInvocationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxNewOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxNewOperationTransformer.java
@@ -4,9 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -18,8 +15,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxNewOperationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxNewOperationTransformer.class );
 
 	public BoxNewOperationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxNullTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxNullTransformer.java
@@ -14,9 +14,6 @@
  */
 package ortus.boxlang.transpiler.transformer.expression;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 
@@ -29,8 +26,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxIntegerLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxNullTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxNullTransformer.class );
 
 	public BoxNullTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxParenthesisTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxParenthesisTransformer.java
@@ -2,8 +2,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxParenthesis;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -14,8 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BoxParenthesisTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxParenthesisTransformer.class );
 
 	public BoxParenthesisTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxScopeTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxScopeTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 
 import ortus.boxlang.ast.BoxNode;
@@ -15,8 +12,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxScopeTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxScopeTransformer.class );
 
 	public BoxScopeTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStringConcatTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStringConcatTransformer.java
@@ -5,9 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 
 import ortus.boxlang.ast.BoxNode;
@@ -20,8 +17,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a String Interpolatiion the equivalent Java Parser AST nodes
  */
 public class BoxStringConcatTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxStringConcatTransformer.class );
 
 	public BoxStringConcatTransformer( Transpiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStringLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStringLiteralTransformer.java
@@ -16,8 +16,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.expression.BoxStringLiteral;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -28,8 +26,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxStringLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxStringLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxStringLiteralTransformer.class );
 
 	public BoxStringLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStructLiteralTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxStructLiteralTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -24,8 +21,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxStructUnorderedLiteral Node the equivalent Java Parser AST nodes
  */
 public class BoxStructLiteralTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxStructLiteralTransformer.class );
 
 	public BoxStructLiteralTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxUnaryOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/expression/BoxUnaryOperationTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.expression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 
 import ortus.boxlang.ast.BoxExpr;
@@ -39,8 +36,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxUnaryOperatorTransformer Node the equivalent Java Parser AST node
  */
 public class BoxUnaryOperationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxUnaryOperationTransformer.class );
 
 	public BoxUnaryOperationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxArgumentDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxArgumentDeclarationTransformer.java
@@ -2,9 +2,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -18,8 +15,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxArgumentDeclarationTransformer Node the equivalent Java Parser AST nodes
  */
 public class BoxArgumentDeclarationTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxArgumentDeclarationTransformer.class );
 
 	public BoxArgumentDeclarationTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxAssertTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxAssertTransformer.java
@@ -16,8 +16,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.transpiler.JavaTranspiler;
 import ortus.boxlang.transpiler.transformer.AbstractTransformer;
@@ -31,8 +29,6 @@ import java.util.Map;
  * Transform a BoxAssert Node the equivalent Java Parser AST nodes
  */
 public class BoxAssertTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxAssertTransformer.class );
 
 	public BoxAssertTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxDoTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxDoTransformer.java
@@ -5,8 +5,6 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.DoStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.BoxStatement;
 import ortus.boxlang.ast.statement.BoxDo;
@@ -18,8 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BoxDoTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxDoTransformer.class );
 
 	public BoxDoTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxForInTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxForInTransformer.java
@@ -19,9 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -41,8 +38,6 @@ import ortus.boxlang.transpiler.transformer.expression.BoxAssignmentTransformer;
  * Transform a BoxForIn Node the equivalent Java Parser AST nodes
  */
 public class BoxForInTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxForInTransformer.class );
 
 	public BoxForInTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxForIndexTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxForIndexTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -37,8 +34,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a BoxForIndex Node the equivalent Java Parser AST nodes
  */
 public class BoxForIndexTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxForIndexTransformer.class );
 
 	public BoxForIndexTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -16,9 +16,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -44,7 +41,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  */
 public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 
-	Logger			logger					= LoggerFactory.getLogger( BoxFunctionDeclarationTransformer.class );
 	// @formatter:off
 	private String registrationTemplate = "${contextName}.registerUDF( ${enclosingClassName}.${className}.getInstance() );";
 	private String classTemplate = """

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxIfElseTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxIfElseTransformer.java
@@ -19,8 +19,6 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.BoxStatement;
 import ortus.boxlang.ast.statement.BoxIfElse;
@@ -32,8 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BoxIfElseTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxIfElseTransformer.class );
 
 	public BoxIfElseTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxImportTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxImportTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -16,8 +13,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxImportTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxImportTransformer.class );
 
 	public BoxImportTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxIncludeTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxIncludeTransformer.java
@@ -18,9 +18,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -34,8 +31,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a Return Statement in the equivalent Java Parser AST nodes
  */
 public class BoxIncludeTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxIncludeTransformer.class );
 
 	public BoxIncludeTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxRethrowTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxRethrowTransformer.java
@@ -1,8 +1,6 @@
 package ortus.boxlang.transpiler.transformer.statement;
 
 import com.github.javaparser.ast.Node;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ortus.boxlang.ast.BoxNode;
 import ortus.boxlang.ast.statement.BoxRethrow;
 import ortus.boxlang.transpiler.JavaTranspiler;
@@ -16,8 +14,6 @@ import java.util.Map;
  * Transform a Rethrow statement in the equivalent Java Parser AST nodes
  */
 public class BoxRethrowTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxRethrowTransformer.class );
 
 	public BoxRethrowTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxReturnTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxReturnTransformer.java
@@ -18,9 +18,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -34,8 +31,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a Return Statement in the equivalent Java Parser AST nodes
  */
 public class BoxReturnTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxReturnTransformer.class );
 
 	public BoxReturnTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxSwitchTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxSwitchTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -37,8 +34,6 @@ import ortus.boxlang.transpiler.transformer.TransformerContext;
  * Transform a SwitchStatement Node the equivalent Java Parser AST nodes
  */
 public class BoxSwitchTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxSwitchTransformer.class );
 
 	public BoxSwitchTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxThrowTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxThrowTransformer.java
@@ -3,9 +3,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
@@ -16,8 +13,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxThrowTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxThrowTransformer.class );
 
 	public BoxThrowTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxTryTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxTryTransformer.java
@@ -20,9 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
@@ -50,8 +47,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxTryTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxTryTransformer.class );
 
 	public BoxTryTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );

--- a/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxWhileTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/statement/BoxWhileTransformer.java
@@ -17,9 +17,6 @@ package ortus.boxlang.transpiler.transformer.statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -33,8 +30,6 @@ import ortus.boxlang.transpiler.transformer.AbstractTransformer;
 import ortus.boxlang.transpiler.transformer.TransformerContext;
 
 public class BoxWhileTransformer extends AbstractTransformer {
-
-	Logger logger = LoggerFactory.getLogger( BoxWhileTransformer.class );
 
 	public BoxWhileTransformer( JavaTranspiler transpiler ) {
 		super( transpiler );


### PR DESCRIPTION
This lets us remove a ton of duplicate Logger boilerplate.

## Type of change

- [X] Improvement

## Checklist

- [X] New and existing unit tests pass locally with my changes
