### PR TITLE
Bl 365 throwable dump table styling

### DIFF
--- a/src/main/resources/dump/html/Array.bxm
+++ b/src/main/resources/dump/html/Array.bxm
@@ -1,10 +1,9 @@
 <!--- array template --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableAy" title="#encodeForHTML( posInCode )#">
+		<table class="bx-table-secondary" title="#encodeForHTML( posInCode )#">
 			<bx:if var.len() >
 				<caption
-					class="bx-dhAy"
 					role="button"
 					tabindex="0"
 					<bx:if expand>open</bx:if>
@@ -30,7 +29,6 @@
 						```
 						<tr>
 							<th
-								class="bx-dhAy"
 								scope="row"
 								valign="top"
 								onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -8,7 +8,7 @@
 </bx:script>
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableCs" title="#encodeForHTML( posInCode )#">
+		<table class="bx-table-tertiary" title="#encodeForHTML( posInCode )#">
 			<caption
 				class="bx-dhCs"
 				role="button"
@@ -29,14 +29,13 @@
 			>
 
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Path</strong></th>
+					<th scope="row"><strong>Path</strong></th>
 					<td>#encodeForHTML( md.path )#</td>
 				</tr>
 
 				<!--- EXTENDS --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
@@ -51,7 +50,6 @@
 				<!--- IMPLEMENTS --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
@@ -65,10 +63,10 @@
 
 				<!--- Annotations --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Annotations</strong></th>
+					<th scope="row"><strong>Annotations</strong></th>
 					<td>
 						<bx:set annotations = md.annotations>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr>
 									<th><b>Annotation</b></th>
@@ -98,15 +96,14 @@
 				<!--- PROPERTIES --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
 						>
-						<strong>Properties</strong>
+						Properties
 					</th>
 					<td>
-						<table >
+						<table class="bx-table-default">
 							<tr>
 								<th>Name</th>
 								<th>Value</th>
@@ -131,15 +128,14 @@
 				<!--- Static METHODS  --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
 						>
-						<strong>Static Methods</strong>
+						Static Methods
 					</th>
 					<td>
-						<table >
+						<table class="bx-table-default">
 							<tr>
 								<th>Name</th>
 								<th>Signature</th>
@@ -170,15 +166,14 @@
 				<!--- PUBLIC METHODS  --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
 						>
-						<strong>Public Methods</strong>
+						Public Methods
 					</th>
 					<td>
-						<table >
+						<table class="bx-table-default">
 							<tr>
 								<th>Name</th>
 								<th>Signature</th>
@@ -209,15 +204,14 @@
 				<!--- PRIVATE METHODS  --->
 				<tr>
 					<th
-						class="bx-dhCs"
 						scope="row"
 						valign="top"
 						onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
 						>
-						<strong>Private Methods</strong>
+						Private Methods
 					</th>
 					<td>
-						<table >
+						<table class="bx-table-default">
 							<tr>
 								<th>Name</th>
 								<th>Signature</th>

--- a/src/main/resources/dump/html/Class.bxm
+++ b/src/main/resources/dump/html/Class.bxm
@@ -1,9 +1,8 @@
 <!--- table of class data --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableCs" title="#encodeForHTML( posInCode )#">
+		<table class="bx-table-tertiary" title="#encodeForHTML( posInCode )#">
 			<caption
-				class="bx-dhCs"
 				role="button"
 				tabindex="0"
 				<bx:if expand>open</bx:if>
@@ -17,22 +16,26 @@
 			>
 				<!--- CLASS toString --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>toString()</strong></th>
+					<th scope="row">
+						toString()
+					</th>
 					<td>#encodeForHTML( var.toString() )#</td>
 				</tr>
 
 				<!--- CLASS NAME --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Class</strong></th>
+					<th scope="row">
+						Class
+					</th>
 					<td>#encodeForHTML( var.getClass().getName() )#</td>
 				</tr>
 
 				<!--- CLASS FIELDS --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Fied(s)</strong></th>
+					<th scope="row">Fied(s)</th>
 					<td>
 						<bx:set fields = var.getClass().getFields()>
-							<table>
+							<table class="bx-table-default">
 								<thead>
 									<tr>
 										<th>Name</th>
@@ -70,10 +73,10 @@
 
 				<!--- CLASS annotations --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Annotations(s)</strong></th>
+					<th scope="row">Annotations(s)</th>
 					<td>
 						<bx:set annotations = var.getClass().getDeclaredannotations()>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr>
 									<th><b>Type</b></th>
@@ -100,10 +103,10 @@
 
 				<!--- CLASS Constructors --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Constructor(s)</strong></th>
+					<th scope="row">Constructor(s)</th>
 					<td>
 						<bx:set constructors = var.getClass().getDeclaredConstructors()>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr>
 									<th><b>Signature</b></th>
@@ -128,7 +131,7 @@
 
 				<!--- CLASS Methods --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Method(s)</strong></th>
+					<th scope="row">Method(s)</th>
 					<td>
 						<bx:script>
 							import java.util.Arrays;
@@ -137,7 +140,7 @@
 								.sorted( Comparator.comparing( m -> m.getName() ) )
 								.toList();
 						</bx:script>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr><th>Name</th><th>Signature</th></tr>
 							</thead>

--- a/src/main/resources/dump/html/Dump.css
+++ b/src/main/resources/dump/html/Dump.css
@@ -61,8 +61,13 @@
 	/* Icon Tokens */
 	--bx-icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(0, 0, 0)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points=' 6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
+	/* Component Tokens */
 	--bx-table-bg: var(--bx-color-surface);
 	--bx-table-color: var(--bx-color-onSurface);
+	--bx-table-color-border: var(--bx-color-border);
+	--bx-table-caption-bg: transparent;
+	--bx-table-caption-color: var(--bx-color-onSurface);
+	--bx-table-th-color-bg: var(--bx-color-secondary-weak);
 
 	font-family: var(--bx-font-family-sans-serif);
 }
@@ -78,14 +83,54 @@
 	border-collapse: collapse;
 	border-spacing: 0;
 	text-indent: 0;
-	border: 1px solid #666;
+	border: 1px solid var(--bx-table-color-border);
 }
 
+.bx-dump .bx-table-default {
+	--bx-table-color-border: var(--bx-color-border);
+	--bx-table-caption-bg: transparent;
+	--bx-table-caption-color: var(--bx-color-onSurface);
+	--bx-table-th-color-bg: var(--bx-color-secondary-weak);
+}
+
+.bx-dump .bx-table-primary {
+	--bx-table-color-border: var(--bx-color-primary-strong);
+	--bx-table-caption-bg: var(--bx-color-primary);
+	--bx-table-caption-color: var(--bx-color-onPrimary);
+	--bx-table-th-color-bg: var(--bx-color-primary-weak);
+}
+
+.bx-dump .bx-table-secondary {
+	--bx-table-color-border: var(--bx-color-secondary-strong);
+	--bx-table-caption-bg: var(--bx-color-secondary);
+	--bx-table-caption-color: var(--bx-color-onSecondary);
+	--bx-table-th-color-bg: var(--bx-color-secondary-weak);
+}
+
+.bx-dump .bx-table-tertiary {
+	--bx-table-color-border: var(--bx-color-tertiary-strong);
+	--bx-table-caption-bg: var(--bx-color-tertiary);
+	--bx-table-caption-color: var(--bx-color-onTertiary);
+	--bx-table-th-color-bg: var(--bx-color-tertiary-weak);
+}
+
+.bx-dump .bx-table-green {
+	--bx-table-color-border: var(--bx-color-primary-strong);
+	--bx-table-caption-bg: var(--bx-color-primary-strong);
+	--bx-table-caption-color: var(--bx-color-onPrimary);
+	--bx-table-th-color-bg: var(--bx-color-primary-weak);
+}
+
+.bx-dump .bx-table-red {
+	--bx-table-color-border: var(--bx-color-danger-strong);
+	--bx-table-caption-bg: var(--bx-color-danger);
+	--bx-table-caption-color: var(--bx-color-onPrimary);
+	--bx-table-th-color-bg: var(--bx-color-danger-weak);
+}
 .bx-dump table> :not(caption)>*>* {
 	border-width: 0 1px 1px;
 }
 
-.bx-dump caption,
 .bx-dump td,
 .bx-dump th {
 	border-color: inherit;
@@ -95,7 +140,12 @@
 }
 
 .bx-dump caption {
+	border-color: inherit;
+	border-style: solid;
+	background-color: var(--bx-table-caption-bg);
+	color: var(--bx-table-caption-color);
 	caption-side: top;
+	padding: 4px;
 	white-space: nowrap;
 }
 
@@ -138,6 +188,9 @@
 }
 
 .bx-dump table th {
+	background-color: var(--bx-table-th-color-bg);
+	color: var(--bx-color-onSecondary);
+
 	text-align: left;
 }
 
@@ -145,55 +198,9 @@
 	font-weight: 400;
 }
 
-.bx-dump caption.bx-dhAy,
-.bx-dump thead th.bx-dhAy {
-	background-color: var(--bx-color-secondary);
-	color: var(--bx-color-onSecondary);
-}
-
-.bx-dump table th,
-.bx-dump tbody th.bx-dhAy[scope="row"] {
-	background-color: var(--bx-color-secondary-weak);
-	color: var(--bx-color-onSecondary);
-}
-
 .bx-dump tbody td {
 	background-color: var(--bx-table-bg);
 	color: var(--bx-table-color);
-}
-
-.bx-dump .bx-tableCs {
-	border-color: var(--bx-color-tertiary-strong)
-}
-
-.bx-dump .bx-tableAy {
-	border-color: var(--bx-color-secondary-strong)
-}
-
-.bx-dump .bx-tableSt {
-	border-color: var(--bx-color-primary-strong)
-}
-
-.bx-dump caption.bx-dhCs,
-.bx-dump thead th.bx-dhCs {
-	background-color: var(--bx-color-tertiary);
-	color: var(--bx-color-onTertiary);
-}
-
-.bx-dump tbody th.bx-dhCs[scope="row"] {
-	background-color: var(--bx-color-tertiary-weak);
-	color: var(--bx-color-onTertiary);
-}
-
-.bx-dump caption.bx-dhSt,
-.bx-dump thead th.bx-dhSt {
-	background-color: var(--bx-color-primary);
-	color: var(--bx-color-onPrimary);
-}
-
-.bx-dump tbody th.bx-dhSt[scope="row"] {
-	background-color: var(--bx-color-primary-weak);
-	color: var(--bx-color-onPrimary);
 }
 
 .bx-dump .bx-dwSv {

--- a/src/main/resources/dump/html/Dump.css
+++ b/src/main/resources/dump/html/Dump.css
@@ -23,24 +23,37 @@
 	--bx-blue-gray-10: #030304;
 	--bx-blue-gray-70: #999EAF;
 	--bx-blue-gray-95: #EDEEF4;
+
+	/* Color Semantic Tokens */
 	--bx-color-surface: #ffffff;
 	--bx-color-onSurface: var(--bx-blue-gray-10);
-	--bx-color-primary: var(--bx-neon-green-50);
-	--bx-color-primary-strong: var(--bx-neon-green-40);
-	--bx-color-primary-weak: var(--bx-neon-green-80);
+
+	--bx-color-primary: var(--bx-neon-green-90);
+	--bx-color-primary-strong: var(--bx-neon-green-70);
+	--bx-color-primary-weak: var(--bx-neon-green-95);
 	--bx-color-onPrimary: var(--bx-blue-gray-10);
-	--bx-color-secondary: var(--bx-neon-blue-50);
-	--bx-color-secondary-strong: var(--bx-neon-blue-40);
-	--bx-color-secondary-weak: var(--bx-neon-blue-80);
+
+	--bx-color-secondary: var(--bx-neon-blue-80);
+	--bx-color-secondary-strong: var(--bx-neon-blue-70);
+	--bx-color-secondary-weak: var(--bx-neon-blue-95);
 	--bx-color-onSecondary: var(--bx-blue-gray-10);
-	--bx-color-tertiary: var(--bx-neon-lime-50);
-	--bx-color-tertiary-strong: var(--bx-neon-lime-40);
-	--bx-color-tertiary-weak: var(--bx-neon-lime-80);
+
+	--bx-color-tertiary: var(--bx-neon-lime-90);
+	--bx-color-tertiary-strong: var(--bx-neon-lime-70);
+	--bx-color-tertiary-weak: var(--bx-neon-lime-98);
 	--bx-color-onTertiary: var(--bx-blue-gray-10);
-	--bx-color-warning: var(--bx-neon-orange-50);
-	--bx-color-warning-strong: var(--bx-neon-orange-40);
-	--bx-color-warning-weak: var(--bx-neon-orange-80);
+
+	--bx-color-warning: var(--bx-orange-80);
+	--bx-color-warning-strong: var(--bx-orange-70);
+	--bx-color-warning-weak: var(--bx-orange-95);
 	--bx-color-onWarning: var(--bx-blue-gray-10);
+
+	--bx-color-danger: var(--bx-red-70);
+	--bx-color-danger-strong: var(--bx-red-60);
+	--bx-color-danger-weak: var(--bx-red-95);
+	--bx-color-onDanger: var(--bx-blue-gray-10);
+
+	--bx-color-border: var(--bx-blue-gray-70);
 
 	/* Text Tokens */
 	--bx-font-family-sans-serif: system-ui, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, Helvetica, Arial, "Helvetica Neue", sans-serif;

--- a/src/main/resources/dump/html/Dump.css
+++ b/src/main/resources/dump/html/Dump.css
@@ -1,22 +1,28 @@
 .bx-dump {
 	/* Color Pallet Tokens */
-	--bx-neon-blue-40: #00a4bf;
-	--bx-neon-blue-50: #00dbff;
-	--bx-neon-blue-80: #bff6ff;
-	--bx-blue-gray-10: #050609;
-	--bx-blue-gray-70: #8D8E95;
-	--bx-blue-gray-95: #F2F2F3;
-	--bx-neon-green-40: #00bf5a;
-	--bx-neon-green-50: #00ff78;
-	--bx-neon-green-80: #bfffdd;
-	--bx-neon-lime-40: #8fbf29;
-	--bx-neon-lime-50: #bfff36;
-	--bx-neon-lime-80: #efffcd;
-	--bx-neon-orange-40: #bf7a2a;
-	--bx-neon-orange-50: #ffa338;
-	--bx-neon-orange-80: #ffe8cd;
+	--bx-neon-blue-70: #00B3D6;
+	--bx-neon-blue-80: #00DCFF;
+	--bx-neon-blue-95: #CAF8FF;
 
-	/* Color Aliases Tokens */
+	--bx-neon-green-70: #00C443;
+	--bx-neon-green-90: #00FF70;
+	--bx-neon-green-95: #B3FFC4;
+
+	--bx-neon-lime-70: #6EB800;
+	--bx-neon-lime-90: #B1FA00;
+	--bx-neon-lime-98: #F0FEE1;
+
+	--bx-orange-70: #FC7200;
+	--bx-orange-80: #FFA100;
+	--bx-orange-95: #FFE19F;
+	
+	--bx-red-60: #E72C29;
+	--bx-red-70: #FF5E52;
+	--bx-red-95: #FFE5E1;
+
+	--bx-blue-gray-10: #030304;
+	--bx-blue-gray-70: #999EAF;
+	--bx-blue-gray-95: #EDEEF4;
 	--bx-color-surface: #ffffff;
 	--bx-color-onSurface: var(--bx-blue-gray-10);
 	--bx-color-primary: var(--bx-neon-green-50);

--- a/src/main/resources/dump/html/Function.bxm
+++ b/src/main/resources/dump/html/Function.bxm
@@ -4,9 +4,8 @@
 </bx:script>
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableCs" title="#encodeForHTML( posInCode )#">
+		<table class="bx-table-tertiary" title="#encodeForHTML( posInCode )#">
 			<caption
-				class="bx-dhCs"
 				role="button"
 				tabindex="0"
 				<bx:if expand>open</bx:if>
@@ -26,13 +25,13 @@
 			>
 				<!--- CLASS NAME --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Class</strong></th>
+					<th scope="row"><strong>Class</strong></th>
 					<td>#encodeForHTML( var.getClass().getName() )#</td>
 				</tr>
 
 				<!--- Modifiers --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Signature</strong></th>
+					<th scope="row"><strong>Signature</strong></th>
 					<td>
 						<pre><code>#encodeForHTML( var.signatureAsString() )#</code></pre>
 					</td>
@@ -40,10 +39,10 @@
 
 				<!--- Arguments --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Argument(s)</strong></th>
+					<th scope="row"><strong>Argument(s)</strong></th>
 					<td>
 						<bx:set args = var.getArguments()>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr>
 									<th><b>Required</b></th>
@@ -85,10 +84,10 @@
 
 				<!--- Annotations --->
 				<tr>
-					<th scope="row" class="bx-dhCs"><strong>Annotations(s)</strong></th>
+					<th scope="row"><strong>Annotations(s)</strong></th>
 					<td>
 						<bx:set annotations = md.annotations>
-						<table>
+						<table class="bx-table-default">
 							<thead>
 								<tr>
 									<th><b>Annotation</b></th>

--- a/src/main/resources/dump/html/List.bxm
+++ b/src/main/resources/dump/html/List.bxm
@@ -1,10 +1,9 @@
 <!--- List template --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableAy" title="#encodeForHTML( posInCode )#">
+		<table class="bx-table-secondary" title="#encodeForHTML( posInCode )#">
 			<bx:if var.len() >
 				<caption
-					class="bx-dhAy"
 					role="button"
 					tabindex="0"
 					<bx:if expand>open</bx:if>
@@ -14,7 +13,7 @@
 					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
 				</caption>
 			<bx:else>
-				<caption class="bx-dhAy">
+				<caption>
 					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
 				</caption>
 			</bx:if>
@@ -30,7 +29,6 @@
 						```
 							<tr>
 								<th
