### PR TITLE
Fix double casting for long decimals by correctly using our formatter

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
@@ -36,6 +36,11 @@ import ortus.boxlang.runtime.types.exceptions.BoxCastException;
  */
 public class StringCaster implements IBoxCaster {
 
+	private static DecimalFormat decimalFormatter = ( DecimalFormat ) DecimalFormat.getInstance();
+	static {
+		decimalFormatter.applyLocalizedPattern( "#.############" );
+	}
+
 	/**
 	 * Tests to see if the value can be cast to a string.
 	 * Returns a {@code CastAttempt<T>} which will contain the result if casting was
@@ -169,8 +174,9 @@ public class StringCaster implements IBoxCaster {
 			double	dObject	= d;
 			long	lObject	= ( long ) dObject;
 			if ( dObject == lObject || Math.abs( dObject - lObject ) < 0.000000000001 ) {
-				return new DecimalFormat( "#.############" ).format( object );
+				return Long.toString( lObject );
 			}
+			return decimalFormatter.format( object );
 		}
 		if ( object instanceof Number ) {
 			return object.toString();

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToStringTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToStringTest.java
@@ -169,4 +169,15 @@ public class ToStringTest {
 		assertThat( variables.getAsString( result ) ).contains( "System" );
 	}
 
+	@DisplayName( "It formats doubles when casting them to strings" )
+	@Test
+	public void testFormatDouble() {
+		instance.executeSource(
+		    """
+		    result = toString( 1756.8000000000002 )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "1756.8" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/KeyCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/KeyCasterTest.java
@@ -59,7 +59,8 @@ public class KeyCasterTest {
 	void testItCanCastADouble() {
 		assertThat( KeyCaster.cast( Double.valueOf( "5" ) ) ).isEqualTo( Key.of( "5" ) );
 		assertThat( KeyCaster.cast( Double.valueOf( "5.0" ) ) ).isEqualTo( Key.of( "5" ) );
-		assertThat( KeyCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( Key.of( "1.2345678901234567" ) );
+		// this one should be truncated according to our double formatter pattern
+		assertThat( KeyCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( Key.of( "1.234567890123" ) );
 	}
 
 	@DisplayName( "It can cast a Float to a key" )

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/StringCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/StringCasterTest.java
@@ -73,7 +73,8 @@ public class StringCasterTest {
 		assertThat( StringCaster.cast( Double.valueOf( "5.7" ) ) ).isEqualTo( "5.7" );
 		assertThat( StringCaster.cast( Double.valueOf( "5.8" ) ) ).isEqualTo( "5.8" );
 		assertThat( StringCaster.cast( Double.valueOf( "5.9" ) ) ).isEqualTo( "5.9" );
-		assertThat( StringCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( "1.2345678901234567" );
+		// this one should be truncated according to our double formatter pattern
+		assertThat( StringCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( "1.234567890123" );
 	}
 
 	@DisplayName( "It can cast a Float to a string" )


### PR DESCRIPTION
# Description

Doubles like 1756.8000000000002 should be formatted as 1756.8.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-265

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
