### PR TITLE
Fix default arguments sharing references

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/types/Argument.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Argument.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.util.DuplicationUtil;
 import ortus.boxlang.runtime.validation.Validatable;
 import ortus.boxlang.runtime.validation.Validator;
 
@@ -122,7 +123,7 @@ public record Argument( boolean required, String type, Key name, Object defaultV
 		if ( defaultExpression != null ) {
 			return defaultExpression.evaluate( context );
 		}
-		return defaultValue;
+		return DuplicationUtil.duplicate( defaultValue, false );
 	}
 
 	public boolean hasDefaultValue() {

--- a/src/main/java/ortus/boxlang/runtime/util/DuplicationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DuplicationUtil.java
@@ -40,7 +40,9 @@ import ortus.boxlang.runtime.types.exceptions.ExceptionUtil;
 public class DuplicationUtil {
 
 	public static Object duplicate( Object target, Boolean deep ) {
-		if ( ClassUtils.isPrimitiveOrWrapper( target.getClass() ) ) {
+		if ( target == null ) {
+			return null;
+		} else if ( ClassUtils.isPrimitiveOrWrapper( target.getClass() ) ) {
 			return target;
 		} else if ( target instanceof IStruct ) {
 			return duplicateStruct( StructCaster.cast( target ), deep );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/DuplicateTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/DuplicateTest.java
@@ -19,10 +19,6 @@
 
 package ortus.boxlang.runtime.bifs.global.system;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Comparator;
 import java.util.HashMap;
 
@@ -47,6 +43,8 @@ import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DuplicateTest {
 
@@ -273,6 +271,19 @@ public class DuplicateTest {
 		    """,
 		    context );
 		assertEquals( variables.get( refKey ), variables.get( resultKey ) );
+	}
+
+	@DisplayName( "It can duplicate null" )
+	@Test
+	public void testDuplicateNull() {
+		instance.executeSource(
+		    """
+		    ref = null;
+		    result = duplicate( ref );
+		    """,
+		    context );
+		assertNull( variables.get( refKey ) );
+		assertNull( variables.get( resultKey ) );
 	}
 
 	@Disabled( "Performance benchmark test on a struct" )

--- a/src/test/java/ortus/boxlang/runtime/types/ArgumentTest.java
+++ b/src/test/java/ortus/boxlang/runtime/types/ArgumentTest.java
@@ -1,0 +1,48 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.ArrayCaster;
+import ortus.boxlang.runtime.scopes.Key;
+
+import java.util.Set;
+
+public class ArgumentTest {
+
+	private IBoxContext context = new ScriptingRequestBoxContext();
+
+	@DisplayName( "Default values should be unique per invocation" )
+	@Test
+	void testDefaultValueIsUnique() {
+		Argument	fooArgument	= new Argument( false, "array", Key.of( "foo" ), new Array(), null, null, null, Set.of() );
+		Array		first		= ArrayCaster.cast( fooArgument.getDefaultValue( context ) );
+		first.add( "one" );
+		Array second = ArrayCaster.cast( fooArgument.getDefaultValue( context ) );
+
+		assertEquals( 1, first.size() );
+		assertEquals( "one", first.get( 0 ) );
+		assertEquals( 0, second.size() );
+	}
+
+}


### PR DESCRIPTION
Default arguments are currently sharing references.

This means given this script:
```
function a( test = [] ){
    test.append( "something" );
    println( test.len() )
}

a();
a();
a();
a();
```
We see this output
```
1
2
3
4
```

This PR does a shallow duplicate when retrieving the default value of an `Argument`.