### PR TITLE
More forgiving casting inside isValid to avoid exceptions

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/decision/IsValid.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/decision/IsValid.java
@@ -21,6 +21,7 @@ import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.DoubleCaster;
 import ortus.boxlang.runtime.dynamic.casters.GenericCaster;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -97,11 +98,11 @@ public class IsValid extends BIF {
 			 * Implemented in ValidationUtil
 			 */
 			case BINARY -> ValidationUtil.isBinary( arguments.get( Key.value ) );
-			case CREDITCARD -> ValidationUtil.isValidCreditCard( arguments.castAsString( Key.value ) );
+			case CREDITCARD -> ValidationUtil.isValidCreditCard( castAsStringOrNull( arguments.get( Key.value ) ) );
 			case CLOSURE -> ValidationUtil.isClosure( arguments.get( Key.value ) );
 			case COMPONENT, CLASS -> ValidationUtil.isBoxClass( arguments.get( Key.value ) );
-			case GUID -> ValidationUtil.isValidGUID( arguments.castAsString( Key.value ) );
-			case EMAIL -> ValidationUtil.isValidEmail( arguments.castAsString( Key.value ) );
+			case GUID -> ValidationUtil.isValidGUID( castAsStringOrNull( arguments.get( Key.value ) ) );
+			case EMAIL -> ValidationUtil.isValidEmail( castAsStringOrNull( arguments.get( Key.value ) ) );
 			case FUNCTION -> ValidationUtil.isFunction( arguments.get( Key.value ) );
 			case INTEGER -> ValidationUtil.isValidInteger( arguments.get( Key.value ) );
 			case LAMBDA -> ValidationUtil.isLambda( arguments.get( Key.value ) );
@@ -112,21 +113,26 @@ public class IsValid extends BIF {
 			    DoubleCaster.cast( arguments.get( Key.max ) )
 			);
 			case REGEX, REGULAR_EXPRESSION -> ValidationUtil.isValidPattern(
-			    arguments.castAsString( Key.value ),
+			    castAsStringOrNull( arguments.get( Key.value ) ),
 			    pattern
 			);
-			case SSN, SOCIAL_SECURITY_NUMBER -> ValidationUtil.isValidSSN( arguments.castAsString( Key.value ) );
-			case TELEPHONE -> ValidationUtil.isValidTelephone( arguments.castAsString( Key.value ) );
-			case URL -> ValidationUtil.isValidURL( arguments.castAsString( Key.value ) );
+			case SSN, SOCIAL_SECURITY_NUMBER -> ValidationUtil.isValidSSN( castAsStringOrNull( arguments.get( Key.value ) ) );
+			case TELEPHONE -> ValidationUtil.isValidTelephone( castAsStringOrNull( arguments.get( Key.value ) ) );
+			case URL -> ValidationUtil.isValidURL( castAsStringOrNull( arguments.get( Key.value ) ) );
 			case UDF -> ValidationUtil.isUDF( arguments.get( Key.value ) );
-			case UUID -> ValidationUtil.isValidUUID( arguments.castAsString( Key.value ) ) || ValidationUtil.isValidGUID( arguments.castAsString( Key.value ) );
-			case VARIABLENAME -> ValidationUtil.isValidVariableName( arguments.castAsString( Key.value ) );
+			case UUID -> ValidationUtil.isValidUUID( castAsStringOrNull( arguments.get( Key.value ) ) )
+			    || ValidationUtil.isValidGUID( castAsStringOrNull( arguments.get( Key.value ) ) );
+			case VARIABLENAME -> ValidationUtil.isValidVariableName( castAsStringOrNull( arguments.get( Key.value ) ) );
 			case USDATE -> context.invokeFunction( Key.of( "LSIsDate" ),
-			    java.util.Map.of( Key.date, arguments.castAsString( Key.value ), Key.locale, "en_US" ) );
-			case ZIPCODE -> ValidationUtil.isValidZipCode( arguments.castAsString( Key.value ) );
+			    java.util.Map.of( Key.date, arguments.get( Key.value ), Key.locale, "en_US" ) );
+			case ZIPCODE -> ValidationUtil.isValidZipCode( castAsStringOrNull( arguments.get( Key.value ) ) );
 
 			default -> throw new IllegalArgumentException( "Invalid type: " + type + ". Valid types are: " + Arrays.toString( IsValidType.toArray() ) );
 		};
