### PR TITLE
Fix `dateAdd` to have value semantics

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateAdd.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateAdd.java
@@ -56,7 +56,7 @@ public class DateAdd extends BIF {
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		ZoneId		timezone	= LocalizationUtil.parseZoneId( null, context );
-		DateTime	ref			= DateTimeCaster.cast( arguments.get( Key.date ), true, timezone );
+		DateTime	ref			= DateTimeCaster.cast( arguments.get( Key.date ), true, timezone, true );
 		return ref.modify(
 		    arguments.getAsString( Key.datepart ),
 		    arguments.getAsLong( Key.number )

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCaster.java
@@ -132,6 +132,22 @@ public class DateTimeCaster implements IBoxCaster {
 	 * @return The value, or null when cannot be cast
 	 */
 	public static DateTime cast( Object object, Boolean fail, ZoneId timezone ) {
+		return cast( object, fail, timezone, false );
+	}
+
+	/**
+	 * Used to cast anything to a DateTime object. We start off by testing the object
+	 * against commonly known Java date objects, and then try to parse the object as a
+	 * string. If we fail, we return null.
+	 *
+	 * @param object   The value to cast
+	 * @param fail     True to throw exception when failing.
+	 * @param timezone The ZoneId to ensure a timezone is applied
+	 * @param clone    If true, will return a clone of the object if it was originally a DateTime.
+	 *
+	 * @return The value, or null when cannot be cast
+	 */
+	public static DateTime cast( Object object, Boolean fail, ZoneId timezone, Boolean clone ) {
 
 		// Null is null
 		if ( object == null ) {
@@ -147,7 +163,7 @@ public class DateTimeCaster implements IBoxCaster {
 
 		// We have a DateTime object
 		if ( object instanceof DateTime targetDateTime ) {
-			return targetDateTime;
+			return clone ? targetDateTime.clone() : targetDateTime;
 		}
 
 		// We have a ZonedDateTime object

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateAddTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateAddTest.java
@@ -108,7 +108,30 @@ public class DateAddTest {
 		assertThat( IntegerCaster.cast( result.format( "yyyy" ) ) ).isEqualTo( 2024 );
 		assertThat( IntegerCaster.cast( result.format( "M" ) ) ).isEqualTo( 1 );
 		assertThat( IntegerCaster.cast( result.format( "d" ) ) ).isEqualTo( 1 );
+	}
 
+	@DisplayName( "It does not modify the original argument" )
+	@Test
+	public void testValueSemantics() {
+		instance.executeSource(
+		    """
+		    			original = createDate( 2023, 12, 31 );
+		    modified = dateAdd( "d", 1, original );
+		    """,
+		    context );
+		DateTime modified = ( DateTime ) variables.get( Key.of( "modified" ) );
+		assertThat( modified ).isInstanceOf( DateTime.class );
+		assertThat( modified.toString() ).isInstanceOf( String.class );
+		assertThat( IntegerCaster.cast( modified.format( "yyyy" ) ) ).isEqualTo( 2024 );
+		assertThat( IntegerCaster.cast( modified.format( "M" ) ) ).isEqualTo( 1 );
+		assertThat( IntegerCaster.cast( modified.format( "d" ) ) ).isEqualTo( 1 );
+
+		DateTime original = ( DateTime ) variables.get( Key.of( "original" ) );
+		assertThat( original ).isInstanceOf( DateTime.class );
+		assertThat( original.toString() ).isInstanceOf( String.class );
+		assertThat( IntegerCaster.cast( original.format( "yyyy" ) ) ).isEqualTo( 2023 );
+		assertThat( IntegerCaster.cast( original.format( "M" ) ) ).isEqualTo( 12 );
+		assertThat( IntegerCaster.cast( original.format( "d" ) ) ).isEqualTo( 31 );
 	}
 
 }


### PR DESCRIPTION
# Description

Fixed by having a clone returned from casting the datetime if the original object was a DateTime instance.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-263


## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