-									class="bx-dhAy"
 									scope="row"
 									valign="top"
 									onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"

--- a/src/main/resources/dump/html/Map.bxm
+++ b/src/main/resources/dump/html/Map.bxm
@@ -1,10 +1,9 @@
 <!--- Map template --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableSt" title="#posInCode#">
+		<table class="bx-table-primary" title="#posInCode#">
 				<bx:if var.size() >
 				<caption
-					class="bx-dhSt"
 					role="button"
 					tabindex="0"
 					<bx:if expand>open</bx:if>
@@ -14,7 +13,7 @@
 					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
 				</caption>
 			<bx:else>
-				<caption class="bx-dhSt">
+				<caption>
 					<strong>#var.getClass().getSimpleName()#: #var.len()# items</strong>
 				</caption>
 			</bx:if>
@@ -33,7 +32,6 @@
 							<tr>
 								<th
 									scope="row"
-									class="bx-dhSt"
 									valign="top"
 									onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
 									>

--- a/src/main/resources/dump/html/Query.bxm
+++ b/src/main/resources/dump/html/Query.bxm
@@ -6,19 +6,23 @@
 					role="button"
 					tabindex="0"
 					<bx:if expand>open</bx:if>
-					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
-					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
+					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');this.nextElementSibling.nextElementSibling.classList.toggle('d-none')"
+					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');this.nextElementSibling.nextElementSibling.classList.toggle('d-none');}"
 				>
 					<strong>Query: #var.recordcount# rows</strong>
 				</caption>