+	}
+
+	public String castAsStringOrNull( Object value ) {
+		return StringCaster.cast( value, false );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/decision/IsValid.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/decision/IsValid.java
@@ -97,11 +97,11 @@ public class IsValid extends BIF {
 			 * Implemented in ValidationUtil
 			 */
 			case BINARY -> ValidationUtil.isBinary( arguments.get( Key.value ) );
-			case CREDITCARD -> ValidationUtil.isValidCreditCard( arguments.getAsString( Key.value ) );
+			case CREDITCARD -> ValidationUtil.isValidCreditCard( arguments.castAsString( Key.value ) );
 			case CLOSURE -> ValidationUtil.isClosure( arguments.get( Key.value ) );
 			case COMPONENT, CLASS -> ValidationUtil.isBoxClass( arguments.get( Key.value ) );
-			case GUID -> ValidationUtil.isValidGUID( arguments.getAsString( Key.value ) );
-			case EMAIL -> ValidationUtil.isValidEmail( arguments.getAsString( Key.value ) );
+			case GUID -> ValidationUtil.isValidGUID( arguments.castAsString( Key.value ) );
+			case EMAIL -> ValidationUtil.isValidEmail( arguments.castAsString( Key.value ) );
 			case FUNCTION -> ValidationUtil.isFunction( arguments.get( Key.value ) );
 			case INTEGER -> ValidationUtil.isValidInteger( arguments.get( Key.value ) );
 			case LAMBDA -> ValidationUtil.isLambda( arguments.get( Key.value ) );
@@ -112,18 +112,18 @@ public class IsValid extends BIF {
 			    DoubleCaster.cast( arguments.get( Key.max ) )
 			);
 			case REGEX, REGULAR_EXPRESSION -> ValidationUtil.isValidPattern(
-			    arguments.getAsString( Key.value ),
+			    arguments.castAsString( Key.value ),
 			    pattern
 			);
-			case SSN, SOCIAL_SECURITY_NUMBER -> ValidationUtil.isValidSSN( arguments.getAsString( Key.value ) );
-			case TELEPHONE -> ValidationUtil.isValidTelephone( arguments.getAsString( Key.value ) );
-			case URL -> ValidationUtil.isValidURL( arguments.getAsString( Key.value ) );
+			case SSN, SOCIAL_SECURITY_NUMBER -> ValidationUtil.isValidSSN( arguments.castAsString( Key.value ) );
+			case TELEPHONE -> ValidationUtil.isValidTelephone( arguments.castAsString( Key.value ) );
+			case URL -> ValidationUtil.isValidURL( arguments.castAsString( Key.value ) );
 			case UDF -> ValidationUtil.isUDF( arguments.get( Key.value ) );
-			case UUID -> ValidationUtil.isValidUUID( arguments.getAsString( Key.value ) ) || ValidationUtil.isValidGUID( arguments.getAsString( Key.value ) );
-			case VARIABLENAME -> ValidationUtil.isValidVariableName( arguments.getAsString( Key.value ) );
+			case UUID -> ValidationUtil.isValidUUID( arguments.castAsString( Key.value ) ) || ValidationUtil.isValidGUID( arguments.castAsString( Key.value ) );
+			case VARIABLENAME -> ValidationUtil.isValidVariableName( arguments.castAsString( Key.value ) );
 			case USDATE -> context.invokeFunction( Key.of( "LSIsDate" ),
-			    java.util.Map.of( Key.date, arguments.getAsString( Key.value ), Key.locale, "en_US" ) );
-			case ZIPCODE -> ValidationUtil.isValidZipCode( arguments.getAsString( Key.value ) );
+			    java.util.Map.of( Key.date, arguments.castAsString( Key.value ), Key.locale, "en_US" ) );
+			case ZIPCODE -> ValidationUtil.isValidZipCode( arguments.castAsString( Key.value ) );
 
 			default -> throw new IllegalArgumentException( "Invalid type: " + type + ". Valid types are: " + Arrays.toString( IsValidType.toArray() ) );
 		};

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
@@ -36,6 +36,11 @@ import ortus.boxlang.runtime.types.exceptions.BoxCastException;
  */
 public class StringCaster implements IBoxCaster {
 
+	private static DecimalFormat decimalFormatter = ( DecimalFormat ) DecimalFormat.getInstance();
+	static {
+		decimalFormatter.applyLocalizedPattern( "#.############" );
+	}
+
 	/**
 	 * Tests to see if the value can be cast to a string.
 	 * Returns a {@code CastAttempt<T>} which will contain the result if casting was
@@ -169,8 +174,9 @@ public class StringCaster implements IBoxCaster {
 			double	dObject	= d;
 			long	lObject	= ( long ) dObject;
 			if ( dObject == lObject || Math.abs( dObject - lObject ) < 0.000000000001 ) {
-				return new DecimalFormat( "#.############" ).format( object );
+				return Long.toString( lObject );
 			}
+			return decimalFormatter.format( object );
 		}
 		if ( object instanceof Number ) {
 			return object.toString();

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import ortus.boxlang.runtime.dynamic.IReferenceable;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.runnables.BoxInterface;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
@@ -250,6 +251,14 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 */
 	default String getAsString( Key key ) {
 		return ( String ) DynamicObject.unWrap( get( key ) );
+	}
+
+	/**
+	 * Convenience method for getting cast as String
+	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 */
+	default String castAsString( Key key ) {
+		return StringCaster.cast( DynamicObject.unWrap( get( key ) ), true );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -254,14 +254,6 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	}
 
 	/**
-	 * Convenience method for getting cast as String
-	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
-	 */
-	default String castAsString( Key key ) {
-		return StringCaster.cast( DynamicObject.unWrap( get( key ) ), true );
-	}
-
-	/**
 	 * Convenience method for getting cast as Double
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
 	 */

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToStringTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToStringTest.java
@@ -169,4 +169,15 @@ public class ToStringTest {
 		assertThat( variables.getAsString( result ) ).contains( "System" );
 	}
 
+	@DisplayName( "It formats doubles when casting them to strings" )
+	@Test
+	public void testFormatDouble() {
+		instance.executeSource(
+		    """
+		    result = toString( 1756.8000000000002 )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "1756.8" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/decision/IsValidTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/decision/IsValidTest.java
@@ -356,6 +356,8 @@ public class IsValidTest {
 	public void testUsdate() {
 		assertThat( ( Boolean ) instance.executeStatement( "isValid( 'usdate', '1/31/2024' )" ) ).isTrue();
 		assertThat( ( Boolean ) instance.executeStatement( "isValid( 'usdate', '31/1/2024' )" ) ).isFalse();
+		assertThat( ( Boolean ) instance.executeStatement( "isValid( 'usdate', 8 )" ) ).isFalse();
+		assertThat( ( Boolean ) instance.executeStatement( "isValid( 'usdate', 8.0 )" ) ).isFalse();
 	}
 
 	@DisplayName( "It works on zipcodes" )
@@ -589,4 +591,5 @@ public class IsValidTest {
 		assertThat( ( Boolean ) variables.get( Key.of( "fClosure" ) ) ).isFalse();
 		assertThat( ( Boolean ) variables.get( Key.of( "fLambda" ) ) ).isFalse();
 	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/KeyCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/KeyCasterTest.java
@@ -59,7 +59,8 @@ public class KeyCasterTest {
 	void testItCanCastADouble() {
 		assertThat( KeyCaster.cast( Double.valueOf( "5" ) ) ).isEqualTo( Key.of( "5" ) );
 		assertThat( KeyCaster.cast( Double.valueOf( "5.0" ) ) ).isEqualTo( Key.of( "5" ) );
-		assertThat( KeyCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( Key.of( "1.2345678901234567" ) );
+		// this one should be truncated according to our double formatter pattern
+		assertThat( KeyCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( Key.of( "1.234567890123" ) );
 	}
 
 	@DisplayName( "It can cast a Float to a key" )

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/StringCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/StringCasterTest.java
@@ -73,7 +73,8 @@ public class StringCasterTest {
 		assertThat( StringCaster.cast( Double.valueOf( "5.7" ) ) ).isEqualTo( "5.7" );
 		assertThat( StringCaster.cast( Double.valueOf( "5.8" ) ) ).isEqualTo( "5.8" );
 		assertThat( StringCaster.cast( Double.valueOf( "5.9" ) ) ).isEqualTo( "5.9" );
-		assertThat( StringCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( "1.2345678901234567" );
+		// this one should be truncated according to our double formatter pattern
+		assertThat( StringCaster.cast( Double.valueOf( "1.2345678901234567" ) ) ).isEqualTo( "1.234567890123" );
 	}
 
 	@DisplayName( "It can cast a Float to a string" )


### PR DESCRIPTION
# Description

Instead of throwing exceptions inside `isValid` when the types don't match, we want to return `false`.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-266

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
