### PR TITLE
JDBC - Implement query caching

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
@@ -68,6 +68,11 @@ public final class ExecutedQuery {
 	private @Nullable Object				generatedKey;
 
 	/**
+	 * If the query was cached.
+	 */
+	private Boolean							isCached;
+
+	/**
 	 * Creates an ExecutedQuery instance.
 	 *
 	 * @param pendingQuery  The {@link PendingQuery} executed.
@@ -76,6 +81,7 @@ public final class ExecutedQuery {
 	 * @param hasResults    Boolean flag from {@link PreparedStatement#execute()} designating if the execution returned any results.
 	 */
 	public ExecutedQuery( @Nonnull PendingQuery pendingQuery, @Nonnull Statement statement, long executionTime, boolean hasResults ) {
+		this.isCached		= false;
 		this.pendingQuery	= pendingQuery;
 		this.executionTime	= executionTime;
 
@@ -190,6 +196,23 @@ public final class ExecutedQuery {
 	}
 
 	/**
+	 * Returns true if the query was cached.
+	 */
+	public Boolean getIsCached() {
+		return this.isCached;
+	}
+
+	/**
+	 * Sets the query as cached.
+	 * <p>
+	 * This is used to indicate that the query was cached - it does not actually cache the query. Use after retrieval from cache.
+	 */
+	public ExecutedQuery setIsCached() {
+		this.isCached = true;
+		return this;
+	}
+
+	/**
 	 * Returns the `result` struct returned from `queryExecute` and `query`.
 	 *
 	 * @return A `result` struct
@@ -206,7 +229,7 @@ public final class ExecutedQuery {
 		 */
 		Struct result = new Struct();
 		result.put( "sql", this.pendingQuery.getOriginalSql() );
-		result.put( "cached", false );
+		result.put( "cached", this.getIsCached() );
 		// cacheKey, cacheTimeout, cacheLastAccessTimeout, cacheRegion
 		result.put( "sqlParameters", Array.fromList( this.pendingQuery.getParameterValues() ) );
 		result.put( "recordCount", getRecordCount() );

--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
@@ -15,12 +15,16 @@
 package ortus.boxlang.runtime.jdbc;
 
 import java.sql.Statement;
+import java.time.Duration;
 
 import javax.annotation.Nullable;
 
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.services.CacheService;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
@@ -103,6 +107,36 @@ public class QueryOptions {
 	private Integer				fetchSize;
 
 	/**
+	 * Whether or not the query results should be cached.
+	 * <p>
+	 * See also {@link #cacheTimeout}, {@link #cacheProvider}, and {@link #cacheLastAccessTimeout}.
+	 */
+	private Boolean				cache;
+
+	/**
+	 * The cache provider to use when caching query results.
+	 * <p>
+	 * See also {@link #cache}, {@link #cacheTimeout} and {@link #cacheLastAccessTimeout}.
+	 */
+	private String				cacheProvider;
+
+	/**
+	 * Maximum duration to retain the query results in the cache. Will ONLY be used if {@link #cache} is true.
+	 * <p>
+	 * See also {@link #cache}, {@link #cacheProvider}, and {@link #cacheLastAccessTimeout}.
+	 */
+	private Duration			cacheTimeout;
+
+	/**
+	 * Maximum duration to retain unreferenced query results in the cache.
+	 * <p>
+	 * Will ONLY be used if {@link #cache} is true. If greater than {@link #cacheTimeout}, the idle timeout will be ignored.
+	 * <p>
+	 * See also {@link #cache}, {@link #cacheProvider}, and {@link #cacheTimeout}.
+	 */
+	private Duration			cacheLastAccessTimeout;
+
+	/**
 	 * --------------------------------------------------------------------------
 	 * Constructor(s)
 	 * --------------------------------------------------------------------------
@@ -116,15 +150,24 @@ public class QueryOptions {
 	 * @param options Struct of query options. Backwards-compatible with the old-style <code>&lt;query&gt;</code> from BL.
 	 */
 	public QueryOptions( IStruct options ) {
-		this.options			= options;
-		this.resultVariableName	= options.getAsString( Key.result );
-		this.username			= options.getAsString( Key.username );
-		this.password			= options.getAsString( Key.password );
-		this.queryTimeout		= options.getAsInteger( Key.timeout );
+		CacheService cacheService = BoxRuntime.getInstance().getCacheService();
+
+		this.options				= options;
+		this.resultVariableName		= options.getAsString( Key.result );
+		this.username				= options.getAsString( Key.username );
+		this.password				= options.getAsString( Key.password );
+		this.queryTimeout			= options.getAsInteger( Key.timeout );
+		this.datasource				= options.get( Key.datasource );
+		this.fetchSize				= ( Integer ) options.getOrDefault( Key.fetchSize, 0 );
+
+		// Caching options
+		this.cache					= BooleanCaster.attempt( options.get( Key.cache ) ).getOrDefault( false );
+		this.cacheTimeout			= ( Duration ) options.getOrDefault( Key.cacheTimeout, Duration.ZERO );
+		this.cacheLastAccessTimeout	= ( Duration ) options.getOrDefault( Key.cacheLastAccessTimeout, Duration.ZERO );
+		this.cacheProvider			= ( String ) options.getOrDefault( Key.cacheProvider, cacheService.getDefaultCache().getName().toString() );
+
 		Integer intMaxRows = options.getAsInteger( Key.maxRows );
-		this.maxRows	= Long.valueOf( intMaxRows != null ? intMaxRows : -1 );
-		this.fetchSize	= ( Integer ) options.getOrDefault( Key.fetchSize, 0 );
-		this.datasource	= options.get( Key.datasource );
+		this.maxRows = Long.valueOf( intMaxRows != null ? intMaxRows : -1 );
 
 		determineReturnType();
 	}
@@ -160,28 +203,74 @@ public class QueryOptions {
 		return this.resultVariableName;
 	}
 
+	/*
+	 * Get the `queryTimeout` query option.
+	 */
 	public Integer getQueryTimeout() {
 		return this.queryTimeout;
 	}
 
+	/*
+	 * Get the `fetchSize` query option.
+	 */
 	public Integer getFetchSize() {
 		return this.fetchSize;
 	}
 
+	/*
+	 * Get the `maxRows` query option.
+	 */
 	public Long getMaxRows() {
 		return this.maxRows;
 	}
 
+	/*
+	 * Get the `returnType` query option.
+	 */
 	public String getReturnType() {
 		return this.returnType;
 	}
 
+	/*
+	 * Get the `username` query option.
+	 */
 	public String getUsername() {
 		return this.username;
 	}
 
+	/*
+	 * Get the `password` query option.
+	 */
 	public String getPassword() {
 		return this.password;
+	}
+
+	/*
+	 * Get the `cache` query option.
+	 */
+	public Boolean isCacheable() {
+		return this.cache;
+	}
+
+	/*
+	 * Get the `cacheTimeout` query option.
+	 */
+	public Duration getCacheTimeout() {
+		return this.cacheTimeout;
+	}
+
+	/*
+	 * Get the `cacheLastAccessTimeout` query option.
+	 */
+	public Duration getCacheLastAccessTimeout() {
+		return this.cacheLastAccessTimeout;
+	}
+
+	/*
+	 * Get the `cacheProvider` query option.
+	 */
+	public String getCacheProvider() {
+		return this.cacheProvider;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -702,6 +702,10 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		nested							= Key.of( "nested" );
 	public static final Key		onTheFly						= Key.of( "onTheFly" );
 	public static final Key		returnCode						= Key.of( "returnCode" );
+	public static final Key		cache							= Key.of( "cache" );
+	public static final Key		cacheTimeout					= Key.of( "cacheTimeout" );
+	public static final Key		cacheLastAccessTimeout			= Key.of( "cacheLastAccessTimeout" );
+	public static final Key		cacheProvider					= Key.of( "cacheProvider" );
 
 	// Datasource configuration keys
 	public static final Key		connectionString				= Key.of( "connectionString" );


### PR DESCRIPTION
# Description

We now support query caching via the `cache`, `cacheTimeout` and `cacheLastAccessTimeout` query options:

```js
queryExecute(
    "SELECT * FROM developers WHERE role = ?",
    [ "Developer" ],
    { cache: true }
);
```

By default, queries will use [the default Boxlang CacheProvider](https://github.com/ortus-boxlang/BoxLang/blob/feat/query-caching/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.javahttps://github.com/ortus-boxlang/BoxLang/blob/d2084dd90910e717eca1ea57c4eca1796935a4cb/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.java), which has default timeouts and `lastAccessTimeout` values set.

To specify a custom caching provider, you can use the `cacheProvider` query option:

```js
queryExecute(
    "SELECT * FROM developers WHERE role = ?",
    [ "Developer" ],
    { cache: true, cacheProvider : "MyCustomCacheProvider" }
);
```

To specify custom cache entry timeouts, use `cacheTimeout` or `cacheLastAccessTimeout`:

```js
queryExecute(
    "SELECT * FROM developers WHERE role = ?",
    [ "Developer" ],
    { cache: true, cacheTimeout : createTimespan( 0, 0, 0, 30 ), cacheLastAccessTimeout : createTimespan( 0, 0, 0, 30 ) }
);
```

Note that the `bx-compat` module will take care of implementing [the historical `cachedWithin` and `cachedAfter` query options](https://cfdocs.org/cfquery).

## Jira Issues

Resolves [BL-256](https://ortussolutions.atlassian.net/browse/BL-256)

## Type of change

Please delete options that are not relevant.

- [X] New Feature
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


[BL-256]: https://ortussolutions.atlassian.net/browse/BL-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