-				<thead>
+				<thead 
+					<bx:if !expand>class="d-none"</bx:if>
+				>
 					<tr>
 						<bx:loop array="#var.columnList.listToArray()#" item="column">
 							<th>#encodeForHTML( column )#</th>
 						</bx:loop>
 					</tr>
 				</thead>
-				<tbody>
+				<tbody 
+					<bx:if !expand>class="d-none"</bx:if>
+				>
 					<bx:loop query="#var#" item="row" index="index">
 						<bx:if top gt 0 and var.currentRow gt top >
 							<bx:break/>

--- a/src/main/resources/dump/html/Query.bxm
+++ b/src/main/resources/dump/html/Query.bxm
@@ -1,9 +1,8 @@
 <!--- Query template --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableSt" title="#posInCode#">
+		<table class="bx-table-green" title="#posInCode#">
 				<caption
-					class="bx-dhSt"
 					role="button"
 					tabindex="0"
 					<bx:if expand>open</bx:if>

--- a/src/main/resources/dump/html/Struct.bxm
+++ b/src/main/resources/dump/html/Struct.bxm
@@ -10,7 +10,7 @@
 					<caption
 						role="button"
 						tabindex="0"
-						open
+						<bx:if expand>open</bx:if>
 						onclick="this.toggleAttribute( 'open' ); this.nextElementSibling.classList.toggle( 'd-none' )"
 						onkeyup="if( event.key === 'Enter' ){ this.toggleAttribute( 'open' ); this.nextElementSibling.classList.toggle( 'd-none' );}"
 					>

