### PR TITLE
Extract abstract `Boxpiler` class and `IBoxpiler` interface to prep for ASM

### DIFF
--- a/src/main/java/ortus/boxlang/debugger/DebugAdapter.java
+++ b/src/main/java/ortus/boxlang/debugger/DebugAdapter.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
@@ -77,6 +78,7 @@ import ortus.boxlang.debugger.types.Source;
 import ortus.boxlang.debugger.types.StackFrame;
 import ortus.boxlang.debugger.types.Variable;
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.runnables.compiler.IBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.SourceMap;
 import ortus.boxlang.runtime.types.BoxLangType;
@@ -93,7 +95,7 @@ public class DebugAdapter {
 	private BoxLangDebugger					debugger;
 	private boolean							running		= true;
 	private List<IAdapterProtocolMessage>	requestQueue;
-	private JavaBoxpiler					javaBoxpiler;
+	private IBoxpiler						boxpiler;
 	private AdapterProtocolMessageReader	DAPReader;
 
 	private List<BreakpointRequest>			breakpoints	= new ArrayList<BreakpointRequest>();
@@ -121,15 +123,13 @@ public class DebugAdapter {
 
 	/**
 	 * Constructor
-	 * 
-	 * @param debugClient The socket that handles communication with the debug tool
 	 */
 	public DebugAdapter( InputStream inputStream, OutputStream outputStream ) {
 		this.logger			= LoggerFactory.getLogger( BoxRuntime.class );
 		this.inputStream	= inputStream;
 		this.outputStream	= outputStream;
 		this.requestQueue	= new ArrayList<IAdapterProtocolMessage>();
-		this.javaBoxpiler	= JavaBoxpiler.getInstance();
+		this.boxpiler		= JavaBoxpiler.getInstance();
 
 		try {
 			this.DAPReader = new AdapterProtocolMessageReader( inputStream );
@@ -168,7 +168,7 @@ public class DebugAdapter {
 
 	/**
 	 * Used to determin if the debug session has completed.
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isRunning() {
@@ -204,7 +204,7 @@ public class DebugAdapter {
 
 	/**
 	 * Starts a new thread to wait for messages from the debug client. Each message will deserialized and then visited.
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	private void createInputListenerThread() throws IOException {
@@ -244,7 +244,7 @@ public class DebugAdapter {
 
 	/**
 	 * Default visit handler
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( IAdapterProtocolMessage debugRequest ) {
@@ -276,7 +276,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit InitializeRequest instances. Respond to the initialize request and send an initialized event.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( InitializeRequest debugRequest ) {
@@ -286,7 +286,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit InitializeRequest instances. Respond to the initialize request and send an initialized event.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( ContinueRequest debugRequest ) {
@@ -318,7 +318,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit InitializeRequest instances. Respond to the initialize request and send an initialized event.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( NextRequest debugRequest ) {
@@ -341,7 +341,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit LaunchRequest instances. Send a NobodyResponse and setup a BoxLangDebugger.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( LaunchRequest debugRequest ) {
@@ -352,7 +352,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit SetBreakpointsRequest instances. Send a response.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( SetBreakpointsRequest debugRequest ) {
@@ -367,7 +367,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit ConfigurationDoneRequest instances. After responding the debugger can begin executing.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( ConfigurationDoneRequest debugRequest ) {
@@ -378,7 +378,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit ConfigurationDoneRequest instances. After responding the debugger can begin executing.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( PauseRequest debugRequest ) {
@@ -392,7 +392,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit EvaluateRequest instances. Will evalauate the expression in either the global scope or a specific stackframe.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( EvaluateRequest debugRequest ) {
@@ -412,7 +412,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit ThreadRequest instances. Should send a ThreadResponse contianing basic information about all vm threds.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( ThreadsRequest debugRequest ) {
@@ -426,7 +426,7 @@ public class DebugAdapter {
 
 			    return t;
 		    } )
-		    .toList();
+		    .collect( Collectors.toList() );
 
 		try {
 
@@ -438,7 +438,7 @@ public class DebugAdapter {
 
 	/**
 	 * Visit ThreadRequest instances. Should send a ThreadResponse contianing basic information about all vm threds.
-	 * 
+	 *
 	 * @param debugRequest
 	 */
 	public void visit( StackTraceRequest debugRequest ) {
@@ -449,7 +449,7 @@ public class DebugAdapter {
 				    com.sun.jdi.StackFrame stackFrame = tuple.stackFrame();
 				    com.sun.jdi.Location location	= tuple.location();
 				    StackFrame			sf			= new StackFrame();
-				    SourceMap			map			= javaBoxpiler.getSourceMapFromFQN( location.declaringType().name() );
+				    SourceMap			map			= boxpiler.getSourceMapFromFQN( location.declaringType().name() );
 				    String				fileName	= Path.of( map.source ).getFileName().toString();
 
 				    sf.id	= tuple.id();
@@ -495,7 +495,7 @@ public class DebugAdapter {
 
 				    return sf;
 			    } )
-			    .toList();
+			    .collect( Collectors.toList() );
 
 			new StackTraceResponse( debugRequest, stackFrames ).send( this.outputStream );
 		} catch ( IncompatibleThreadStateException e ) {
@@ -523,7 +523,7 @@ public class DebugAdapter {
 			    .map( ( scopeNameValue ) -> ( String ) ( ( com.sun.jdi.StringReference ) scopeNameValue ).value() )
 			    .map( ( scopeName ) -> scopeByName( context, scopeName ) )
 			    .filter( ( scope ) -> scope != null )
-			    .toList();
+			    .collect( Collectors.toList() );
 
 			new ScopeResponse( debugRequest, scopes ).send( this.outputStream );
 		} catch ( Exception e ) {
@@ -584,7 +584,7 @@ public class DebugAdapter {
 	}
 
 	private SourceMap getSourceMapFromJavaLocation( Location location ) {
-		return javaBoxpiler.getSourceMapFromFQN( location.declaringType().name() );
+		return boxpiler.getSourceMapFromFQN( location.declaringType().name() );
 	}
 
 	// ===================================================
@@ -592,7 +592,7 @@ public class DebugAdapter {
 	// ===================================================
 
 	public void sendStoppedEventForBreakpoint( BreakpointEvent breakpointEvent ) {
-		SourceMap			map			= javaBoxpiler.getSourceMapFromFQN( breakpointEvent.location().declaringType().name() );
+		SourceMap			map			= boxpiler.getSourceMapFromFQN( breakpointEvent.location().declaringType().name() );
 		String				sourcePath	= map.source.toLowerCase();
 
 		BreakpointRequest	bp			= null;

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -50,6 +50,8 @@ import ortus.boxlang.runtime.logging.LoggingConfigurator;
 import ortus.boxlang.runtime.runnables.BoxScript;
 import ortus.boxlang.runtime.runnables.BoxTemplate;
 import ortus.boxlang.runtime.runnables.RunnableLoader;
+import ortus.boxlang.runtime.runnables.compiler.ClassInfo;
+import ortus.boxlang.runtime.runnables.compiler.IBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ApplicationService;
@@ -164,7 +166,7 @@ public class BoxRuntime {
 	/**
 	 * The JavaBoxPiler instance
 	 */
-	private JavaBoxpiler					javaBoxpiler;
+	private IBoxpiler						boxpiler;
 
 	/**
 	 * The Scheduler service in charge of all schedulers
@@ -300,7 +302,7 @@ public class BoxRuntime {
 
 		// Create our runtime context that will be the granddaddy of all contexts that execute inside this runtime
 		this.runtimeContext	= new RuntimeBoxContext();
-		this.javaBoxpiler	= JavaBoxpiler.getInstance();
+		this.boxpiler		= JavaBoxpiler.getInstance();
 
 		// Now startup the modules so we can have a runtime context available to them
 		this.moduleService.onStartup();
@@ -898,10 +900,11 @@ public class BoxRuntime {
 	}
 
 	public void printTranspiledJavaCode( String filePath ) {
-		JavaBoxpiler.ClassInfo	classInfo	= JavaBoxpiler.ClassInfo.forTemplate( Path.of( filePath ), "boxclass.generated", BoxScriptType.BOXSCRIPT );
-		ParsingResult			result		= javaBoxpiler.parseOrFail( Path.of( filePath ).toFile() );
+		// TODO: How to handle this with ASM?
+		ClassInfo		classInfo	= ClassInfo.forTemplate( Path.of( filePath ), "boxclass.generated", BoxScriptType.BOXSCRIPT, this.boxpiler );
+		ParsingResult	result		= boxpiler.parseOrFail( Path.of( filePath ).toFile() );
 
-		System.out.print( javaBoxpiler.generateJavaSource( result.getRoot(), classInfo ) );
+		System.out.print( boxpiler.generateJavaSource( result.getRoot(), classInfo ) );
 	}
 
 	/**
@@ -911,7 +914,7 @@ public class BoxRuntime {
 	 *
 	 */
 	public void printSourceAST( String source ) {
-		ParsingResult result = javaBoxpiler.parseOrFail( source, BoxScriptType.BOXSCRIPT );
+		ParsingResult result = boxpiler.parseOrFail( source, BoxScriptType.BOXSCRIPT );
 		System.out.println( result.getRoot().toJSON() );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/dynamic/javaproxy/InterfaceProxyService.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/javaproxy/InterfaceProxyService.java
@@ -20,12 +20,14 @@ package ortus.boxlang.runtime.dynamic.javaproxy;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.loader.ClassLocator;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.runnables.IProxyRunnable;
+import ortus.boxlang.runtime.runnables.compiler.IBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.util.EncryptionUtil;
@@ -40,15 +42,15 @@ public class InterfaceProxyService {
 	/**
 	 * BoxPiler
 	 */
-	private static final JavaBoxpiler	boxpiler		= JavaBoxpiler.getInstance();
+	private static final IBoxpiler		boxpiler		= JavaBoxpiler.getInstance();
 
 	/**
 	 * Create a proxy class that wraps a Box class and implements the given interfaces
-	 * 
+	 *
 	 * @param context    The current context
 	 * @param boxClass   The box class to wrap
 	 * @param interfaces The array of interfaces to implement
-	 * 
+	 *
 	 * @return The proxy
 	 */
 	public static IProxyRunnable createProxy( IBoxContext context, IClassRunnable boxClass, Array interfaces ) {
@@ -62,10 +64,10 @@ public class InterfaceProxyService {
 
 	/**
 	 * Turn an array of interfaces into a proxy definition
-	 * 
+	 *
 	 * @param context    The context
 	 * @param interfaces The interfaces
-	 * 
+	 *
 	 * @return The proxy definition
 	 */
 	public static InterfaceProxyDefinition generateDefinition( IBoxContext context, Array interfaces ) {
@@ -79,7 +81,7 @@ public class InterfaceProxyService {
 		}
 		// TODO: validate overlapping methods? Remove duplicate method signatures?
 
-		return new InterfaceProxyDefinition( name, methods, interfaces.stream().map( Object::toString ).toList() );
+		return new InterfaceProxyDefinition( name, methods, interfaces.stream().map( Object::toString ).collect( Collectors.toList() ) );
 	}
 
 	private static String generateName( Array interfaces ) {

--- a/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import ortus.boxlang.parser.BoxScriptType;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.compiler.IBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.MissingIncludeException;
@@ -42,7 +43,8 @@ public class RunnableLoader {
 	/**
 	 * Singleton instance
 	 */
-	private static RunnableLoader instance;
+	private static RunnableLoader	instance;
+	private IBoxpiler				boxpiler;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -54,6 +56,7 @@ public class RunnableLoader {
 	 * Private constructor
 	 */
 	private RunnableLoader() {
+		this.boxpiler = JavaBoxpiler.getInstance();
 	}
 
 	/**
@@ -87,7 +90,7 @@ public class RunnableLoader {
 			throw new MissingIncludeException( "The template path [" + path.toString() + "] could not be found.", path.toString() );
 		}
 		// TODO: enforce valid include extensions (.cfm, .cfs, .bxs, .bxm, .bx)
-		Class<IBoxRunnable> clazz = JavaBoxpiler.getInstance().compileTemplate( path, packagePath );
+		Class<IBoxRunnable> clazz = this.boxpiler.compileTemplate( path, packagePath );
 		return ( BoxTemplate ) DynamicObject.of( clazz ).invokeStatic( "getInstance" );
 	}
 
@@ -136,7 +139,7 @@ public class RunnableLoader {
 	 * @return
 	 */
 	public BoxScript loadSource( String source, BoxScriptType type ) {
-		Class<IBoxRunnable> clazz = JavaBoxpiler.getInstance().compileScript( source, type );
+		Class<IBoxRunnable> clazz = this.boxpiler.compileScript( source, type );
 		if ( IClassRunnable.class.isAssignableFrom( clazz ) ) {
 			throw new RuntimeException( "Cannot define class in an ad-hoc script." );
 		}
@@ -162,7 +165,7 @@ public class RunnableLoader {
 	 * @return
 	 */
 	public BoxScript loadStatement( String source ) {
-		Class<IBoxRunnable> clazz = JavaBoxpiler.getInstance().compileStatement( source, BoxScriptType.BOXSCRIPT );
+		Class<IBoxRunnable> clazz = this.boxpiler.compileStatement( source, BoxScriptType.BOXSCRIPT );
 		return ( BoxScript ) DynamicObject.of( clazz ).invokeStatic( "getInstance" );
 	}
 
@@ -177,7 +180,7 @@ public class RunnableLoader {
 	 * @return
 	 */
 	public Class<IClassRunnable> loadClass( String source, IBoxContext context, BoxScriptType type ) {
-		return JavaBoxpiler.getInstance().compileClass( source, type );
+		return this.boxpiler.compileClass( source, type );
 	}
 
 	/**
@@ -191,7 +194,7 @@ public class RunnableLoader {
 	 * @return The class
 	 */
 	public Class<IClassRunnable> loadClass( Path path, String packagePath, IBoxContext context ) {
-		return JavaBoxpiler.getInstance().compileClass( path.toAbsolutePath(), packagePath );
+		return this.boxpiler.compileClass( path.toAbsolutePath(), packagePath );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/runnables/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/compiler/Boxpiler.java
@@ -1,0 +1,279 @@
+package ortus.boxlang.runtime.runnables.compiler;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ortus.boxlang.parser.BoxParser;
+import ortus.boxlang.parser.BoxScriptType;
+import ortus.boxlang.parser.ParsingResult;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.javaproxy.InterfaceProxyDefinition;
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.IBoxRunnable;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
+import ortus.boxlang.runtime.runnables.IProxyRunnable;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.exceptions.ParseException;
+import ortus.boxlang.runtime.util.FRTransService;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class Boxpiler implements IBoxpiler {
+
+	/**
+	 * Logger
+	 */
+	protected static final Logger		logger			= LoggerFactory.getLogger( JavaBoxpiler.class );
+	/**
+	 * Keeps track of the classes we've compiled
+	 */
+	protected Map<String, ClassInfo>	classPool		= new HashMap<>();
+	/**
+	 * The transaction service used to track subtransactions
+	 */
+	protected FRTransService			frTransService	= FRTransService.getInstance();
+	/**
+	 * The disk class util
+	 */
+	protected DiskClassUtil				diskClassUtil;
+	/**
+	 * The directory where the generated classes are stored
+	 */
+	protected Path						classGenerationDirectory;
+
+	public Boxpiler() {
+		this.classGenerationDirectory	= Paths.get( BoxRuntime.getInstance().getConfiguration().compiler.classGenerationDirectory );
+		this.diskClassUtil				= new DiskClassUtil( classGenerationDirectory );
+		this.classGenerationDirectory.toFile().mkdirs();
+
+		// If we are in debug mode, let's clean out the class generation directory
+		if ( BoxRuntime.getInstance().inDebugMode() && Files.exists( this.classGenerationDirectory ) ) {
+			try {
+				logger.atDebug().log( "Running in debugmode, first startup cleaning out class generation directory: " + classGenerationDirectory );
+				// if ( false )
+				FileUtils.cleanDirectory( classGenerationDirectory.toFile() );
+			} catch ( IOException e ) {
+				throw new BoxRuntimeException( "Error cleaning out class generation directory on first run", e );
+			}
+		}
+	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Public Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	public Map<String, ClassInfo> getClassPool() {
+		return classPool;
+	}
+
+	/**
+	 * Parse source text into BoxLang AST nodes. This method will NOT throw an exception if the parse fails.
+	 *
+	 * @param source The source to parse.
+	 * @param type   The BoxScriptType of the source.
+	 *
+	 * @return The parsed AST nodes and any issues if encountered while parsing.
+	 */
+	@Override
+	public ParsingResult parse( String source, BoxScriptType type ) {
+		DynamicObject	trans	= frTransService.startTransaction( "BL Source Parse", type.name() );
+		BoxParser		parser	= new BoxParser();
+		try {
+			return parser.parse( source, type );
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error compiling source", e );
+		} finally {
+			frTransService.endTransaction( trans );
+		}
+	}
+
+	/**
+	 * Parse a file on disk into BoxLang AST nodes. This method will throw an exception if the parse fails.
+	 *
+	 * @param file The file to parse
+	 *
+	 * @return The parsed AST nodes and any issues if encountered while parsing.
+	 */
+	@Override
+	public ParsingResult parseOrFail( File file ) {
+		return validateParse( parse( file ), file.toString() );
+	}
+
+	/**
+	 * Parse a file on disk into BoxLang AST nodes. This method will NOT throw an exception if the parse fails.
+	 *
+	 * @param file The file to parse
+	 *
+	 * @return The parsed AST nodes and any issues if encountered while parsing.
+	 */
+	@Override
+	public ParsingResult parse( File file ) {
+		DynamicObject	trans	= frTransService.startTransaction( "BL File Parse", file.toString() );
+		BoxParser		parser	= new BoxParser();
+		try {
+			return parser.parse( file );
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error compiling source " + file, e );
+		} finally {
+			frTransService.endTransaction( trans );
+		}
+	}
+
+	/**
+	 * Parse source text into BoxLang AST nodes. This method will throw an exception if the parse fails.
+	 *
+	 * @param source The source to parse.
+	 * @param type   The BoxScriptType of the source.
+	 *
+	 * @return The parsed AST nodes and any issues if encountered while parsing.
+	 */
+	@Override
+	public ParsingResult parseOrFail( String source, BoxScriptType type ) {
+		return validateParse( parse( source, type ), "ad-hoc source" );
+	}
+
+	/**
+	 * Validate a parsing result and throw an exception if the parse failed.
+	 *
+	 * @param result The parsing result to validate
+	 *
+	 * @return The parsing result if the parse was successful
+	 */
+	@Override
+	public ParsingResult validateParse( ParsingResult result, String source ) {
+		if ( !result.isCorrect() ) {
+			throw new ParseException( result.getIssues(), source );
+		}
+		return result;
+	}
+
+	/**
+	 * Compile a single BoxLang statement into a Java class
+	 *
+	 * @param source The BoxLang source code as a string
+	 * @param type   The type of BoxLang source code
+	 *
+	 * @return The loaded class
+	 */
+	@Override
+	public Class<IBoxRunnable> compileStatement( String source, BoxScriptType type ) {
+		ClassInfo classInfo = ClassInfo.forStatement( source, type, this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		classInfo = classPool.get( classInfo.FQN() );
+
+		return classInfo.getDiskClass();
+
+	}
+
+	/**
+	 * Compile a BoxLang script into a Java class
+	 *
+	 * @param source The BoxLang source code as a string
+	 * @param type   The type of BoxLang source code
+	 *
+	 * @return The loaded class
+	 */
+	@Override
+	public Class<IBoxRunnable> compileScript( String source, BoxScriptType type ) {
+		ClassInfo classInfo = ClassInfo.forScript( source, type, this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		classInfo = classPool.get( classInfo.FQN() );
+
+		return classInfo.getDiskClass();
+	}
+
+	/**
+	 * Compile a BoxLang template (file on disk) into a Java class
+	 *
+	 * @param path        The BoxLang source on disk as a Path
+	 * @param packagePath The package path used to resolve this file path
+	 *
+	 * @return The loaded class
+	 */
+	@Override
+	public Class<IBoxRunnable> compileTemplate( Path path, String packagePath ) {
+		ClassInfo classInfo = ClassInfo.forTemplate( path, packagePath, BoxParser.detectFile( path.toFile() ), this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		// If the new class is newer than the one on disk, recompile it
+		if ( classPool.get( classInfo.FQN() ).lastModified() < classInfo.lastModified() ) {
+			try {
+				// Don't know if this does anything, but calling it for good measure
+				classPool.get( classInfo.FQN() ).getClassLoader().close();
+			} catch ( IOException e ) {
+				e.printStackTrace();
+			}
+			classPool.put( classInfo.FQN(), classInfo );
+			compileClassInfo( classInfo.FQN() );
+		} else {
+			classInfo = classPool.get( classInfo.FQN() );
+		}
+		return classInfo.getDiskClass();
+	}
+
+	/**
+	 * Compile a BoxLang Class from source into a Java class
+	 *
+	 * @param source The BoxLang source code as a string
+	 *
+	 * @return The loaded class
+	 */
+	@Override
+	public Class<IClassRunnable> compileClass( String source, BoxScriptType type ) {
+		ClassInfo classInfo = ClassInfo.forClass( source, type, this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		classInfo = classPool.get( classInfo.FQN() );
+
+		return classInfo.getDiskClassClass();
+	}
+
+	/**
+	 * Compile a BoxLang Class from a file into a Java class
+	 *
+	 * @param path        The BoxLang source code as a Path on disk
+	 * @param packagePath The package path representing the mapping used to resolve this class
+	 *
+	 * @return The loaded class
+	 */
+	public Class<IClassRunnable> compileClass( Path path, String packagePath ) {
+		ClassInfo classInfo = ClassInfo.forClass( path, packagePath.replace( "-", "_" ), BoxParser.detectFile( path.toFile() ), this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		// If the new class is newer than the one on disk, recompile it
+		if ( classPool.get( classInfo.FQN() ).lastModified() < classInfo.lastModified() ) {
+			try {
+				// Don't know if this does anything, but calling it for good measure
+				classPool.get( classInfo.FQN() ).getClassLoader().close();
+			} catch ( IOException e ) {
+				e.printStackTrace();
+			}
+			classPool.put( classInfo.FQN(), classInfo );
+			compileClassInfo( classInfo.FQN() );
+		} else {
+			classInfo = classPool.get( classInfo.FQN() );
+		}
+		return classInfo.getDiskClassClass();
+	}
+
+	@Override
+	public Class<IProxyRunnable> compileInterfaceProxy( IBoxContext context, InterfaceProxyDefinition definition ) {
+		ClassInfo classInfo = ClassInfo.forInterfaceProxy( definition.name(), definition, this );
+		classPool.putIfAbsent( classInfo.FQN(), classInfo );
+		classInfo = classPool.get( classInfo.FQN() );
+
+		return classInfo.getDiskClassProxy();
+
+	}
+
+	@Override
+	public SourceMap getSourceMapFromFQN( String FQN ) {
+		return diskClassUtil.readLineNumbers( IBoxpiler.getBaseFQN( FQN ) );
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/runnables/compiler/ClassInfo.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/compiler/ClassInfo.java
@@ -1,0 +1,225 @@
+package ortus.boxlang.runtime.runnables.compiler;
+
+import ortus.boxlang.parser.BoxScriptType;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.dynamic.javaproxy.InterfaceProxyDefinition;
+import ortus.boxlang.runtime.runnables.IBoxRunnable;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
+import ortus.boxlang.runtime.runnables.IProxyRunnable;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A Record that represents the information about a class to be compiled
+ */
+public record ClassInfo( String sourcePath, String packageName, String className, String boxPackageName,
+    String baseclass,
+    String returnType, BoxScriptType sourceType, String source, Path path, Long lastModified,
+    DiskClassLoader[] diskClassLoader,
+    InterfaceProxyDefinition interfaceProxyDefinition, IBoxpiler boxpiler ) {
+
+	public static ClassInfo forScript( String source, BoxScriptType sourceType, IBoxpiler boxpiler ) {
+		return new ClassInfo(
+		    null,
+		    "boxgenerated.scripts",
+		    "Script_" + IBoxpiler.MD5( sourceType.toString() + source ),
+		    "",
+		    "BoxScript",
+		    "Object",
+		    sourceType,
+		    source,
+		    null,
+		    0L,
+		    new DiskClassLoader[ 1 ],
+		    null,
+		    boxpiler
+		);
+	}
+
+	public static ClassInfo forStatement( String source, BoxScriptType sourceType, IBoxpiler boxpiler ) {
+		return new ClassInfo(
+		    null,
+		    "boxgenerated.scripts",
+		    "Statement_" + IBoxpiler.MD5( sourceType.toString() + source ),
+		    "",
+		    "BoxScript",
+		    "Object",
+		    sourceType,
+		    source,
+		    null,
+		    0L,
+		    new DiskClassLoader[ 1 ],
+		    null,
+		    boxpiler
+		);
+	}
+
+	public static ClassInfo forTemplate( Path path, String packagePath, BoxScriptType sourceType, IBoxpiler boxpiler ) {
+		File	lcaseFile	= new File( packagePath.toString().toLowerCase() );
+		String	packageName	= IBoxpiler.getPackageName( lcaseFile );
+		// if package name has starting dot, remove it
+		if ( packageName.startsWith( "." ) ) {
+			packageName = packageName.substring( 1 );
+		}
+		packageName = "boxgenerated.templates" + ( packageName.equals( "" ) ? "" : "." ) + packageName;
+		String className = IBoxpiler.getClassName( lcaseFile );
+		return new ClassInfo(
+		    path.toString(),
+		    packageName,
+		    className,
+		    packageName,
+		    "BoxTemplate",
+		    "void",
+		    sourceType,
+		    null,
+		    path,
+		    path.toFile().lastModified(),
+		    new DiskClassLoader[ 1 ],
+		    null,
+		    boxpiler
+		);
+	}
+
+	public static ClassInfo forClass( Path path, String packagePath, BoxScriptType sourceType, IBoxpiler boxpiler ) {
+		String boxPackagePath = packagePath;
+		if ( boxPackagePath.endsWith( "." ) ) {
+			boxPackagePath = boxPackagePath.substring( 0, boxPackagePath.length() - 1 );
+		}
+		packagePath = "boxgenerated.boxclass." + packagePath;
+		// trim trailing period
+		if ( packagePath.endsWith( "." ) ) {
+			packagePath = packagePath.substring( 0, packagePath.length() - 1 );
+		}
+		String className = IBoxpiler.getClassName( path.toFile() );
+
+		return new ClassInfo(
+		    path.toString(),
+		    packagePath,
+		    className,
+		    boxPackagePath,
+		    null,
+		    null,
+		    sourceType,
+		    null,
+		    path,
+		    path.toFile().lastModified(),
+		    new DiskClassLoader[ 1 ],
+		    null,
+		    boxpiler
+		);
+	}
+
+	public static ClassInfo forClass( String source, BoxScriptType sourceType, IBoxpiler boxpiler ) {
+		return new ClassInfo(
+		    null,
+		    "boxgenerated.boxclass",
+		    "Class_" + IBoxpiler.MD5( source ),
+		    "",
+		    null,
+		    null,
+		    sourceType,
+		    source,
+		    null,
+		    0L,
+		    new DiskClassLoader[ 1 ],
+		    null,
+		    boxpiler
+		);
+	}
+
+	public static ClassInfo forInterfaceProxy( String name, InterfaceProxyDefinition interfaceProxyDefinition, IBoxpiler boxpiler ) {
+		return new ClassInfo(
+		    null,
+		    "boxgenerated.dynamicProxy",
+		    "InterfaceProxy_" + name,
+		    "",
+		    null,
+		    null,
+		    null,
+		    null,
+		    null,
+		    0L,
+		    new DiskClassLoader[ 1 ],
+		    interfaceProxyDefinition,
+		    boxpiler
+		);
+	}
+
+	public String FQN() {
+		return packageName + "." + className();
+	}
+
+	public String toString() {
+		if ( sourcePath != null )
+			return "Class Info-- sourcePath: [" + sourcePath + "], packageName: [" + packageName + "], className: [" + className + "]";
+		else if ( sourceType != null )
+			return "Class Info-- type: [" + sourceType + "], packageName: [" + packageName + "], className: [" + className + "]";
+		else if ( interfaceProxyDefinition != null )
+			return "Class Info-- interface proxy: [" + interfaceProxyDefinition.interfaces().toString() + "],  packageName: [" + packageName
+			    + "], className: [" + className + "]";
+		else
+			return "Class Info-- packageName: [" + packageName + "], className: [" + className + "]";
+	}
+
+	public DiskClassLoader getClassLoader() {
+		if ( diskClassLoader[ 0 ] != null ) {
+			return diskClassLoader[ 0 ];
+		}
+		synchronized ( this ) {
+			if ( diskClassLoader[ 0 ] != null ) {
+				return diskClassLoader[ 0 ];
+			}
+			diskClassLoader[ 0 ] = new DiskClassLoader(
+			    new URL[] {},
+			    boxpiler().getClass().getClassLoader(),
+			    Paths.get( BoxRuntime.getInstance().getConfiguration().compiler.classGenerationDirectory ),
+			    boxpiler()
+			);
+			return diskClassLoader[ 0 ];
+		}
+	}
+
+	/**
+	 * Get a class for a class name from disk
+	 *
+	 * @return The loaded class
+	 */
+	public Class<IBoxRunnable> getDiskClass() {
+		try {
+			return ( Class<IBoxRunnable> ) getClassLoader().loadClass( FQN() );
+		} catch ( ClassNotFoundException e ) {
+			throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
+		}
+	}
+
+	/**
+	 * Get a Box class for a class name from disk
+	 *
+	 * @return The loaded class
+	 */
+	public Class<IClassRunnable> getDiskClassClass() {
+		try {
+			return ( Class<IClassRunnable> ) getClassLoader().loadClass( FQN() );
+		} catch ( ClassNotFoundException e ) {
+			throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
+		}
+	}
+
+	/**
+	 * Get a proxy class for a class name from disk
+	 *
+	 * @return The loaded class
+	 */
+	public Class<IProxyRunnable> getDiskClassProxy() {
+		try {
+			return ( Class<IProxyRunnable> ) getClassLoader().loadClass( FQN() );
+		} catch ( ClassNotFoundException e ) {
+			throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
+		}
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/runnables/compiler/DiskClassLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/compiler/DiskClassLoader.java
@@ -37,7 +37,7 @@ public class DiskClassLoader extends URLClassLoader {
 	/**
 	 * The boxpiler
 	 */
-	JavaBoxpiler	boxPiler;
+	IBoxpiler		boxPiler;
 
 	/**
 	 * Constructor
@@ -45,11 +45,11 @@ public class DiskClassLoader extends URLClassLoader {
 	 * @param urls      classpath
 	 * @param parent    parent classloader
 	 * @param diskStore disk store location path
-	 * @param manager   memory manager
+	 * @param boxpiler  Boxpiler
 	 */
-	public DiskClassLoader( URL[] urls, ClassLoader parent, Path diskStore, JavaBoxpiler boxPiler ) {
+	public DiskClassLoader( URL[] urls, ClassLoader parent, Path diskStore, IBoxpiler boxpiler ) {
 		super( urls, parent );
-		this.boxPiler	= boxPiler;
+		this.boxPiler	= boxpiler;
 		this.diskStore	= diskStore;
 		// Init disk store
 		diskStore.toFile().mkdirs();
@@ -62,9 +62,9 @@ public class DiskClassLoader extends URLClassLoader {
 	 */
 	@Override
 	protected Class<?> findClass( String name ) throws ClassNotFoundException {
-		Path					diskPath	= generateDiskPath( name );
+		Path		diskPath	= generateDiskPath( name );
 		// JIT compile
-		JavaBoxpiler.ClassInfo	classInfo	= boxPiler.getClassPool().get( boxPiler.getBaseFQN( name ) );
+		ClassInfo	classInfo	= boxPiler.getClassPool().get( IBoxpiler.getBaseFQN( name ) );
 		if ( !hasClass( diskPath ) || ( classInfo != null && ( classInfo.lastModified() > diskPath.toFile().lastModified() ) ) ) {
 			// After this call, the class files will exist on disk
 			boxPiler.compileClassInfo( name );

--- a/src/main/java/ortus/boxlang/runtime/runnables/compiler/IBoxpiler.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/compiler/IBoxpiler.java
@@ -1,0 +1,140 @@
+package ortus.boxlang.runtime.runnables.compiler;
+
+import ortus.boxlang.ast.BoxNode;
+import ortus.boxlang.parser.BoxScriptType;
+import ortus.boxlang.parser.ParsingResult;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.javaproxy.InterfaceProxyDefinition;
+import ortus.boxlang.runtime.runnables.IBoxRunnable;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
+import ortus.boxlang.runtime.runnables.IProxyRunnable;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public interface IBoxpiler {
+
+	/**
+	 * Generate an MD5 hash.
+	 * TODO: Move to util class
+	 *
+	 * @param md5 String to hash
+	 *
+	 * @return MD5 hash
+	 */
+	static String MD5( String md5 ) {
+		try {
+			java.security.MessageDigest	md		= java.security.MessageDigest.getInstance( "MD5" );
+			byte[]						array	= md.digest( md5.getBytes() );
+			StringBuilder				sb		= new StringBuilder();
+			for ( byte b : array ) {
+				sb.append( Integer.toHexString( ( b & 0xFF ) | 0x100 ).substring( 1, 3 ) );
+			}
+			return sb.toString();
+		} catch ( java.security.NoSuchAlgorithmException e ) {
+			throw new BoxRuntimeException( "Error compiling source", e );
+		}
+	}
+
+	/**
+	 * Transforms the path into the package name
+	 *
+	 * @param file File object to grab the package name for.
+	 *
+	 * @return returns the class name according the name conventions Test.ext -
+	 *         Test$ext
+	 */
+	static String getPackageName( File file ) {
+		String packg = file.toString().replace( File.separatorChar + file.getName(), "" );
+		if ( packg.startsWith( "/" ) ) {
+			packg = packg.substring( 1 );
+		}
+		// trim trailing period
+		if ( packg.endsWith( "." ) ) {
+			packg = packg.substring( 0, packg.length() - 1 );
+		}
+		// trim trailing \ or /
+		if ( packg.endsWith( "\\" ) || packg.endsWith( "/" ) ) {
+			packg = packg.substring( 0, packg.length() - 1 );
+		}
+		// TODO: This needs a lot more work. There are tons of disallowed edge cases
+		// such as a folder that is a number.
+		// We probably need to iterate each path segment and clean or remove as
+		// neccessary to make it a valid package name.
+		// Also, I'd like cfincluded files to use the relative path as the package name,
+		// which will require some refactoring.
+
+		// Take out periods in folder names
+		packg	= packg.replaceAll( "\\.", "" );
+		// Replace / with .
+		packg	= packg.replaceAll( "/", "." );
+		// Remove any : from Windows drives
+		packg	= packg.replaceAll( ":", "" );
+		// Replace \ with .
+		packg	= packg.replaceAll( "\\\\", "." );
+		// Replace .. with .
+		packg	= packg.replaceAll( "\\.\\.", "." );
+		// Remove any non alpha-numeric chars.
+		packg	= packg.replaceAll( "[^a-zA-Z0-9\\.]", "" );
+		return packg.toLowerCase();
+
+	}
+
+	/**
+	 * Transforms the filename into the class name
+	 *
+	 * @param file File object to grab the class name for.
+	 *
+	 * @return returns the class name according the name conventions Test.ext -
+	 *         Test$ext
+	 */
+	static String getClassName( File file ) {
+		String name = file.getName().replace( ".", "$" );
+		name = name.substring( 0, 1 ).toUpperCase() + name.substring( 1 );
+		return name;
+	}
+
+	Map<String, ClassInfo> getClassPool();
+
+	Class<IBoxRunnable> compileStatement( String source, BoxScriptType type );
+
+	Class<IBoxRunnable> compileScript( String source, BoxScriptType type );
+
+	Class<IBoxRunnable> compileTemplate( Path path, String packagePath );
+
+	Class<IClassRunnable> compileClass( String source, BoxScriptType type );
+
+	Class<IClassRunnable> compileClass( Path path, String packagePath );
+
+	Class<IProxyRunnable> compileInterfaceProxy( IBoxContext context, InterfaceProxyDefinition definition );
+
+	ParsingResult parse( File file );
+
+	ParsingResult parse( String source, BoxScriptType type );
+
+	ParsingResult parseOrFail( File file );
+
+	ParsingResult parseOrFail( String source, BoxScriptType type );
+
+	ParsingResult validateParse( ParsingResult result, String source );
+
+	@SuppressWarnings( "unused" )
+	String generateJavaSource( BoxNode node, ClassInfo classInfo );
+
+	SourceMap getSourceMapFromFQN( String FQN );
+
+	static String getBaseFQN( String FQN ) {
+		// If fqn ends with $Cloure_xxx or $Func_xxx, $Lambda_xxx, then we need to strip that off to get the original FQN
+		Matcher m = Pattern.compile( "(.*?)(\\$Closure_.*|\\$Func_.*|\\$Lambda_.*)$" ).matcher( FQN );
+		if ( m.find() ) {
+			FQN = m.group( 1 );
+		}
+		return FQN;
+	}
+
+	void compileClassInfo( String FQN );
+}

--- a/src/main/java/ortus/boxlang/runtime/runnables/compiler/JavaBoxpiler.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/compiler/JavaBoxpiler.java
@@ -17,20 +17,13 @@
  */
 package ortus.boxlang.runtime.runnables.compiler;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.tools.DiagnosticCollector;
@@ -40,10 +33,6 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.JSON.Feature;
 import com.fasterxml.jackson.jr.ob.JSONObjectException;
@@ -52,20 +41,10 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 
 import ortus.boxlang.ast.BoxNode;
-import ortus.boxlang.parser.BoxParser;
-import ortus.boxlang.parser.BoxScriptType;
 import ortus.boxlang.parser.ParsingResult;
-import ortus.boxlang.runtime.BoxRuntime;
-import ortus.boxlang.runtime.context.IBoxContext;
-import ortus.boxlang.runtime.dynamic.javaproxy.InterfaceProxyDefinition;
 import ortus.boxlang.runtime.interop.DynamicObject;
-import ortus.boxlang.runtime.runnables.IBoxRunnable;
-import ortus.boxlang.runtime.runnables.IClassRunnable;
-import ortus.boxlang.runtime.runnables.IProxyRunnable;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ExpressionException;
-import ortus.boxlang.runtime.types.exceptions.ParseException;
-import ortus.boxlang.runtime.util.FRTransService;
 import ortus.boxlang.transpiler.CustomPrettyPrinter;
 import ortus.boxlang.transpiler.TranspiledCode;
 import ortus.boxlang.transpiler.Transpiler;
@@ -76,7 +55,7 @@ import ortus.boxlang.transpiler.transformer.indexer.BoxNodeKey;
  * This class uses the Java compiler to turn a BoxLang script into a Java class
  */
 @SuppressWarnings( "unchecked" )
-public class JavaBoxpiler {
+public class JavaBoxpiler extends Boxpiler {
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -87,37 +66,12 @@ public class JavaBoxpiler {
 	/**
 	 * Singleton instance
 	 */
-	private static JavaBoxpiler		instance;
+	private static JavaBoxpiler	instance;
 
 	/**
 	 * The Java compiler
 	 */
-	private JavaCompiler			compiler;
-
-	/**
-	 * Keeps track of the classes we've compiled
-	 */
-	private Map<String, ClassInfo>	classPool		= new HashMap<>();
-
-	/**
-	 * The disk class util
-	 */
-	private DiskClassUtil			diskClassUtil;
-
-	/**
-	 * Logger
-	 */
-	private static final Logger		logger			= LoggerFactory.getLogger( JavaBoxpiler.class );
-
-	/**
-	 * The directory where the generated classes are stored
-	 */
-	private Path					classGenerationDirectory;
-
-	/**
-	 * The transaction service used to track subtransactions
-	 */
-	private FRTransService			frTransService	= FRTransService.getInstance();
+	private JavaCompiler		compiler;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -129,21 +83,8 @@ public class JavaBoxpiler {
 	 * Private constructor
 	 */
 	private JavaBoxpiler() {
-		this.compiler					= ToolProvider.getSystemJavaCompiler();
-		this.classGenerationDirectory	= Paths.get( BoxRuntime.getInstance().getConfiguration().compiler.classGenerationDirectory );
-		this.diskClassUtil				= new DiskClassUtil( classGenerationDirectory );
-		this.classGenerationDirectory.toFile().mkdirs();
-
-		// If we are in debug mode, let's clean out the class generation directory
-		if ( BoxRuntime.getInstance().inDebugMode() && Files.exists( this.classGenerationDirectory ) ) {
-			try {
-				logger.atDebug().log( "Running in debugmode, first startup cleaning out class generation directory: " + classGenerationDirectory );
-				// if ( false )
-				FileUtils.cleanDirectory( classGenerationDirectory.toFile() );
-			} catch ( IOException e ) {
-				throw new BoxRuntimeException( "Error cleaning out class generation directory on first run", e );
-			}
-		}
+		super();
+		this.compiler = ToolProvider.getSystemJavaCompiler();
 	}
 
 	/**
@@ -159,201 +100,6 @@ public class JavaBoxpiler {
 	}
 
 	/**
-	 * --------------------------------------------------------------------------
-	 * Public Methods
-	 * --------------------------------------------------------------------------
-	 */
-
-	public Map<String, ClassInfo> getClassPool() {
-		return classPool;
-	}
-
-	/**
-	 * Compile a single BoxLang statement into a Java class
-	 *
-	 * @param source The BoxLang source code as a string
-	 * @param type   The type of BoxLang source code
-	 *
-	 * @return The loaded class
-	 */
-	public Class<IBoxRunnable> compileStatement( String source, BoxScriptType type ) {
-		ClassInfo classInfo = ClassInfo.forStatement( source, type );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		classInfo = classPool.get( classInfo.FQN() );
-
-		return classInfo.getDiskClass();
-
-	}
-
-	/**
-	 * Compile a BoxLang script into a Java class
-	 *
-	 * @param source The BoxLang source code as a string
-	 * @param type   The type of BoxLang source code
-	 *
-	 * @return The loaded class
-	 */
-	public Class<IBoxRunnable> compileScript( String source, BoxScriptType type ) {
-		ClassInfo classInfo = ClassInfo.forScript( source, type );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		classInfo = classPool.get( classInfo.FQN() );
-
-		return classInfo.getDiskClass();
-	}
-
-	/**
-	 * Compile a BoxLang template (file on disk) into a Java class
-	 *
-	 * @param source      The BoxLang source on disk as a Path
-	 * @param packagePath The package path used to resolve this file path
-	 *
-	 * @return The loaded class
-	 */
-	public Class<IBoxRunnable> compileTemplate( Path path, String packagePath ) {
-		ClassInfo classInfo = ClassInfo.forTemplate( path, packagePath, BoxParser.detectFile( path.toFile() ) );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		// If the new class is newer than the one on disk, recompile it
-		if ( classPool.get( classInfo.FQN() ).lastModified() < classInfo.lastModified() ) {
-			try {
-				// Don't know if this does anything, but calling it for good measure
-				classPool.get( classInfo.FQN() ).getClassLoader().close();
-			} catch ( IOException e ) {
-				e.printStackTrace();
-			}
-			classPool.put( classInfo.FQN(), classInfo );
-			compileClassInfo( classInfo.FQN() );
-		} else {
-			classInfo = classPool.get( classInfo.FQN() );
-		}
-		return classInfo.getDiskClass();
-	}
-
-	/**
-	 * Compile a BoxLang Class from source into a Java class
-	 *
-	 * @param source The BoxLang source code as a string
-	 *
-	 * @return The loaded class
-	 */
-	public Class<IClassRunnable> compileClass( String source, BoxScriptType type ) {
-		ClassInfo classInfo = ClassInfo.forClass( source, type );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		classInfo = classPool.get( classInfo.FQN() );
-
-		return classInfo.getDiskClassClass();
-	}
-
-	public Class<IProxyRunnable> compileInterfaceProxy( IBoxContext context, InterfaceProxyDefinition definition ) {
-		ClassInfo classInfo = ClassInfo.forInterfaceProxy( definition.name(), definition );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		classInfo = classPool.get( classInfo.FQN() );
-
-		return classInfo.getDiskClassProxy();
-
-	}
-
-	/**
-	 * Compile a BoxLang Class from a file into a Java class
-	 *
-	 * @param source      The BoxLang source code as a Path on disk
-	 * @param packagePath The package path representing the mapping used to resolve this class
-	 *
-	 * @return The loaded class
-	 */
-	public Class<IClassRunnable> compileClass( Path path, String packagePath ) {
-		ClassInfo classInfo = ClassInfo.forClass( path, packagePath.replace( "-", "_" ), BoxParser.detectFile( path.toFile() ) );
-		classPool.putIfAbsent( classInfo.FQN(), classInfo );
-		// If the new class is newer than the one on disk, recompile it
-		if ( classPool.get( classInfo.FQN() ).lastModified() < classInfo.lastModified() ) {
-			try {
-				// Don't know if this does anything, but calling it for good measure
-				classPool.get( classInfo.FQN() ).getClassLoader().close();
-			} catch ( IOException e ) {
-				e.printStackTrace();
-			}
-			classPool.put( classInfo.FQN(), classInfo );
-			compileClassInfo( classInfo.FQN() );
-		} else {
-			classInfo = classPool.get( classInfo.FQN() );
-		}
-		return classInfo.getDiskClassClass();
-	}
-
-	/**
-	 * Parse a file on disk into BoxLang AST nodes. This method will NOT throw an exception if the parse fails.
-	 *
-	 * @param file The file to parse
-	 *
-	 * @return The parsed AST nodes and any issues if encountered while parsing.
-	 */
-	public ParsingResult parse( File file ) {
-		DynamicObject	trans	= frTransService.startTransaction( "BL File Parse", file.toString() );
-		BoxParser		parser	= new BoxParser();
-		try {
-			return parser.parse( file );
-		} catch ( IOException e ) {
-			throw new BoxRuntimeException( "Error compiling source " + file.toString(), e );
-		} finally {
-			frTransService.endTransaction( trans );
-		}
-	}
-
-	/**
-	 * Parse source text into BoxLang AST nodes. This method will NOT throw an exception if the parse fails.
-	 *
-	 * @param file The file to parse
-	 *
-	 * @return The parsed AST nodes and any issues if encountered while parsing.
-	 */
-	public ParsingResult parse( String source, BoxScriptType type ) {
-		DynamicObject	trans	= frTransService.startTransaction( "BL Source Parse", type.name() );
-		BoxParser		parser	= new BoxParser();
-		try {
-			return parser.parse( source, type );
-		} catch ( IOException e ) {
-			throw new BoxRuntimeException( "Error compiling source", e );
-		} finally {
-			frTransService.endTransaction( trans );
-		}
-	}
-
-	/**
-	 * Parse a file on disk into BoxLang AST nodes. This method will throw an exception if the parse fails.
-	 *
-	 * @param file The file to parse
-	 *
-	 * @return The parsed AST nodes and any issues if encountered while parsing.
-	 */
-	public ParsingResult parseOrFail( File file ) {
-		return validateParse( parse( file ), file.toString() );
-	}
-
-	/**
-	 * Parse source text into BoxLang AST nodes. This method will throw an exception if the parse fails.
-	 *
-	 * @param file The file to parse
-	 *
-	 * @return The parsed AST nodes and any issues if encountered while parsing.
-	 */
-	public ParsingResult parseOrFail( String source, BoxScriptType type ) {
-		return validateParse( parse( source, type ), "ad-hoc source" );
-	}
-
-	/**
-	 * Validate a parsing result and throw an exception if the parse failed.
-	 *
-	 * @param result The parsing result to validate
-	 *
-	 * @return The parsing result if the parse was successful
-	 */
-	public ParsingResult validateParse( ParsingResult result, String source ) {
-		if ( !result.isCorrect() ) {
-			throw new ParseException( result.getIssues(), source );
-		}
-		return result;
-	}
-
-	/**
 	 * Generate Java source code from BoxLang AST nodes
 	 *
 	 * @param node      The BoxLang root AST node
@@ -361,6 +107,7 @@ public class JavaBoxpiler {
 	 *
 	 * @return The generated Java source code as a string
 	 */
+	@Override
 	@SuppressWarnings( "unused" )
 	public String generateJavaSource( BoxNode node, ClassInfo classInfo ) {
 		Transpiler transpiler = Transpiler.getTranspiler();
@@ -370,6 +117,7 @@ public class JavaBoxpiler {
 		transpiler.setProperty( "baseclass", classInfo.baseclass() );
 		transpiler.setProperty( "returnType", classInfo.returnType() );
 		transpiler.setProperty( "sourceType", classInfo.sourceType().name() );
+
 		TranspiledCode	javaASTs;
 		DynamicObject	trans	= frTransService.startTransaction( "Java Transpilation", classInfo.toString() );
 		try {
@@ -402,23 +150,7 @@ public class JavaBoxpiler {
 		return javaSource;
 	}
 
-	public String generateProxyJavaSource( ClassInfo classInfo ) {
-		return ProxyTransformer.transform( classInfo );
-	}
-
-	public SourceMap getSourceMapFromFQN( String FQN ) {
-		return diskClassUtil.readLineNumbers( getBaseFQN( FQN ) );
-	}
-
-	public String getBaseFQN( String FQN ) {
-		// If fqn ends with $Cloure_xxx or $Func_xxx, $Lambda_xxx, then we need to strip that off to get the original FQN
-		Matcher m = Pattern.compile( "(.*?)(\\$Closure_.*|\\$Func_.*|\\$Lambda_.*)$" ).matcher( FQN );
-		if ( m.find() ) {
-			FQN = m.group( 1 );
-		}
-		return FQN;
-	}
-
+	@Override
 	public void compileClassInfo( String FQN ) {
 		ClassInfo classInfo = classPool.get( FQN );
 		if ( classInfo == null ) {
@@ -444,7 +176,7 @@ public class JavaBoxpiler {
 	 * @param fqn        The fully qualified name of the class
 	 */
 	@SuppressWarnings( "unused" )
-	public void compileSource( String javaSource, String fqn ) {
+	private void compileSource( String javaSource, String fqn ) {
 		DynamicObject trans = frTransService.startTransaction( "Java Compilation", fqn );
 		// System.out.println( "Compiling " + fqn );
 
@@ -524,11 +256,11 @@ public class JavaBoxpiler {
 			    }
 			    return result2;
 		    } )
-		    .toList();
+		    .collect( Collectors.toList() );
 
 		Map<String, Object>					output	= new HashMap<String, Object>();
 		output.put( "sourceMapRecords", stuff );
-		output.put( "source", classInfo.sourcePath );
+		output.put( "source", classInfo.sourcePath() );
 		try {
 			return JSON.std.with( Feature.PRETTY_PRINT_OUTPUT ).asString( output );
 		} catch ( JSONObjectException e ) {
@@ -540,304 +272,8 @@ public class JavaBoxpiler {
 		}
 	}
 
-	/**
-	 * Generate an MD5 hash.
-	 * TODO: Move to util class
-	 *
-	 * @param md5 String to hash
-	 *
-	 * @return MD5 hash
-	 */
-	public static String MD5( String md5 ) {
-		try {
-			java.security.MessageDigest	md		= java.security.MessageDigest.getInstance( "MD5" );
-			byte[]						array	= md.digest( md5.getBytes() );
-			StringBuilder				sb		= new StringBuilder();
-			for ( int i = 0; i < array.length; ++i ) {
-				sb.append( Integer.toHexString( ( array[ i ] & 0xFF ) | 0x100 ).substring( 1, 3 ) );
-			}
-			return sb.toString();
-		} catch ( java.security.NoSuchAlgorithmException e ) {
-			throw new BoxRuntimeException( "Error compiling source", e );
-		}
-	}
-
-	/**
-	 * Transforms the filename into the class name
-	 *
-	 * @param file File object to grab the class name for.
-	 *
-	 * @return returns the class name according the name conventions Test.ext -
-	 *         Test$ext
-	 */
-	public static String getClassName( File file ) {
-		String name = file.getName().replace( ".", "$" );
-		name = name.substring( 0, 1 ).toUpperCase() + name.substring( 1 );
-		return name;
-	}
-
-	/**
-	 * Transforms the path into the package name
-	 *
-	 * @param file File object to grab the package name for.
-	 *
-	 * @return returns the class name according the name conventions Test.ext -
-	 *         Test$ext
-	 */
-	public static String getPackageName( File file ) {
-		String packg = file.toString().replace( File.separatorChar + file.getName(), "" );
-		if ( packg.startsWith( "/" ) ) {
-			packg = packg.substring( 1 );
-		}
-		// trim trailing period
-		if ( packg.endsWith( "." ) ) {
-			packg = packg.substring( 0, packg.length() - 1 );
-		}
-		// trim trailing \ or /
-		if ( packg.endsWith( "\\" ) || packg.endsWith( "/" ) ) {
-			packg = packg.substring( 0, packg.length() - 1 );
-		}
-		// TODO: This needs a lot more work. There are tons of disallowed edge cases
-		// such as a folder that is a number.
-		// We probably need to iterate each path segment and clean or remove as
-		// neccessary to make it a valid package name.
-		// Also, I'd like cfincluded files to use the relative path as the package name,
-		// which will require some refactoring.
-
-		// Take out periods in folder names
-		packg	= packg.replaceAll( "\\.", "" );
-		// Replace / with .
-		packg	= packg.replaceAll( "/", "." );
-		// Remove any : from Windows drives
-		packg	= packg.replaceAll( ":", "" );
-		// Replace \ with .
-		packg	= packg.replaceAll( "\\\\", "." );
-		// Replace .. with .
-		packg	= packg.replaceAll( "\\.\\.", "." );
-		// Remove any non alpha-numeric chars.
-		packg	= packg.replaceAll( "[^a-zA-Z0-9\\.]", "" );
-		return packg.toLowerCase();
-
-	}
-
-	/**
-	 * Get line numbers for fqn
-	 *
-	 * @param fqn The fully qualified name of the class
-	 *
-	 * @return The line numbers
-	 */
-	public SourceMap getLineNumbers( String fqn ) {
-		return diskClassUtil.readLineNumbers( fqn );
-	}
-
-	/**
-	 * A Record that represents the information about a class to be compiled
-	 */
-	public record ClassInfo( String sourcePath, String packageName, String className, String boxPackageName, String baseclass,
-	    String returnType, BoxScriptType sourceType, String source, Path path, Long lastModified, DiskClassLoader[] diskClassLoader,
-	    InterfaceProxyDefinition interfaceProxyDefinition ) {
-
-		public static ClassInfo forScript( String source, BoxScriptType sourceType ) {
-			return new ClassInfo(
-			    null,
-			    "boxgenerated.scripts",
-			    "Script_" + MD5( sourceType.toString() + source ),
-			    "",
-			    "BoxScript",
-			    "Object",
-			    sourceType,
-			    source,
-			    null,
-			    0L,
-			    new DiskClassLoader[ 1 ],
-			    null
-			);
-		}
-
-		public static ClassInfo forStatement( String source, BoxScriptType sourceType ) {
-			return new ClassInfo(
-			    null,
-			    "boxgenerated.scripts",
-			    "Statement_" + MD5( sourceType.toString() + source ),
-			    "",
-			    "BoxScript",
-			    "Object",
-			    sourceType,
-			    source,
-			    null,
-			    0L,
-			    new DiskClassLoader[ 1 ],
-			    null
-			);
-		}
-
-		public static ClassInfo forTemplate( Path path, String packagePath, BoxScriptType sourceType ) {
-			File	lcaseFile	= new File( packagePath.toString().toLowerCase() );
-			String	packageName	= getPackageName( lcaseFile );
-			// if package name has starting dot, remove it
-			if ( packageName.startsWith( "." ) ) {
-				packageName = packageName.substring( 1 );
-			}
-			packageName = "boxgenerated.templates" + ( packageName.equals( "" ) ? "" : "." ) + packageName;
-			String className = getClassName( lcaseFile );
-			return new ClassInfo(
-			    path.toString(),
-			    packageName,
-			    className,
-			    packageName,
-			    "BoxTemplate",
-			    "void",
-			    sourceType,
-			    null,
-			    path,
-			    path.toFile().lastModified(),
-			    new DiskClassLoader[ 1 ],
-			    null
-			);
-		}
-
-		public static ClassInfo forClass( Path path, String packagePath, BoxScriptType sourceType ) {
-			String boxPackagePath = packagePath;
-			if ( boxPackagePath.endsWith( "." ) ) {
-				boxPackagePath = boxPackagePath.substring( 0, boxPackagePath.length() - 1 );
-			}
-			packagePath = "boxgenerated.boxclass." + packagePath;
-			// trim trailing period
-			if ( packagePath.endsWith( "." ) ) {
-				packagePath = packagePath.substring( 0, packagePath.length() - 1 );
-			}
-			String className = getClassName( path.toFile() );
-
-			return new ClassInfo(
-			    path.toString(),
-			    packagePath,
-			    className,
-			    boxPackagePath,
-			    null,
-			    null,
-			    sourceType,
-			    null,
-			    path,
-			    path.toFile().lastModified(),
-			    new DiskClassLoader[ 1 ],
-			    null
-			);
-		}
-
-		public static ClassInfo forClass( String source, BoxScriptType sourceType ) {
-			return new ClassInfo(
-			    null,
-			    "boxgenerated.boxclass",
-			    "Class_" + MD5( source ),
-			    "",
-			    null,
-			    null,
-			    sourceType,
-			    source,
-			    null,
-			    0L,
-			    new DiskClassLoader[ 1 ],
-			    null
-			);
-		}
-
-		public static ClassInfo forInterfaceProxy( String name, InterfaceProxyDefinition interfaceProxyDefinition ) {
-			return new ClassInfo(
-			    null,
-			    "boxgenerated.dynamicProxy",
-			    "InterfaceProxy_" + name,
-			    "",
-			    null,
-			    null,
-			    null,
-			    null,
-			    null,
-			    0L,
-			    new DiskClassLoader[ 1 ],
-			    interfaceProxyDefinition
-			);
-		}
-
-		public String FQN() {
-			return packageName + "." + className();
-		}
-
-		public String toString() {
-			if ( sourcePath != null )
-				return "Class Info-- sourcePath: [" + sourcePath + "], packageName: [" + packageName + "], className: [" + className + "]";
-			else if ( sourceType != null )
-				return "Class Info-- type: [" + sourceType + "], packageName: [" + packageName + "], className: [" + className + "]";
-			else if ( interfaceProxyDefinition != null )
-				return "Class Info-- interface proxy: [" + interfaceProxyDefinition.interfaces().toString() + "],  packageName: [" + packageName
-				    + "], className: [" + className + "]";
-			else
-				return "Class Info-- packageName: [" + packageName + "], className: [" + className + "]";
-		}
-
-		public DiskClassLoader getClassLoader() {
-			if ( diskClassLoader[ 0 ] != null ) {
-				return diskClassLoader[ 0 ];
-			}
-			synchronized ( this ) {
-				if ( diskClassLoader[ 0 ] != null ) {
-					return diskClassLoader[ 0 ];
-				}
-				diskClassLoader[ 0 ] = new DiskClassLoader(
-				    new URL[] {},
-				    JavaBoxpiler.getInstance().getClass().getClassLoader(),
-				    Paths.get( BoxRuntime.getInstance().getConfiguration().compiler.classGenerationDirectory ),
-				    JavaBoxpiler.getInstance()
-				);
-				return diskClassLoader[ 0 ];
-			}
-		}
-
-		/**
-		 * Get a class for a class name from disk
-		 *
-		 * @param fqn The fully qualified name of the class
-		 *
-		 * @return The loaded class
-		 */
-		public Class<IBoxRunnable> getDiskClass() {
-			try {
-				return ( Class<IBoxRunnable> ) getClassLoader().loadClass( FQN() );
-			} catch ( ClassNotFoundException e ) {
-				throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
-			}
-		}
-
-		/**
-		 * Get a Box class for a class name from disk
-		 *
-		 * @param fqn The fully qualified name of the class
-		 *
-		 * @return The loaded class
-		 */
-		public Class<IClassRunnable> getDiskClassClass() {
-			try {
-				return ( Class<IClassRunnable> ) getClassLoader().loadClass( FQN() );
-			} catch ( ClassNotFoundException e ) {
-				throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
-			}
-		}
-
-		/**
-		 * Get a proxy class for a class name from disk
-		 *
-		 * @param fqn The fully qualified name of the class
-		 *
-		 * @return The loaded class
-		 */
-		public Class<IProxyRunnable> getDiskClassProxy() {
-			try {
-				return ( Class<IProxyRunnable> ) getClassLoader().loadClass( FQN() );
-			} catch ( ClassNotFoundException e ) {
-				throw new BoxRuntimeException( "Error compiling source " + FQN(), e );
-			}
-		}
-
+	private String generateProxyJavaSource( ClassInfo classInfo ) {
+		return ProxyTransformer.transform( classInfo );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/types/exceptions/ExceptionUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/exceptions/ExceptionUtil.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.operators.InstanceOf;
+import ortus.boxlang.runtime.runnables.compiler.IBoxpiler;
 import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;

--- a/src/main/java/ortus/boxlang/transpiler/JavaTranspiler.java
+++ b/src/main/java/ortus/boxlang/transpiler/JavaTranspiler.java
@@ -232,19 +232,6 @@ public class JavaTranspiler extends Transpiler {
 	}
 
 	/**
-	 * Utility method to transform a node
-	 *
-	 * @param node a BoxLang AST Node
-	 *
-	 * @return a JavaParser AST Node
-	 *
-	 * @throws IllegalStateException
-	 */
-	public Node transform( BoxNode node ) throws IllegalStateException {
-		return this.transform( node, TransformerContext.NONE );
-	}
-
-	/**
 	 * Utility method to transform a node with a transformation context
 	 *
 	 * @param node    a BoxLang AST Node

--- a/src/main/java/ortus/boxlang/transpiler/Transpiler.java
+++ b/src/main/java/ortus/boxlang/transpiler/Transpiler.java
@@ -99,7 +99,18 @@ public abstract class Transpiler implements ITranspiler {
 	@Override
 	public abstract TranspiledCode transpile( BoxNode node ) throws BoxRuntimeException;
 
-	public abstract Node transform( BoxNode node );
+	/**
+	 * Utility method to transform a node
+	 *
+	 * @param node a BoxLang AST Node
+	 *
+	 * @return a JavaParser AST Node
+	 *
+	 * @throws IllegalStateException
+	 */
+	public Node transform( BoxNode node ) throws IllegalStateException {
+		return this.transform( node, TransformerContext.NONE );
+	}
 
 	public abstract Node transform( BoxNode node, TransformerContext context );
 

--- a/src/main/java/ortus/boxlang/transpiler/transformer/ProxyTransformer.java
+++ b/src/main/java/ortus/boxlang/transpiler/transformer/ProxyTransformer.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import ortus.boxlang.runtime.config.util.PlaceholderHelper;
-import ortus.boxlang.runtime.runnables.compiler.JavaBoxpiler.ClassInfo;
+import ortus.boxlang.runtime.runnables.compiler.ClassInfo;
 
 public class ProxyTransformer {
 


### PR DESCRIPTION
# Description

This PR extracts a `Boxpiler` abstract class and an `IBoxpiler` interface in order to prepare for different transpilers and compilers, like ASM.  We already had a `Transpiler` and `ITranspiler` interface, but there was some logic that was specific to our Java AST and compiling strategy in the `JavaBoxpiler` class, so extracting the abstract class and interface made sense.

**No changes to the running code should be in this PR.**  It should only be moving around classes and interfaces.

The tests pass locally, but aren't able to be ran in CI.  I would appreciate a few of you pulling down this branch and running it locally to make sure it's not just my setup.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
