### PR TITLE
TimeUnitsTest, DateTimeHelperTest

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
+++ b/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
@@ -292,8 +292,8 @@ public class DateTimeHelper {
 		    // First business day of the month
 		    .with( TemporalAdjusters.firstInMonth( DayOfWeek.MONDAY ) )
 		    // Specific Time
-		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 	}
 
@@ -349,8 +349,8 @@ public class DateTimeHelper {
 		    // last business day of the month
 		    .with( TemporalAdjusters.lastDayOfMonth() )
 		    // Specific Time
-		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 
 		// Verify if on weekend
@@ -473,22 +473,29 @@ public class DateTimeHelper {
 	 * @return The calculated dateTime
 	 */
 	public static LocalDateTime dateTimeAdd( LocalDateTime target, long amount, TimeUnit timeUnit ) {
-		switch ( timeUnit ) {
-			case DAYS :
-				return target.plusDays( amount );
-			case HOURS :
-				return target.plusHours( amount );
-			case MINUTES :
-				return target.plusMinutes( amount );
-			case MILLISECONDS :
-				return target.plusSeconds( amount / 1000 );
-			case MICROSECONDS :
-				return target.plusNanos( amount * 1000 );
-			case NANOSECONDS :
-				return target.plusNanos( amount );
-			default :
-				return target.plusSeconds( amount );
-		}
+		return switch ( timeUnit ) {
+			case DAYS -> {
+				yield target.plusDays( amount );
+			}
+			case HOURS -> {
+				yield target.plusHours( amount );
+			}
+			case MINUTES -> {
+				yield target.plusMinutes( amount );
+			}
+			case MILLISECONDS -> {
+				yield target.plusSeconds( amount / 1000 );
+			}
+			case MICROSECONDS -> {
+				yield target.plusNanos( amount * 1000 );
+			}
+			case NANOSECONDS -> {
+				yield target.plusNanos( amount );
+			}
+			default -> {
+				yield target.plusSeconds( amount );
+			}
+		};
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
+++ b/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
@@ -292,8 +292,8 @@ public class DateTimeHelper {
 		    // First business day of the month
 		    .with( TemporalAdjusters.firstInMonth( DayOfWeek.MONDAY ) )
 		    // Specific Time
-		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 	}
 
@@ -349,8 +349,8 @@ public class DateTimeHelper {
 		    // last business day of the month
 		    .with( TemporalAdjusters.lastDayOfMonth() )
 		    // Specific Time
-		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 
 		// Verify if on weekend
@@ -473,15 +473,22 @@ public class DateTimeHelper {
 	 * @return The calculated dateTime
 	 */
 	public static LocalDateTime dateTimeAdd( LocalDateTime target, long amount, TimeUnit timeUnit ) {
-		return switch ( timeUnit ) {
-			case DAYS -> target.plusDays( amount );
-			case HOURS -> target.plusHours( amount );
-			case MINUTES -> target.plusMinutes( amount );
-			case MILLISECONDS -> target.plusSeconds( amount / 1000 );
-			case MICROSECONDS -> target.plusNanos( amount * 1000 );
-			case NANOSECONDS -> target.plusNanos( amount );
-			default -> target.plusSeconds( amount );
-		};
+		switch ( timeUnit ) {
+			case DAYS :
+				return target.plusDays( amount );
+			case HOURS :
+				return target.plusHours( amount );
+			case MINUTES :
+				return target.plusMinutes( amount );
+			case MILLISECONDS :
+				return target.plusSeconds( amount / 1000 );
+			case MICROSECONDS :
+				return target.plusNanos( amount * 1000 );
+			case NANOSECONDS :
+				return target.plusNanos( amount );
+			default :
+				return target.plusSeconds( amount );
+		}
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
+++ b/src/main/java/ortus/boxlang/runtime/async/time/DateTimeHelper.java
@@ -292,8 +292,8 @@ public class DateTimeHelper {
 		    // First business day of the month
 		    .with( TemporalAdjusters.firstInMonth( DayOfWeek.MONDAY ) )
 		    // Specific Time
-		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 	}
 
@@ -349,8 +349,8 @@ public class DateTimeHelper {
 		    // last business day of the month
 		    .with( TemporalAdjusters.lastDayOfMonth() )
 		    // Specific Time
-		    .withHour( Integer.valueOf( time.split( ":" )[ 0 ] ) )
-		    .withMinute( Integer.valueOf( time.split( ":" )[ 1 ] ) )
+		    .withHour( Integer.parseInt( time.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.parseInt( time.split( ":" )[ 1 ] ) )
 		    .withSecond( 0 );
 
 		// Verify if on weekend
@@ -473,22 +473,15 @@ public class DateTimeHelper {
 	 * @return The calculated dateTime
 	 */
 	public static LocalDateTime dateTimeAdd( LocalDateTime target, long amount, TimeUnit timeUnit ) {
-		switch ( timeUnit ) {
-			case DAYS :
-				return target.plusDays( amount );
-			case HOURS :
-				return target.plusHours( amount );
-			case MINUTES :
-				return target.plusMinutes( amount );
-			case MILLISECONDS :
-				return target.plusSeconds( amount / 1000 );
-			case MICROSECONDS :
-				return target.plusNanos( amount * 1000 );
-			case NANOSECONDS :
-				return target.plusNanos( amount );
-			default :
-				return target.plusSeconds( amount );
-		}
+		return switch ( timeUnit ) {
+			case DAYS -> target.plusDays( amount );
+			case HOURS -> target.plusHours( amount );
+			case MINUTES -> target.plusMinutes( amount );
+			case MILLISECONDS -> target.plusSeconds( amount / 1000 );
+			case MICROSECONDS -> target.plusNanos( amount * 1000 );
+			case NANOSECONDS -> target.plusNanos( amount );
+			default -> target.plusSeconds( amount );
+		};
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
@@ -67,11 +67,11 @@ public class ParseDateTime extends BIF {
 			}
 			return dateObj;
 		}
-		if ( format != null ) {
+
+		if ( format != null )
 			return new DateTime( StringCaster.cast( dateRef ), format, timezone );
-		} else {
-			return new DateTime( StringCaster.cast( dateRef ), timezone );
-		}
+
+		return new DateTime( StringCaster.cast( dateRef ), timezone );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
@@ -67,11 +67,11 @@ public class ParseDateTime extends BIF {
 			}
 			return dateObj;
 		}
-
-		if ( format != null )
+		if ( format != null ) {
 			return new DateTime( StringCaster.cast( dateRef ), format, timezone );
-
-		return new DateTime( StringCaster.cast( dateRef ), timezone );
+		} else {
+			return new DateTime( StringCaster.cast( dateRef ), timezone );
+		}
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/async/time/DateTimeHelperTest.java
+++ b/src/test/java/ortus/boxlang/runtime/async/time/DateTimeHelperTest.java
@@ -1,0 +1,38 @@
+package ortus.boxlang.runtime.async.time;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateTimeHelperTest {
+
+	DateTimeHelper dateTimeHelper;
+
+	@BeforeEach
+	void setUp() {
+		// Create a test fixture
+	}
+
+	@DisplayName( "Testing dateTimeAdd method" )
+	@Test
+	void testDateTimeAdd() {
+		LocalDateTime		currentDateTime		= LocalDateTime.now().plusHours( 1L );
+
+		DateTimeFormatter	formatter			= DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm" );
+		String				formattedDateTime1	= currentDateTime.format( formatter );
+
+		LocalDateTime		result				= DateTimeHelper.dateTimeAdd( LocalDateTime.now(), 1, TimeUnit.HOURS );
+		assertThat( result ).isInstanceOf( LocalDateTime.class );
+
+		String formattedDateTime2 = result.format( formatter );
+		assertEquals( formattedDateTime1, formattedDateTime2 );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
@@ -22,9 +22,7 @@ package ortus.boxlang.runtime.bifs.global.temporal;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.Year;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
 import java.time.temporal.WeekFields;
@@ -278,9 +276,9 @@ public class TimeUnitsTest {
 		assertEquals( result, refDaysInYear );
 	}
 
-	@DisplayName( "It tests the BIF DayOfWeek" )
+	@DisplayName( "It tests the BIF DayOfWeek with system Locale" )
 	@Test
-	public void testBifDayOfWeek() {
+	public void testBifDayOfWeekWithSystemLocale() {
 		Integer refDayOfWeek = ZonedDateTime.now().get( WeekFields.of( locale ).dayOfWeek() );
 		instance.executeSource(
 		    """
@@ -290,14 +288,20 @@ public class TimeUnitsTest {
 		    context );
 		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
 		assertEquals( result, refDayOfWeek );
+	}
+
+	@DisplayName( "It tests the BIF DayOfWeek with parse date/time" )
+	@Test
+	public void testBifDayOfWeekWithParseDateTime() {
+		Integer refDayOfWeek = LocalDate.of( 2024, Month.APRIL, 7 ).getDayOfWeek().getValue();
 		instance.executeSource(
 		    """
 		    now = parseDateTime( "2024-04-07" );
 		       result = dayOfWeek( now );
 		       """,
 		    context );
-		result = variables.getAsInteger( Key.of( "result" ) );
-		assertEquals( 1, result );
+		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
+		assertEquals( refDayOfWeek, result );
 	}
 
 	@DisplayName( "It tests the DateTime Member function DayOfWeek" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
@@ -290,14 +290,20 @@ public class TimeUnitsTest {
 		    context );
 		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
 		assertEquals( result, refDayOfWeek );
+	}
+
+	@DisplayName( "it should match Sunday which is day number 7 [BIF DayOfWeek]" )
+	@Test
+	public void testBifDayOfWeekFromDateString() {
 		instance.executeSource(
 		    """
-		    now = parseDateTime( "2024-04-07" );
-		       result = dayOfWeek( now );
+		    dateString = parseDateTime( "2024-04-07" );
+		       result = dayOfWeek( dateString );
 		       """,
 		    context );
-		result = variables.getAsInteger( Key.of( "result" ) );
-		assertEquals( 1, result );
+
+		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
+		assertEquals( 7, result );
 	}
 
 	@DisplayName( "It tests the DateTime Member function DayOfWeek" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/TimeUnitsTest.java
@@ -290,20 +290,14 @@ public class TimeUnitsTest {
 		    context );
 		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
 		assertEquals( result, refDayOfWeek );
-	}
-
-	@DisplayName( "it should match Sunday which is day number 7 [BIF DayOfWeek]" )
-	@Test
-	public void testBifDayOfWeekFromDateString() {
 		instance.executeSource(
 		    """
-		    dateString = parseDateTime( "2024-04-07" );
-		       result = dayOfWeek( dateString );
+		    now = parseDateTime( "2024-04-07" );
+		       result = dayOfWeek( now );
 		       """,
 		    context );
-
-		Integer result = ( Integer ) variables.get( Key.of( "result" ) );
-		assertEquals( 7, result );
+		result = variables.getAsInteger( Key.of( "result" ) );
+		assertEquals( 1, result );
 	}
 
 	@DisplayName( "It tests the DateTime Member function DayOfWeek" )


### PR DESCRIPTION
Fixed TimeUnitsTest
Added DateTimeHelperTest
changed to switch expression
Interger.parse for handling String integer


## Type of change
- [x] Bug Fix
- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