--- a/src/main/resources/dump/html/Struct.bxm
+++ b/src/main/resources/dump/html/Struct.bxm
@@ -1,14 +1,13 @@
 <!--- Struct template --->
 <bx:output>
 	<div class="bx-dump">
-		<table class="bx-tableSt" title="#posInCode#">
+		<table class="bx-table-primary" title="#posInCode#">
 			<!--- TODO: Special handling of CGI scope to show all keys --->
 
 			<!--- SCOPE HEADERS --->
 			<bx:if var instanceof "ortus.boxlang.runtime.scopes.IScope" >
 				<bx:if var.len() || var instanceof 'CGIScope' >
 					<caption
-						class="bx-dhSt"
 						role="button"
 						tabindex="0"
 						open
@@ -18,7 +17,7 @@
 						<strong>#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items</strong>
 					</caption>
 				<bx:else>
-					<caption class="bx-dhSt">
+					<caption>
 						<strong>#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items</strong>
 					</caption>
 				</bx:if>
@@ -27,7 +26,6 @@
 			<bx:else>
 				<bx:if var.len() >
 					<caption
-						class="bx-dhSt"
 						role="button"
 						tabindex="0"
 						<bx:if expand>open</bx:if>
@@ -37,7 +35,7 @@
 						<strong>Struct: #var.len()# items</strong>
 					</caption>
 				<bx:else>
-					<caption class="bx-dhSt">
+					<caption>
 						<strong>Struct: #var.len()# items</strong>
 					</caption>
 				</bx:if>

--- a/src/main/resources/dump/html/Throwable.bxm
+++ b/src/main/resources/dump/html/Throwable.bxm
@@ -2,27 +2,62 @@
 <!--- Throwable template --->
 <bx:output>
 	<bx:set isBXError = var instanceof "ortus.boxlang.runtime.types.exceptions.BoxLangException">
-	<table border='1' cellpadding='3' cellspacing='0' title="#posInCode#">
-		<bx:if isBXError>
-			<tr><th colspan="2">Error: #encodeForHTML( var.getType() )#</th></tr>
-		<bx:else>
-			<tr><th colspan="2">Error: #var.getClass().getName()#</th></tr>
-		</bx:if>
-		<tr><td>Message</td><td>#encodeForHTML( var.getMessage() )#</td></tr>
-		<bx:if isBXError>
-			<tr><td>Detail</td><td>#encodeForHTML( var.getDetail() )#</td></tr>
-			<tr><td>Tag Congtext</td><td>
-				<bx:dump var="#var.getTagContext()#">
-			</td></tr>
-			<!--- TODO: Details from other exception subclasses --->
-		</bx:if>
-		<bx:if var.getCause() != null >
-			<tr><td>Cause</td><td>
-				<bx:dump var="#var.getCause()#">
-			</td></tr>
-		</bx:if>
-		<tr><td>StackTrace</td><td>
-			<pre>#encodeForHTML( ExceptionUtil.getStackTraceAsString( var ) )#</pre>
-		</td></tr>
-	</table>
+	<div class="bx-dump">
+		<table class="bx-table-red" title="#posInCode#">
+			<bx:if isBXError>
+				<caption
+					role="button"
+					tabindex="0"
+					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
+					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
+				>
+					<strong>Error: #encodeForHTML( var.getType() )#</strong>
+				</caption>
+			<bx:else>
+				<caption
+					role="button"
+					tabindex="0"
+					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
+					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
+				>
+					<strong>Error: #var.getClass().getName()#</strong>
+				</caption>
+			</bx:if>
+			<!--- Throwable BODY --->
+			<tbody
+				<bx:if !expand>class="d-none"</bx:if>
+			>
+				<tr>
+					<th scope="row">Message</th>
+					<td>#encodeForHTML( var.getMessage() )#</td></tr>
+				<bx:if isBXError>
+					<tr>
+						<th scope="row">Detail</th>
+						<td>#encodeForHTML( var.getDetail() )#</td>
+					</tr>
+					<tr>
+						<th scope="row">Tag Congtext</th>
+						<td>
+							<bx:dump var="#var.getTagContext()#">
+						</td>
+					</tr>
+					<!--- TODO: Details from other exception subclasses --->
+				</bx:if>
+				<bx:if var.getCause() != null >
+					<tr>
+						<th scope="row">Cause</th>
+						<td>
+							<bx:dump var="#var.getCause()#">
+						</td>
+					</tr>
+				</bx:if>
+				<tr>
+					<th scope="row">StackTrace</th>
+					<td>
+						<pre>#encodeForHTML( ExceptionUtil.getStackTraceAsString( var ) )#</pre>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
 </bx:output>


### PR DESCRIPTION
# Description

- Styles the Throwable Dump Table.
- Fixes the expand/collapse of the Query Dump Table.
- Fixed the toggle icon direction in the Struct Dump Table.
- Adjusted the color palette and renamed the dump table classes to facilitate future customization via settings.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/c6998033-6a46-4803-893f-4ee0177ee6f0">


## Jira Issues

[All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.](https://ortussolutions.atlassian.net/browse/BL-365)

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL/issues


## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [x] Improvement
- [ ] New Feature

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
