### PR TITLE
v1.0.0-Beta7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ on:
   workflow_dispatch:
     inputs:
       lts:
-        description: 'The LTS marker'
+        description: "The LTS marker"
         required: false
-        default: true
+        default: false
         type: boolean
 
 env:
@@ -165,7 +165,6 @@ jobs:
           changelog: changelog.md
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: refs/tags/v${{ env.VERSION }}
-
 
       - name: Inform Slack
         if: ${{ always() }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - development
 
+  # Manual Trigger for Snapshot builds
+  workflow_dispatch:
+
 #Cancel running builds if another push to branch is made while this build is running
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta6] - 2024-07-19
+
 ## [1.0.0-beta5] - 2024-07-12
 
 ## [1.0.0-beta4] - 2024-07-05
@@ -23,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta1] - 2024-06-14
 
-[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta5...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta6...HEAD
+
+[1.0.0-beta6]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta5...v1.0.0-beta6
 
 [1.0.0-beta5]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta4...v1.0.0-beta5
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Fri Jul 12 11:06:57 UTC 2024
+#Fri Jul 19 14:27:23 UTC 2024
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.0.0-beta6
+version=1.0.0-beta7

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxScriptParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxScriptParser.java
@@ -396,7 +396,7 @@ public class BoxScriptParser extends AbstractParser {
 		}
 
 		// Check if there are unconsumed tokens
-		Token token = lexer.nextToken();
+		Token token = lexer._token;
 		while ( token.getType() != Token.EOF && ( token.getChannel() == BoxScriptLexerCustom.HIDDEN ) ) {
 			token = lexer.nextToken();
 		}

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxTemplateParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxTemplateParser.java
@@ -224,7 +224,7 @@ public class BoxTemplateParser extends AbstractParser {
 			// the ability to check for unconsumed tokens.
 
 			// Check if there are unconsumed tokens
-			token = lexer.nextToken();
+			token = lexer._token;
 			while ( token.getType() != Token.EOF && ( token.getChannel() == BoxTemplateLexerCustom.HIDDEN || token.getText().isBlank() ) ) {
 				token = lexer.nextToken();
 			}

--- a/src/main/java/ortus/boxlang/compiler/parser/CFScriptParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFScriptParser.java
@@ -392,7 +392,7 @@ public class CFScriptParser extends AbstractParser {
 		}
 
 		// Check if there are unconsumed tokens
-		Token token = lexer.nextToken();
+		Token token = lexer._token;
 		while ( token.getType() != Token.EOF && ( token.getChannel() == CFScriptLexerCustom.HIDDEN ) ) {
 			token = lexer.nextToken();
 		}

--- a/src/main/java/ortus/boxlang/compiler/parser/CFTemplateParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFTemplateParser.java
@@ -239,7 +239,7 @@ public class CFTemplateParser extends AbstractParser {
 			// the ability to check for unconsumed tokens.
 
 			// Check if there are unconsumed tokens
-			token = lexer.nextToken();
+			token = lexer._token;
 			while ( token.getType() != Token.EOF && ( token.getChannel() == CFTemplateLexerCustom.HIDDEN || token.getText().isBlank() ) ) {
 				token = lexer.nextToken();
 			}

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -484,7 +484,7 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @return A BoxRuntime instance
 	 *
 	 */
-	public static synchronized BoxRuntime getInstance( Boolean debugMode ) {
+	public static BoxRuntime getInstance( Boolean debugMode ) {
 		return getInstance( debugMode, null );
 	}
 
@@ -499,7 +499,7 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @return A BoxRuntime instance
 	 *
 	 */
-	public static synchronized BoxRuntime getInstance( Boolean debugMode, String configPath ) {
+	public static BoxRuntime getInstance( Boolean debugMode, String configPath ) {
 		return getInstance( debugMode, configPath, DEFAULT_RUNTIME_HOME.toString() );
 	}
 
@@ -515,9 +515,13 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @return A BoxRuntime instance
 	 *
 	 */
-	public static synchronized BoxRuntime getInstance( Boolean debugMode, String configPath, String runtimeHome ) {
+	public static BoxRuntime getInstance( Boolean debugMode, String configPath, String runtimeHome ) {
 		if ( instance == null ) {
-			instance = new BoxRuntime( debugMode, configPath, runtimeHome );
+			synchronized ( BoxRuntime.class ) {
+				if ( instance == null ) {
+					instance = new BoxRuntime( debugMode, configPath, runtimeHome );
+				}
+			}
 			// We split in order to avoid circular dependencies on the runtime
 			instance.startup();
 		}

--- a/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
@@ -157,7 +157,7 @@ public abstract class BaseApplicationListener {
 	protected BaseApplicationListener( RequestBoxContext context ) {
 		this.context = context;
 		context.setApplicationListener( this );
-		this.interceptorPool = new InterceptorPool( Key.appListener )
+		this.interceptorPool = new InterceptorPool( Key.appListener, BoxRuntime.getInstance() )
 		    .registerInterceptionPoint( REQUEST_INTERCEPTION_POINTS );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/MemberDescriptor.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/MemberDescriptor.java
@@ -83,6 +83,7 @@ public class MemberDescriptor {
 	 * @return The result of the invocation
 	 */
 	public Object invoke( IBoxContext context, Object object ) {
+		// TODO: add arg to skip validation for incoming object which has already been vetted
 		return BIFDescriptor.invoke( context, new Object[] { object }, true, name );
 	}
 
@@ -123,6 +124,7 @@ public class MemberDescriptor {
 			// System.out.println( args[ i ] );
 			// }
 
+			// TODO: add arg to skip validation for incoming object which has already been vetted
 			return BIFDescriptor.invoke( context, args, true, name );
 		}
 	}
@@ -147,6 +149,7 @@ public class MemberDescriptor {
 			}
 			namedArguments.put( args[ 0 ].name(), object );
 		}
+		// TODO: add arg to skip validation for incoming object which has already been vetted
 		return BIFDescriptor.invoke( context, namedArguments, true, name );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/async/ThreadNew.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/async/ThreadNew.java
@@ -1,0 +1,116 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.async;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.RequestBoxContext;
+import ortus.boxlang.runtime.context.ThreadBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.Function;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.exceptions.AbortException;
+import ortus.boxlang.runtime.util.RequestThreadManager;
+import ortus.boxlang.runtime.validation.Validator;
+
+@BoxBIF
+public class ThreadNew extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public ThreadNew() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, Argument.FUNCTION, Key.runnable ),
+		    new Argument( false, Argument.STRUCT, Key.attributes, new Struct() ),
+		    new Argument( false, Argument.STRING, Key._NAME, "" ),
+		    new Argument( false, Argument.STRING, Key.priority, "normal", Set.of( Validator.valueOneOf( "high", "low", "normal" ) ) )
+		};
+	}
+
+	/**
+	 * Creates a new thread of execution based on the passed closure/lambda.
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @arguments.runnable The closure/lambda to execute in the new thread.
+	 *
+	 * @arguments.attributes A struct of data to bind into the thread's scope.
+	 *
+	 * @argument.threadName The name of the thread to track it, if not provided a default name will be generated.
+	 *
+	 * @argument.priority The priority of the thread. Possible values are "high", "low", and "normal". Default is "normal".
+	 *
+	 * @return The newly created thread object if you want to monitor it.
+	 */
+	@Override
+	public Thread _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		Function				task			= arguments.getAsFunction( Key.runnable );
+		String					name			= arguments.getAsString( Key._NAME );
+		String					priority		= arguments.getAsString( Key.priority );
+		IStruct					attributes		= arguments.getAsStruct( Key.attributes );
+		RequestThreadManager	threadManager	= context.getParentOfType( RequestBoxContext.class ).getThreadManager();
+		final Key				nameKey			= RequestThreadManager.ensureThreadName( name );
+		ThreadBoxContext		tContext		= threadManager.createThreadContext( context, nameKey );
+
+		// Startup the thread
+		return threadManager.startThread(
+		    // The thread context to run in
+		    tContext,
+		    // The name of the thread as a key
+		    nameKey,
+		    // The thread priority
+		    priority,
+		    // The Runnable Proxy
+		    () -> {
+			    StringBuffer buffer		= new StringBuffer();
+			    Throwable	exception	= null;
+			    Logger		logger		= LoggerFactory.getLogger( ThreadNew.class );
+			    try {
+				    // Execute the function using the thread context
+				    tContext.invokeFunction( task );
+			    } catch ( AbortException e ) {
+				    // We log it so we can potentially find out why it was aborted
+				    logger.debug( "Thread [{}] aborted at stacktrace: {}", nameKey.getName(), e.getStackTrace() );
+			    } catch ( Throwable e ) {
+				    exception = e;
+				    logger.error( "Thread [{}] terminated with exception: {}", nameKey.getName(), e.getMessage() );
+				    logger.error( "-> Exception", e );
+			    } finally {
+				    threadManager.completeThread(
+				        nameKey,
+				        buffer.toString(),
+				        exception,
+				        java.lang.Thread.interrupted()
+				    );
+			    }
+		    },
+		    // The Struct of data to bind into the thread's scope
+		    attributes
+		);
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/conversion/JSONSerialize.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/conversion/JSONSerialize.java
@@ -55,7 +55,8 @@ public class JSONSerialize extends BIF {
 		    new Argument( true, "any", Key.var ),
 		    // NOT A BOOLEAN! Can be true, false, row, column, or struct
 		    new Argument( false, "string", Key.queryFormat, "row" ),
-		    new Argument( false, "boolean", Key.useSecureJSONPrefix, false ),
+		    // Don't set this to a boolean, Lucee accepts a charset here which ColdBox passes
+		    new Argument( false, "string", Key.useSecureJSONPrefix, false ),
 		    new Argument( false, "boolean", Key.useCustomSerializer )
 		};
 	}
@@ -75,6 +76,8 @@ public class JSONSerialize extends BIF {
 	 * @argument.useCustomSerializer If true, the JSON string is serialized using a custom serializer. (Not used)
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		// TODO useSecureJSONPrefix - Don't assume this is a boolean, Lucee accepts a charset here which ColdBox passes
+
 		Object	obj			= arguments.get( Key.var );
 		String	queryFormat	= arguments.getAsString( Key.queryFormat ).toLowerCase();
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/conversion/JSONSerialize.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/conversion/JSONSerialize.java
@@ -37,13 +37,14 @@ import ortus.boxlang.runtime.types.util.JSONUtil;
 import ortus.boxlang.runtime.types.util.ListUtil;
 
 @BoxBIF
+@BoxMember( type = BoxLangType.CUSTOM, customType = java.lang.Boolean.class, name = "toJSON" )
+@BoxMember( type = BoxLangType.CUSTOM2, customType = java.lang.Number.class, name = "toJSON" )
 @BoxMember( type = BoxLangType.ARRAY, name = "toJSON" )
 @BoxMember( type = BoxLangType.CLASS, name = "toJSON" )
-@BoxMember( type = BoxLangType.LIST, name = "toJSON" )
 @BoxMember( type = BoxLangType.QUERY, name = "toJSON" )
-@BoxMember( type = BoxLangType.STRING, name = "toJSON" )
 @BoxMember( type = BoxLangType.STRUCT, name = "toJSON" )
 @BoxMember( type = BoxLangType.STRING, name = "listToJSON" )
+@BoxMember( type = BoxLangType.STRING, name = "toJSON" )
 public class JSONSerialize extends BIF {
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXArray.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXArray.java
@@ -1,0 +1,54 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import java.util.stream.Stream;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxMember;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.util.BLCollector;
+
+@BoxMember( type = BoxLangType.STREAM )
+public class ToBXArray extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public ToBXArray() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "stream", Key.stream )
+		};
+	}
+
+	/**
+	 * Collect a Java stream into a BoxLang Array
+	 * 
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 * 
+	 * @argument.stream The stream to collect.
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		Stream<?> stream = arguments.getAsStream( Key.stream );
+		return stream.collect( BLCollector.toArray() );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXList.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXList.java
@@ -1,0 +1,60 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import java.util.stream.Stream;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxMember;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.util.ListUtil;
+
+@BoxMember( type = BoxLangType.STREAM )
+public class ToBXList extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public ToBXList() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "stream", Key.stream ),
+		    new Argument( false, "string", Key.delimiter, "," )
+		};
+	}
+
+	/**
+	 * Collect a Java stream into a BoxLang delimited list. Each item in the stream will cast
+	 * to a string and then be joined with the delimiter.
+	 * 
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 * 
+	 * @argument.stream The stream to collect.
+	 * 
+	 * @argument.delimiter The delimiter to use.
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		Stream<?>	stream		= arguments.getAsStream( Key.stream );
+		String		delimiter	= arguments.getAsString( Key.delimiter );
+		return ListUtil.asString( Array.fromList( stream.toList() ), delimiter );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXQuery.java
@@ -1,0 +1,62 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import java.util.stream.Stream;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxMember;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Query;
+import ortus.boxlang.runtime.types.util.BLCollector;
+
+@BoxMember( type = BoxLangType.STREAM )
+public class ToBXQuery extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public ToBXQuery() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "stream", Key.stream ),
+		    new Argument( true, "query", Key.query )
+		};
+	}
+
+	/**
+	 * Collect a Java stream into a BoxLang Query. Provde an empty query to populate.
+	 * 
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 * 
+	 * @argument.stream The stream to collect.
+	 * 
+	 * @argument.query The query to populate.
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		@SuppressWarnings( "unchecked" )
+		// If this is not a stream of IStruct, then the cast will fail
+		Stream<IStruct>	stream	= ( Stream<IStruct> ) arguments.getAsStream( Key.stream );
+		Query			query	= arguments.getAsQuery( Key.query );
+		return stream.collect( BLCollector.toQuery( query ) );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/stream/ToBXStruct.java
@@ -1,0 +1,63 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxMember;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.util.BLCollector;
+
+@BoxMember( type = BoxLangType.STREAM )
+public class ToBXStruct extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public ToBXStruct() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "stream", Key.stream ),
+		    new Argument( false, "string", Key.type, "default" )
+		};
+	}
+
+	/**
+	 * Collect a Java stream into a BoxLang Struct. Must be a stream of Map.Entry instances.
+	 * 
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 * 
+	 * @argument.stream The stream to collect.
+	 * 
+	 * @argument.type The type of struct to create.
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		@SuppressWarnings( "unchecked" )
+		// If this is not a stream of Map.Entry, then the cast will fail
+		Stream<Map.Entry<Key, Object>>	stream	= ( Stream<Entry<Key, Object>> ) arguments.getAsStream( Key.stream );
+		IStruct.TYPES					type	= IStruct.TYPES.fromString( arguments.getAsString( Key.type ) );
+		return stream.collect( BLCollector.toStruct( type ) );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructNew.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructNew.java
@@ -41,19 +41,6 @@ import ortus.boxlang.runtime.util.LocalizationUtil;
 
 public class StructNew extends BIF {
 
-	private static final HashMap<Key, IStruct.TYPES> typeMap = new HashMap<>();
-
-	// Available types
-	static {
-		typeMap.put( Key.of( "casesensitive" ), IStruct.TYPES.CASE_SENSITIVE );
-		typeMap.put( Key.of( "default" ), IStruct.TYPES.DEFAULT );
-		typeMap.put( Key.of( "ordered-casesensitive" ), IStruct.TYPES.LINKED_CASE_SENSITIVE );
-		typeMap.put( Key.of( "ordered" ), IStruct.TYPES.LINKED );
-		typeMap.put( Key.of( "soft" ), IStruct.TYPES.SOFT );
-		typeMap.put( Key.of( "sorted" ), IStruct.TYPES.SORTED );
-		typeMap.put( Key.of( "weak" ), IStruct.TYPES.WEAK );
-	}
-
 	/**
 	 * Constructor
 	 */
@@ -92,17 +79,8 @@ public class StructNew extends BIF {
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 
-		// Validate Types
-		Key typeKey = Key.of( arguments.getAsString( Key.type ) );
-		if ( !typeMap.containsKey( typeKey ) ) {
-			throw new BoxRuntimeException(
-			    String.format(
-			        "Could not create a struct with a type of [%s] as it is not a known type.",
-			        arguments.getAsString( Key.type )
-			    )
-			);
-		}
-		CastAttempt<Function> typeCastToFunctionAttempt = FunctionCaster.attempt( arguments.get( Key.sortType ), "Comparator" );
+		IStruct.TYPES			type						= IStruct.TYPES.fromString( arguments.getAsString( Key.type ) );
+		CastAttempt<Function>	typeCastToFunctionAttempt	= FunctionCaster.attempt( arguments.get( Key.sortType ), "Comparator" );
 		if ( typeCastToFunctionAttempt.wasSuccessful() ) {
 			arguments.put( Key.callback, typeCastToFunctionAttempt.get() );
 			arguments.put( Key.sortType, null );
@@ -118,22 +96,21 @@ public class StructNew extends BIF {
 
 		// With Sorting
 		if ( sort != null ) {
-			Key initialType = Key.of( arguments.getAsString( Key.type ) );
-			typeKey = Key.of( "sorted" );
 			Key sortKey = Key.of( sort + arguments.getAsString( Key.sortOrder ) );
 
-			if ( sort.toLowerCase().contains( "nocase" ) && typeMap.get( initialType ).equals( IStruct.TYPES.LINKED_CASE_SENSITIVE ) ) {
+			if ( sort.toLowerCase().contains( "nocase" ) && type.equals( IStruct.TYPES.LINKED_CASE_SENSITIVE ) ) {
 				throw new BoxRuntimeException(
 				    String.format( "Invalid sort type [%s]. A case-sensitive struct can not be ordered without case consideration.", sort )
 				);
 			}
-			comparator = commonComparators.get( sortKey );
+			type		= IStruct.TYPES.SORTED;
+			comparator	= commonComparators.get( sortKey );
 		}
 		// With Comparator
 		else if ( arguments.getAsFunction( Key.callback ) != null ) {
 			// TODO: This doesn't quite match ACF's method signature.
 			// We will need to investigates other types of maps that can use a `K,V,KV` BiFunction as a comparator
-			typeKey		= Key.of( "sorted" );
+			type		= IStruct.TYPES.SORTED;
 			comparator	= ( a, b ) -> ( Integer ) context.invokeFunction(
 			    arguments.getAsFunction( Key.callback ),
 			    new Object[] { a.getName(), b.getName() }
@@ -141,7 +118,7 @@ public class StructNew extends BIF {
 		}
 
 		return comparator == null
-		    ? new Struct( typeMap.get( typeKey ) )
+		    ? new Struct( type )
 		    : new Struct( comparator );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/cache/providers/AbstractCacheProvider.java
+++ b/src/main/java/ortus/boxlang/runtime/cache/providers/AbstractCacheProvider.java
@@ -218,7 +218,7 @@ public abstract class AbstractCacheProvider implements ICacheProvider {
 		// Create the stats
 		this.stats				= new BoxCacheStats();
 		// Create local interceptor pool
-		this.interceptorPool	= new InterceptorPool( this.name ).registerInterceptionPoint( BoxEvent.toArray() );
+		this.interceptorPool	= new InterceptorPool( this.name, cacheService.getRuntime() ).registerInterceptionPoint( BoxEvent.toArray() );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -383,6 +383,10 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 		    .forEach( entry -> this.properties.putIfAbsent( entry.getKey(), entry.getValue() ) );
 
 		// Validation and normalization
+		// DBDriver Alias for CFConfig
+		if ( this.properties.containsKey( Key.dbdriver ) ) {
+			this.properties.computeIfAbsent( Key.driver, key -> this.properties.get( Key.dbdriver ) );
+		}
 
 		// Type Driver Alias
 		if ( this.properties.containsKey( Key.type ) ) {

--- a/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
@@ -611,6 +611,7 @@ public class FunctionBoxContext extends BaseBoxContext {
 	 * @param udf The UDF to register
 	 */
 	public void registerUDF( UDF udf, boolean override ) {
+		// If we're in a class, register it there
 		if ( isInClass() ) {
 			IClassRunnable boxClass = getThisClass();
 			if ( udf.hasModifier( BoxMethodDeclarationModifier.STATIC ) ) {
@@ -623,6 +624,7 @@ public class FunctionBoxContext extends BaseBoxContext {
 				boxClass.getVariablesScope().put( udf.getName(), udf );
 			}
 		} else {
+			// else, defer to parent context
 			getParent().registerUDF( udf, override );
 		}
 	}

--- a/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
@@ -44,7 +44,8 @@ import ortus.boxlang.runtime.util.ArgumentUtil;
 
 /**
  * This context represents the context of any function execution in BoxLang
- * It encapsulates the arguments scope and local scope and has a reference to the function being invoked.
+ * It encapsulates the arguments scope and local scope and has a reference to
+ * the function being invoked.
  * This context is extended for use with both UDFs and Closures as well
  */
 public class FunctionBoxContext extends BaseBoxContext {
@@ -80,12 +81,14 @@ public class FunctionBoxContext extends BaseBoxContext {
 	protected BoxInterface		enclosingBoxInterface	= null;
 
 	/**
-	 * The Function name being invoked with this context. Note this may or may not be the name the function was declared as.
+	 * The Function name being invoked with this context. Note this may or may not
+	 * be the name the function was declared as.
 	 */
 	protected Key				functionCalledName;
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context
 	 *
 	 * @param parent   The parent context
 	 * @param function The function being invoked with this context
@@ -95,7 +98,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context
 	 *
 	 * @param parent             The parent context
 	 * @param function           The function being invoked with this context
@@ -107,7 +111,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context and arguments scope
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context and arguments scope
 	 *
 	 * @param parent         The parent context
 	 * @param function       The function being invoked with this context
@@ -118,14 +123,16 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context and arguments scope
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context and arguments scope
 	 *
 	 * @param parent             The parent context
 	 * @param function           The function being invoked with this context
 	 * @param functionCalledName The name of the function being invoked
 	 * @param argumentsScope     The arguments scope
 	 */
-	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName, ArgumentsScope argumentsScope ) {
+	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName,
+	    ArgumentsScope argumentsScope ) {
 		super( parent );
 		if ( parent == null ) {
 			throw new BoxRuntimeException( "Parent context cannot be null for FunctionBoxContext" );
@@ -140,14 +147,16 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context and arguments scope
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context and arguments scope
 	 *
 	 * @param parent              The parent context
 	 * @param function            The function being invoked with this context
 	 * @param functionCalledName  The name of the function being invoked
 	 * @param positionalArguments The arguments
 	 */
-	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName, Object[] positionalArguments, IClassRunnable thisClass ) {
+	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName,
+	    Object[] positionalArguments, IClassRunnable thisClass ) {
 		super( parent );
 		if ( parent == null ) {
 			throw new BoxRuntimeException( "Parent context cannot be null for FunctionBoxContext" );
@@ -162,21 +171,24 @@ public class FunctionBoxContext extends BaseBoxContext {
 		setThisClass( thisClass );
 		pushTemplate( function );
 		try {
-			ArgumentUtil.createArgumentsScope( this, positionalArguments, function.getArguments(), this.argumentsScope, function.getName() );
+			ArgumentUtil.createArgumentsScope( this, positionalArguments, function.getArguments(), this.argumentsScope,
+			    function.getName() );
 		} finally {
 			popTemplate();
 		}
 	}
 
 	/**
-	 * Creates a new execution context with a bounded function instance and parent context and arguments scope
+	 * Creates a new execution context with a bounded function instance and parent
+	 * context and arguments scope
 	 *
 	 * @param parent             The parent context
 	 * @param function           The function being invoked with this context
 	 * @param functionCalledName The name of the function being invoked
 	 * @param namedArguments     The arguments
 	 */
-	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName, Map<Key, Object> namedArguments, IClassRunnable thisClass ) {
+	public FunctionBoxContext( IBoxContext parent, Function function, Key functionCalledName,
+	    Map<Key, Object> namedArguments, IClassRunnable thisClass ) {
 		super( parent );
 		if ( parent == null ) {
 			throw new BoxRuntimeException( "Parent context cannot be null for FunctionBoxContext" );
@@ -191,7 +203,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 		setThisClass( thisClass );
 		pushTemplate( function );
 		try {
-			ArgumentUtil.createArgumentsScope( this, namedArguments, function.getArguments(), this.argumentsScope, function.getName() );
+			ArgumentUtil.createArgumentsScope( this, namedArguments, function.getArguments(), this.argumentsScope,
+			    function.getName() );
 		} finally {
 			popTemplate();
 		}
@@ -207,7 +220,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 		}
 		if ( isInClass() ) {
 			// A function executing in a class can see the class variables
-			scopes.getAsStruct( Key.contextual ).put( VariablesScope.name, getThisClass().getBottomClass().getVariablesScope() );
+			scopes.getAsStruct( Key.contextual ).put( VariablesScope.name,
+			    getThisClass().getBottomClass().getVariablesScope() );
 			scopes.getAsStruct( Key.contextual ).put( StaticScope.name, getThisClass().getStaticScope() );
 		}
 		return scopes;
@@ -234,7 +248,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 
 		// Special check for $bx
 		if ( key.equals( BoxMeta.key ) && isInClass() ) {
-			return new ScopeSearchResult( getThisClass().getBottomClass(), getThisClass().getBottomClass().getBoxMeta(), BoxMeta.key, false );
+			return new ScopeSearchResult( getThisClass().getBottomClass(), getThisClass().getBottomClass().getBoxMeta(),
+			    BoxMeta.key, false );
 		}
 
 		// Look in the local scope first
@@ -320,7 +335,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 				return parent.scopeFindNearby( key, defaultScope, true );
 			}
 
-			// A UDF is "transparent" and can see everything in the parent scope as a "local" observer
+			// A UDF is "transparent" and can see everything in the parent scope as a
+			// "local" observer
 			return parent.scopeFindNearby( key, defaultScope );
 		}
 
@@ -379,7 +395,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 				return null;
 			}
 
-			// We don't have a check for "this" here because this.foo transpiles to a direct reference to the class itself
+			// We don't have a check for "this" here because this.foo transpiles to a direct
+			// reference to the class itself
 
 			// A component cannot see nearby scopes above it
 			return parent.getScope( name );
@@ -397,7 +414,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	/**
 	 * Finds the closest function call name
 	 *
-	 * @return The called name of the function if found, null if this code is not called from a function
+	 * @return The called name of the function if found, null if this code is not
+	 *         called from a function
 	 */
 	@Override
 	public Key findClosestFunctionName() {
@@ -412,9 +430,10 @@ public class FunctionBoxContext extends BaseBoxContext {
 	@Override
 	public IScope getDefaultAssignmentScope() {
 		// CF Source sets into variable scope. BoxLang defaults to local scope
-		return getFunction().getSourceType().equals( BoxSourceType.CFSCRIPT ) || getFunction().getSourceType().equals( BoxSourceType.CFTEMPLATE )
-		    ? getScopeNearby( VariablesScope.name )
-		    : localScope;
+		return getFunction().getSourceType().equals( BoxSourceType.CFSCRIPT )
+		    || getFunction().getSourceType().equals( BoxSourceType.CFTEMPLATE )
+		        ? getScopeNearby( VariablesScope.name )
+		        : localScope;
 	}
 
 	/**
@@ -424,7 +443,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	 */
 	@Override
 	public IBoxContext getFunctionParentContext() {
-		// If a function is executed inside another function, it uses the parent since there is nothing a function can "see" from inside it's calling function
+		// If a function is executed inside another function, it uses the parent since
+		// there is nothing a function can "see" from inside it's calling function
 		return getParent();
 	}
 
@@ -469,7 +489,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	/**
 	 * Set the enclosing static box class
 	 *
-	 * @param enclosingStaticBoxClass The static class in which this function is executing
+	 * @param enclosingStaticBoxClass The static class in which this function is
+	 *                                executing
 	 */
 	public FunctionBoxContext setThisStaticClass( DynamicObject enclosingStaticBoxClass ) {
 		this.enclosingStaticBoxClass = enclosingStaticBoxClass;
@@ -493,7 +514,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	/**
 	 * Set the enclosing static box class
 	 *
-	 * @param enclosingBoxInterface The static class in which this function is executing
+	 * @param enclosingBoxInterface The static class in which this function is
+	 *                              executing
 	 */
 	public FunctionBoxContext setThisInterface( BoxInterface enclosingBoxInterface ) {
 		this.enclosingBoxInterface = enclosingBoxInterface;
@@ -516,7 +538,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Invoke a function call such as foo() using positional args. Will check for a registered BIF first, then search known scopes for a UDF.
+	 * Invoke a function call such as foo() using positional args. Will check for a
+	 * registered BIF first, then search known scopes for a UDF.
 	 *
 	 * @return Return value of the function call
 	 */
@@ -525,7 +548,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * Invoke a function call such as foo() using named args. Will check for a registered BIF first, then search known scopes for a UDF.
+	 * Invoke a function call such as foo() using named args. Will check for a
+	 * registered BIF first, then search known scopes for a UDF.
 	 *
 	 * @return Return value of the function call
 	 */
@@ -580,7 +604,8 @@ public class FunctionBoxContext extends BaseBoxContext {
 	}
 
 	/**
-	 * If this function is executing inside of a BoxClass, register a UDF in the class's variables scope
+	 * If this function is executing inside of a BoxClass, register a UDF in the
+	 * class's variables scope
 	 * OTherise, defer to the parent context, which is probably a scripting context
 	 *
 	 * @param udf The UDF to register
@@ -597,13 +622,15 @@ public class FunctionBoxContext extends BaseBoxContext {
 			if ( override || !boxClass.getVariablesScope().containsKey( udf.getName() ) ) {
 				boxClass.getVariablesScope().put( udf.getName(), udf );
 			}
+		} else {
+			getParent().registerUDF( udf, override );
 		}
-		getParent().registerUDF( udf, override );
 	}
 
 	/**
 	 * Can the current context output to the response stream?
-	 * Contexts tied to a specific object like a function or class may override this to return false based on their own logic.
+	 * Contexts tied to a specific object like a function or class may override this
+	 * to return false based on their own logic.
 	 */
 	public Boolean canOutput() {
 		return getFunction().canOutput( this );

--- a/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
@@ -28,7 +28,9 @@ import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Function;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.exceptions.CustomException;
 import ortus.boxlang.runtime.types.exceptions.NoElementException;
 import ortus.boxlang.runtime.util.ValidationUtil;
 
@@ -595,6 +597,29 @@ public class Attempt<T> {
 	 */
 	public T orThrow() {
 		return orThrow( "Attempt is empty" );
+	}
+
+	/**
+	 * If a value is present, returns the value, otherwise throws a BoxLang exception with the
+	 * provided type and message
+	 *
+	 * @param type    The type of the exception to throw
+	 * @param message The message to display
+	 *
+	 * @return The value of the attempt if present or throws an exception
+	 */
+	public T orThrow( String type, String message ) {
+		if ( this.isEmpty() ) {
+			orThrow( new CustomException(
+			    message,
+			    "",
+			    "",
+			    type,
+			    new Struct(),
+			    null
+			) );
+		}
+		return this.value;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
@@ -448,6 +448,16 @@ public class Attempt<T> {
 
 	/**
 	 * If a value is present, performs the given action with the value, otherwise
+	 * does nothing. Alias to {@link #ifPresent}
+	 *
+	 * @param action The action to perform
+	 */
+	public Attempt<T> ifSuccesful( Consumer<? super T> action ) {
+		return ifPresent( action );
+	}
+
+	/**
+	 * If a value is present, performs the given action with the value, otherwise
 	 * performs the given empty-based action.
 	 */
 	public Attempt<T> ifPresentOrElse( Consumer<? super T> action, Runnable emptyAction ) {

--- a/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/Attempt.java
@@ -41,9 +41,6 @@ import ortus.boxlang.runtime.util.ValidationUtil;
  * <p>
  * Attemps are also immutable, so you can chain methods to handle the value in a
  * more functional way, but it never mutates the original value.
- * <p>
- * You can also seed the value with a Function (closure or lambda) that will be
- * executed when the value is requested. This gives you a delayed attempt.
  */
 public class Attempt<T> {
 
@@ -57,8 +54,7 @@ public class Attempt<T> {
 
 	/**
 	 * The target value to evaluate
-	 * This can be a truthy or falsey value or a Function instance to execute, or a
-	 * IClassRunnable instance
+	 * This can be a truthy or falsey value
 	 */
 	private final T					value;
 
@@ -378,7 +374,6 @@ public class Attempt<T> {
 
 	/**
 	 * Verifies if the attempt is empty or not using the following rules:
-	 * - If the value is a function, execute it and set the value to the result
 	 * - If the value is null, it is empty
 	 * - If the value is a truthy/falsey value, evaluate it
 	 */
@@ -696,7 +691,7 @@ public class Attempt<T> {
 
 	/**
 	 * If a value is present, and the value matches the given predicate, returns an
-	 * Optional describing the value, otherwise returns an empty Optional.
+	 * Attempt describing the value, otherwise returns an empty Attempt.
 	 *
 	 * @param predicate The predicate to test the value
 	 *

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
@@ -20,6 +20,10 @@ package ortus.boxlang.runtime.dynamic.casters;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.operators.InstanceOf;
@@ -224,6 +228,28 @@ public class GenericCaster implements IBoxCaster {
 			}
 			if ( fail ) {
 				throw new BoxCastException( String.format( "Cannot cast %s, to a Query.", object.getClass().getName() ) );
+			} else {
+				return null;
+			}
+		}
+
+		if ( type.equals( "stream" ) ) {
+			// No real "casting" to do, just return it if it is one
+			if ( object instanceof Stream ) {
+				return object;
+			}
+			if ( object instanceof IntStream is ) {
+				return is.boxed();
+			}
+			if ( object instanceof DoubleStream ds ) {
+				return ds.boxed();
+			}
+			if ( object instanceof LongStream ls ) {
+				return ls.boxed();
+			}
+
+			if ( fail ) {
+				throw new BoxCastException( String.format( "Cannot cast %s, to a Stream.", object.getClass().getName() ) );
 			} else {
 				return null;
 			}

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
@@ -96,11 +96,12 @@ public class InterceptorPool {
 	/**
 	 * Construct a pool with a unique name
 	 *
-	 * @param name The name of the pool
+	 * @param name    The name of the pool
+	 * @param runtime The runtime singleton
 	 */
-	public InterceptorPool( Key name ) {
+	public InterceptorPool( Key name, BoxRuntime runtime ) {
 		this.name		= name;
-		this.runtime	= BoxRuntime.getInstance();
+		this.runtime	= runtime;
 	}
 
 	/**
@@ -108,8 +109,8 @@ public class InterceptorPool {
 	 *
 	 * @param name The name of the pool
 	 */
-	public InterceptorPool( String name ) {
-		this( Key.of( name ) );
+	public InterceptorPool( String name, BoxRuntime runtime ) {
+		this( Key.of( name ), runtime );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
@@ -76,6 +76,7 @@ import ortus.boxlang.runtime.types.exceptions.NoMethodException;
 import ortus.boxlang.runtime.types.meta.BoxMeta;
 import ortus.boxlang.runtime.types.meta.GenericMeta;
 import ortus.boxlang.runtime.types.util.ListUtil;
+import ortus.boxlang.runtime.types.util.ObjectRef;
 
 /**
  * This class is used to provide a way to dynamically and efficiently interact with the java layer from the within a BoxLang environment.
@@ -1735,8 +1736,10 @@ public class DynamicInteropService {
 		}
 
 		if ( targetInstance != null ) {
-			MemberDescriptor memberDescriptor = BoxRuntime.getInstance().getFunctionService().getMemberMethod( context, name, targetInstance );
+			ObjectRef			ref					= ObjectRef.of( targetInstance );
+			MemberDescriptor	memberDescriptor	= BoxRuntime.getInstance().getFunctionService().getMemberMethod( context, name, ref );
 			if ( memberDescriptor != null ) {
+				targetInstance = ref.get();
 				return memberDescriptor.invoke( context, targetInstance, positionalArguments );
 			}
 		}
@@ -1783,8 +1786,10 @@ public class DynamicInteropService {
 		}
 
 		if ( targetInstance != null ) {
-			MemberDescriptor memberDescriptor = BoxRuntime.getInstance().getFunctionService().getMemberMethod( context, name, targetInstance );
+			ObjectRef			ref					= ObjectRef.of( targetInstance );
+			MemberDescriptor	memberDescriptor	= BoxRuntime.getInstance().getFunctionService().getMemberMethod( context, name, ref );
 			if ( memberDescriptor != null ) {
+				targetInstance = ref.get();
 				return memberDescriptor.invoke( context, targetInstance, namedArguments );
 			}
 		}

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -74,7 +74,8 @@ public class ChildTransaction implements ITransaction {
 	 * Will log a warning if called; otherwise no action taken.
 	 */
 	public ChildTransaction setIsolationLevel( int isolationLevel ) {
-		logger.warn( "Cannot set isolation level on a nested transaction. No action required; this nested transaction will use the isolation level defined by the parent" );
+		logger.warn(
+		    "Cannot set isolation level on a nested transaction. No action required; this nested transaction will use the isolation level defined by the parent" );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/loader/ClassLocator.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/ClassLocator.java
@@ -436,7 +436,7 @@ public class ClassLocator extends ClassLoader {
 
 		if ( throwException ) {
 			throw new ClassNotFoundBoxLangException(
-			    String.format( "The requested class [%s] has not been located in an the [%s] resolver.", name, resolverPrefix )
+			    String.format( "The requested class [%s] has not been located in the [%s] resolver.", name, resolverPrefix )
 			);
 		}
 

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -514,6 +514,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		queryParams						= Key.of( "queryParams" );
 	public static final Key		queryTimeout					= Key.of( "queryTimeout" );
 	public static final Key		radix							= Key.of( "radix" );
+	public static final Key		runnable						= Key.of( "runnable" );
 	public static final Key		Raw_Trace						= Key.of( "Raw_Trace" );
 	public static final Key		read							= Key.of( "read" );
 	public static final Key		readBinary						= Key.of( "readBinary" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -710,7 +710,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		cacheTimeout					= Key.of( "cacheTimeout" );
 	public static final Key		dbname							= Key.of( "dbname" );
 	public static final Key		driver							= Key.of( "driver" );
-	public static final Key		dbdriver							= Key.of( "dbdriver" );
+	public static final Key		dbdriver						= Key.of( "dbdriver" );
 	public static final Key		host							= Key.of( "host" );
 	public static final Key		isolation						= Key.of( "isolation" );
 	public static final Key		nested							= Key.of( "nested" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -611,6 +611,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		statusCode						= Key.of( "statusCode" );
 	public static final Key		statusText						= Key.of( "statusText" );
 	public static final Key		storedproc						= Key.of( "storedproc" );
+	public static final Key		stream							= Key.of( "stream" );
 	public static final Key		strict							= Key.of( "strict" );
 	public static final Key		strictMapping					= Key.of( "strictMapping" );
 	public static final Key		string							= Key.of( "string" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -710,6 +710,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		cacheTimeout					= Key.of( "cacheTimeout" );
 	public static final Key		dbname							= Key.of( "dbname" );
 	public static final Key		driver							= Key.of( "driver" );
+	public static final Key		dbdriver							= Key.of( "dbdriver" );
 	public static final Key		host							= Key.of( "host" );
 	public static final Key		isolation						= Key.of( "isolation" );
 	public static final Key		nested							= Key.of( "nested" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -748,6 +748,8 @@ public class Key implements Comparable<Key>, Serializable {
 
 	// CFConfig-style datasource config keys
 	public static final Key		custom							= Key.of( "custom" );
+	public static final Key		custom2							= Key.of( "custom2" );
+	public static final Key		custom3							= Key.of( "custom3" );
 	public static final Key		dsn								= Key.of( "dsn" );
 
 	// HikariCP configuration Key names. Includes all "Essential" and "Frquently Used" configuration keys, but no "Infrequently used" keys (for now.)

--- a/src/main/java/ortus/boxlang/runtime/services/ComponentService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ComponentService.java
@@ -238,7 +238,7 @@ public class ComponentService extends BaseService {
 	 */
 	public void loadComponentRegistry() throws IOException {
 		ServiceLoader
-		    .load( Component.class, BoxRuntime.getInstance().getClass().getClassLoader() )
+		    .load( Component.class, runtime.getClass().getClassLoader() )
 		    .stream()
 		    .parallel()
 		    .map( ServiceLoader.Provider::type )

--- a/src/main/java/ortus/boxlang/runtime/services/ComponentService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ComponentService.java
@@ -238,7 +238,7 @@ public class ComponentService extends BaseService {
 	 */
 	public void loadComponentRegistry() throws IOException {
 		ServiceLoader
-		    .load( Component.class, runtime.getClass().getClassLoader() )
+		    .load( Component.class, BoxRuntime.class.getClassLoader() )
 		    .stream()
 		    .parallel()
 		    .map( ServiceLoader.Provider::type )

--- a/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
@@ -352,7 +352,7 @@ public class FunctionService extends BaseService {
 	 */
 	public void loadGlobalFunctions() throws IOException {
 		ServiceLoader
-		    .load( BIF.class, runtime.getClass().getClassLoader() )
+		    .load( BIF.class, BoxRuntime.class.getClassLoader() )
 		    .stream()
 		    .parallel()
 		    .map( ServiceLoader.Provider::type )

--- a/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
@@ -352,7 +352,7 @@ public class FunctionService extends BaseService {
 	 */
 	public void loadGlobalFunctions() throws IOException {
 		ServiceLoader
-		    .load( BIF.class, BoxRuntime.getInstance().getClass().getClassLoader() )
+		    .load( BIF.class, runtime.getClass().getClassLoader() )
 		    .stream()
 		    .parallel()
 		    .map( ServiceLoader.Provider::type )

--- a/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
@@ -18,6 +18,8 @@
 package ortus.boxlang.runtime.services;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
@@ -237,9 +239,13 @@ public class FunctionService extends BaseService {
 			// Breaks on first successful cast
 			for ( Map.Entry<BoxLangType, MemberDescriptor> entry : targetMethodMap.entrySet() ) {
 				MemberDescriptor descriptor = entry.getValue();
+				System.out.println( "descriptor.type: " + descriptor.type.toString() );
 
-				if ( descriptor.type == BoxLangType.CUSTOM && descriptor.customClass.isInstance( object.get() ) ) {
-					return descriptor;
+				// A workaround to let a member method can associate with up to 3 custom types
+				if ( descriptor.type == BoxLangType.CUSTOM || descriptor.type == BoxLangType.CUSTOM2 || descriptor.type == BoxLangType.CUSTOM3 ) {
+					if ( descriptor.customClass.isInstance( object.get() ) ) {
+						return descriptor;
+					}
 				}
 
 				CastAttempt<?> castAttempt = GenericCaster.attempt( context, object.get(), entry.getKey() );
@@ -325,7 +331,7 @@ public class FunctionService extends BaseService {
 		// Make sure the container for the member key exists
 		// Ex: memberMethods[ "foo" ] = { BoxLangType.ARRAY : MemberDescriptor, BoxLangType.STRING : MemberDescriptor }
 		synchronized ( this.memberMethods ) {
-			this.memberMethods.putIfAbsent( memberKey, new ConcurrentHashMap<>() );
+			this.memberMethods.putIfAbsent( memberKey, Collections.synchronizedMap( new LinkedHashMap<>() ) );
 		}
 
 		// Now add them up

--- a/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/FunctionService.java
@@ -239,7 +239,7 @@ public class FunctionService extends BaseService {
 			// Breaks on first successful cast
 			for ( Map.Entry<BoxLangType, MemberDescriptor> entry : targetMethodMap.entrySet() ) {
 				MemberDescriptor descriptor = entry.getValue();
-				System.out.println( "descriptor.type: " + descriptor.type.toString() );
+				// System.out.println( "descriptor.type: " + descriptor.type.toString() );
 
 				// A workaround to let a member method can associate with up to 3 custom types
 				if ( descriptor.type == BoxLangType.CUSTOM || descriptor.type == BoxLangType.CUSTOM2 || descriptor.type == BoxLangType.CUSTOM3 ) {

--- a/src/main/java/ortus/boxlang/runtime/services/InterceptorService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/InterceptorService.java
@@ -60,8 +60,7 @@ public class InterceptorService extends InterceptorPool implements IService {
 	 * @param runtime The runtime singleton
 	 */
 	public InterceptorService( BoxRuntime runtime ) {
-		super( Key.interceptorService );
-		this.runtime = runtime;
+		super( Key.interceptorService, runtime );
 		registerInterceptionPoint( BoxEvent.toArray() );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/types/BoxLangType.java
+++ b/src/main/java/ortus/boxlang/runtime/types/BoxLangType.java
@@ -41,7 +41,8 @@ public enum BoxLangType {
 	STRING( Key._STRING ),
 	STRUCT( Key._STRUCT ),
 	UDF( Key._UDF ),
-	XML( Key.XML );
+	XML( Key.XML ),
+	STREAM( Key.stream );
 
 	/**
 	 * This class is used to store the key of the enum.

--- a/src/main/java/ortus/boxlang/runtime/types/BoxLangType.java
+++ b/src/main/java/ortus/boxlang/runtime/types/BoxLangType.java
@@ -30,6 +30,9 @@ public enum BoxLangType {
 	CLASS( Key._CLASS ),
 	CLOSURE( Key.closure ),
 	CUSTOM( Key.custom ),
+    // A workaround to let a member method can associate with up to 3 custom types
+	CUSTOM2( Key.custom2 ),
+	CUSTOM3( Key.custom3 ),
 	DATE( Key._DATE ),
 	DATETIME( Key._DATETIME ),
 	FILE( Key._FILE ),

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import ortus.boxlang.runtime.dynamic.Attempt;
 import ortus.boxlang.runtime.dynamic.IReferenceable;
@@ -28,6 +29,7 @@ import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.runnables.BoxInterface;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 
@@ -35,13 +37,52 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 * The Available types of structs
 	 */
 	public enum TYPES {
+
 		CASE_SENSITIVE,
 		DEFAULT,
 		LINKED_CASE_SENSITIVE,
 		LINKED,
 		SOFT,
 		SORTED,
-		WEAK
+		WEAK;
+
+		/**
+		 * Get the type of struct from a string
+		 *
+		 * @param type The string type to get
+		 *
+		 * @return The type of struct
+		 */
+		public static TYPES fromString( String type ) {
+			String uType = type.toUpperCase();
+			switch ( uType ) {
+				case "CASESENSITIVE" :
+					return CASE_SENSITIVE;
+				case "DEFAULT" :
+					return DEFAULT;
+				case "ORDERED-CASESENSITIVE" :
+					return LINKED_CASE_SENSITIVE;
+				case "ORDERED" :
+					return LINKED;
+				case "SOFT" :
+					return SOFT;
+				case "SORTED" :
+					return SORTED;
+				case "WEAK" :
+					return WEAK;
+			}
+
+			try {
+				return TYPES.valueOf( type );
+			} catch ( IllegalArgumentException e ) {
+				throw new BoxRuntimeException(
+				    String.format(
+				        "Could not create a struct with a type of [%s] as it is not a known type.",
+				        type
+				    )
+				);
+			}
+		}
 	}
 
 	/**
@@ -349,6 +390,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 */
 	default BoxInterface getAsBoxInterface( Key key ) {
 		return ( BoxInterface ) DynamicObject.unWrap( get( key ) );
+	}
+
+	default Stream<?> getAsStream( Key key ) {
+		return ( Stream<?> ) DynamicObject.unWrap( get( key ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/exceptions/CustomException.java
+++ b/src/main/java/ortus/boxlang/runtime/types/exceptions/CustomException.java
@@ -79,20 +79,31 @@ public class CustomException extends BoxRuntimeException {
 	/**
 	 * Constructor
 	 *
-	 * @param message   The message
-	 * @param detail    The detail
-	 * @param errorCode The errorCode
-	 * @param cause     The cause
+	 * @param message      The message
+	 * @param detail       The detail
+	 * @param errorCode    The errorCode
+	 * @param type         The type
+	 * @param extendedInfo The extended info
+	 * @param cause        The cause
 	 */
 	public CustomException( String message, String detail, String errorCode, String type, Object extendedInfo, Throwable cause ) {
 		super( message, detail, type, extendedInfo, cause );
 		this.errorCode = errorCode;
 	}
 
+	/**
+	 * Get the error code
+	 *
+	 * @return The error code
+	 */
 	public String getErrorCode() {
 		return errorCode;
 	}
 
+	/**
+	 * Get the data as a struct
+	 */
+	@Override
 	public IStruct dataAsStruct() {
 		IStruct result = super.dataAsStruct();
 		result.put( ErrorCodeKey, errorCode );

--- a/src/main/java/ortus/boxlang/runtime/types/util/ObjectRef.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/ObjectRef.java
@@ -1,0 +1,68 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.types.util;
+
+/**
+ * I am a simple wrapper for a value which allows it to be passed by reference into a method, possibly modified in that method, and then the
+ * modified value accessed without needing to return it from the method.
+ * 
+ */
+public class ObjectRef {
+
+	/**
+	 * The value being wrapped
+	 */
+	private Object value;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param value The value to wrap
+	 */
+	public ObjectRef( Object value ) {
+		this.value = value;
+	}
+
+	/**
+	 * Factory method to create a new ObjectRef
+	 * 
+	 * @param value The value to wrap
+	 * 
+	 * @return A new ObjectRef wrapping the value
+	 */
+	public static ObjectRef of( Object value ) {
+		return new ObjectRef( value );
+	}
+
+	/**
+	 * Get the value
+	 */
+	public Object get() {
+		return value;
+	}
+
+	/**
+	 * Set the value
+	 * 
+	 * @param value The new value
+	 */
+	public void set( Object value ) {
+		this.value = value;
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -431,7 +431,7 @@ public final class LocalizationUtil {
 		String			parseable		= StringCaster.cast( value );
 		ParsePosition	parsePosition	= new ParsePosition( 0 );
 		Number			parseResult		= parser.parse( StringCaster.cast( value ), parsePosition );
-		return parsePosition.getIndex() == parseable.length() ? parseResult.doubleValue() : null;
+		return parsePosition.getIndex() == parseable.length() && parseResult != null ? parseResult.doubleValue() : null;
 
 	}
 

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -69,7 +69,7 @@
 		}
 	},
 	// You can assign a global default datasource to be used in the language
-	"defaultDasource": "",
+	"defaultDatasource": "",
 	// The registered global datasources in the language
 	// The key is the name of the datasource and the value is a struct of the datasource settings
 	"datasources": {

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -2555,23 +2555,29 @@ public class CoreLangTest {
 
 		instance.executeSource(
 		    """
-		    	 import java:java.lang.String;
-		    	 javaStatic = java.lang.String::valueOf;
-		    	 result = javaStatic( "test" )
+		       	 import java:java.lang.String;
+		       	 javaStatic = java.lang.String::valueOf;
+		       	 result = javaStatic( "test" )
 
-		    	 javaInstance = result.toUpperCase
-		    	 result2 = javaInstance()
+		       	 javaInstance = result.toUpperCase
+		       	 result2 = javaInstance()
 
-		    	 import java.util.Collections;
-		    	 result3 = [ 1, 7, 3, 99, 0 ].sort( Collections.reverseOrder().compare  )
+		       	 import java.util.Collections;
+		       	 result3 = [ 1, 7, 3, 99, 0 ].sort( Collections.reverseOrder().compare  )
 
-		    	 import java:java.lang.Math;
-		    	 result4 = [ 1, 2.4, 3.9, 4.5 ].map( Math::floor )
+		       	 import java:java.lang.Math;
+		       	 result4 = [ 1, 2.4, 3.9, 4.5 ].map( Math::floor )
 
-		    // Use the compare method from the Java reverse order comparator to sort a BL array
-		    [ 1, 7, 3, 99, 0 ].sort( Collections.reverseOrder()  )
+		       // Use the compare method from the Java reverse order comparator to sort a BL array
+		       [ 1, 7, 3, 99, 0 ].sort( Collections.reverseOrder()  )
 
-		    	   """,
+		    import java.util.function.Predicate;
+		    isBrad = Predicate.isEqual( "brad" ) castas "function:Predicate"
+		    result5 = isBrad( "brad" )
+		    result6 = isBrad( "luis" )
+		    result7 = [ "brad", "luis", "jon" ].filter( isBrad )
+
+		       	   """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "test" );
 
@@ -2582,6 +2588,10 @@ public class CoreLangTest {
 
 		Array result4 = variables.getAsArray( Key.of( "result4" ) );
 		assertThat( result4 ).isEqualTo( Array.of( 1.0, 2.0, 3.0, 4.0 ) );
+
+		assertThat( variables.get( Key.of( "result5" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "result6" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "result7" ) ) ).isEqualTo( Array.of( "brad" ) );
 	}
 
 	@Test

--- a/src/test/java/TestCases/phase1/ExpressionValidAccessTest.java
+++ b/src/test/java/TestCases/phase1/ExpressionValidAccessTest.java
@@ -1,0 +1,288 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package TestCases.phase1;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import ortus.boxlang.compiler.parser.Parser;
+import ortus.boxlang.compiler.parser.ParsingResult;
+import ortus.boxlang.runtime.BoxRuntime;
+
+public class ExpressionValidAccessTest {
+
+	static BoxRuntime	instance;
+	static Set<String>	allExpressions		= new TreeSet<>();
+	static Set<String>	validAccessLHS		= new HashSet<>();
+	static Set<String>	validDotAccess		= new TreeSet<>();
+	static Set<String>	validArrayAccess	= new TreeSet<>();
+	static Set<String>	invalidDotAccess	= new TreeSet<>();
+	static Set<String>	invalidArrayAccess	= new TreeSet<>();
+
+	Parser				parser;
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		parser = new Parser();
+	}
+
+	// Valid for dot access RHS (both of these are valid for LHS as well)
+	static Set<String>	validDotAccessRHS	= Set.of(
+	    "foo",
+	    "foo(bar, baz)",
+	    "true",
+	    "false",
+	    "null",
+	    "42.5",
+	    "foo++",
+	    "bar--",
+	    "foo ^ bar",
+	    "foo * bar",
+	    "foo + bar",
+	    "foo b<< bar",
+	    "foo b& bar",
+	    "foo b^ bar",
+	    "foo b| bar",
+	    "foo eqv bar",
+	    "foo < bar",
+	    "foo > bar",
+	    "foo == bar",
+	    "foo XOR bar",
+	    "foo & bar",
+	    "foo DOES NOT CONTAIN bar",
+	    "foo AND bar",
+	    "foo OR bar",
+	    "foo ?: bar",
+	    "foo InstanceOf bar",
+	    "foo CastAs bar",
+	    "foo ? bar : baz",
+	    "xc.y?.z",
+	    "foo[bar]",
+	    "42" );
+
+	// Standalone expressions. (not valid for LHS or RHS of access expression
+	// without paren wrapper)
+	static Set<String>	standaloneExpr		= Set.of(
+	    "function() {}",
+	    "() => {}",
+	    "() -> {}" );
+	static {
+
+		// Valid for any access LHS
+		validAccessLHS.addAll( Set.of(
+		    // This needs to work, but the old grammar doesn't support it
+		    // uncommment to test on new grammar
+		    // "foo::bar",
+		    "new foo.bar.Baz()",
+		    "\"bar\"",
+		    "[1,2,3]",
+		    "{foo:bar}",
+		    "42.5", // must be a decimal, or it won't work
+		    "true",
+		    "false",
+		    "null",
+		    "foo",
+		    "foo(bar, baz)",
+		    "xc.y?.z",
+		    "foo[bar]",
+		    "foo ^ bar",
+		    "foo * bar",
+		    "foo + bar",
+		    "foo b<< bar",
+		    "foo b& bar",
+		    "foo b^ bar",
+		    "foo b| bar",
+		    "foo eqv bar",
+		    "foo < bar",
+		    "foo > bar",
+		    "foo == bar",
+		    "foo XOR bar",
+		    "foo & bar",
+		    "foo DOES NOT CONTAIN bar",
+		    "foo AND bar",
+		    "foo OR bar",
+		    "foo ?: bar",
+		    "foo InstanceOf bar",
+		    "foo CastAs bar",
+		    "foo ? bar : baz",
+		    "( foo )", // This can be any expression, but we don't need to test them all.
+		    // if starting an access expression with one of these, you may have ambiguity
+		    // without parenthesis, but they are valid
+		    "!foo",
+		    "-foo",
+		    "+foo",
+		    "++foo",
+		    "--foo" ) );
+
+		allExpressions.addAll( validAccessLHS );
+		allExpressions.addAll( validDotAccessRHS );
+		allExpressions.addAll( standaloneExpr );
+
+		// create every possible combination of valid LHS and RHS for array access and
+		// place them in validArrayAccess
+		validAccessLHS.forEach( lhs -> allExpressions.forEach( rhs -> validArrayAccess.add( lhs + "[ " + rhs + " ]" ) ) );
+
+		// loop over StandaloneExpr and add all of them wrapped in ()
+		standaloneExpr.forEach( expr -> validAccessLHS.add( "( " + expr + " )" ) );
+
+		// create every possible combination of valid LHS and RHS for dot expressions
+		// and place them in validDotAccess
+		validAccessLHS.forEach( lhs -> validDotAccessRHS.forEach( rhs -> validDotAccess.add( lhs + "." + rhs ) ) );
+
+		// create all possible combinations of valid LHS with allExpressions NOT in
+		// validDotAccessRHS
+
+		validAccessLHS
+		    .stream()
+		    .filter( expr -> !expr.equals( "42" ) )
+		    .forEach(
+		        lhs -> allExpressions.stream()
+		            .filter( expr -> !validDotAccessRHS.contains( expr ) )
+		            // These are not valid the LHS of dot access, but they pass because stuff like ()=>{}.foo looks like the return value is a struct literal dereferencing the foo
+		            .filter( expr -> !Set.of( "function() {}", "() => {}", "() -> {}" ).contains( expr ) )
+		            .forEach( rhs -> invalidDotAccess.add( lhs + "." + rhs ) )
+		    );
+
+		// now add to that all allExpressions NOT in validAccessLHS pared with all validDotAccessRHS.
+		allExpressions.stream().filter( expr -> !validAccessLHS.contains( expr ) )
+		    // These are not valid the LHS of dot access, but they pass because stuff like ()=>{}.foo looks like the return value is a struct literal dereferencing the foo
+		    .filter( expr -> !Set.of( "function() {}", "() => {}", "() -> {}" ).contains( expr ) )
+		    .filter( expr -> !expr.startsWith( "42" ) )
+		    .forEach( lhs -> validDotAccessRHS.stream().filter( expr -> !expr.startsWith( "42" ) ).forEach( rhs -> invalidDotAccess.add( lhs + "." + rhs ) ) );
+
+		// now add all the invalid left and invalid right hand sides from above
+		invalidDotAccess.addAll(
+		    allExpressions.stream()
+		        .filter( expr -> !validAccessLHS.contains( expr ) )
+		        .flatMap( lhs -> allExpressions.stream().filter( expr -> !validDotAccessRHS.contains( expr ) ).map( rhs -> lhs + "." + rhs ) )
+		        .filter( expr -> !Set.of( "42.( foo )", "42.+foo", "42.-foo" ).contains( expr ) )
+		        .collect( Collectors.toSet() )
+		);
+
+		// now add to that all allExpressions NOT in validAccessLHS paired with all validDotAccessRHS.
+		allExpressions.stream().filter( expr -> !validAccessLHS.contains( expr ) )
+		    // These are not valid the LHS of dot access, but they pass because stuff like ()=>{}.foo looks like the return value is a struct literal dereferencing the foo
+		    .filter( expr -> !Set.of( "function() {}", "() => {}", "() -> {}" ).contains( expr ) )
+		    // 42[ property ] is actually fine
+		    .filter( expr -> !expr.startsWith( "42" ) )
+		    .forEach( lhs -> invalidArrayAccess.add( lhs + "[ expr ]" ) );
+
+	}
+
+	static Stream<String> expressionProvider() {
+		return allExpressions.stream()
+		    .map( ExpressionValidAccessTest::replaceParentheses );
+	}
+
+	static Stream<String> validDotAccessProvider() {
+		return validDotAccess.stream()
+		    .map( ExpressionValidAccessTest::replaceParentheses );
+	}
+
+	static Stream<String> validArrayAccessProvider() {
+		return validArrayAccess.stream()
+		    .map( ExpressionValidAccessTest::replaceParentheses );
+	}
+
+	static Stream<String> invalidDotAccessProvider() {
+		return invalidDotAccess.stream()
+		    .map( ExpressionValidAccessTest::replaceParentheses );
+	}
+
+	static Stream<String> invalidArrayAccessProvider() {
+		return invalidArrayAccess.stream()
+		    .map( ExpressionValidAccessTest::replaceParentheses );
+	}
+
+	@ParameterizedTest( name = "Valid Expression {index} -- {0}" )
+	@MethodSource( "expressionProvider" )
+	public void testParseExpression( String expression ) {
+		expression = unreplaceParentheses( expression );
+		System.out.println( "Valid Expression: " + expression );
+		ParsingResult result = parser.parseExpression( expression );
+		if ( !result.isCorrect() ) {
+			throw new AssertionError( "Expression >> " + expression + " >> " + result.getIssues() );
+		}
+	}
+
+	@ParameterizedTest( name = "Valid Dot Access {index} -- {0}" )
+	@MethodSource( "validDotAccessProvider" )
+	public void testParseValidDotAccess( String expression ) {
+		expression = unreplaceParentheses( expression );
+		System.out.println( "Valid Dot Access: " + expression );
+		ParsingResult result = parser.parseExpression( expression );
+		if ( !result.isCorrect() ) {
+			throw new AssertionError( "Valid Dot Access -- " + expression + " -- " + result.getIssues() );
+		}
+	}
+
+	@ParameterizedTest( name = "Valid Array Access {index} -- {0}" )
+	@MethodSource( "validArrayAccessProvider" )
+	public void testParseValidArrayAccess( String expression ) {
+		expression = unreplaceParentheses( expression );
+		System.out.println( "Valid Array Access: " + expression );
+		ParsingResult result = parser.parseExpression( expression );
+		if ( !result.isCorrect() ) {
+			throw new AssertionError( "Valid Array Access -- " + expression + " -- " + result.getIssues() );
+		}
+	}
+
+	@ParameterizedTest( name = "Invalid Dot Access {index} -- {0}" )
+	@MethodSource( "invalidDotAccessProvider" )
+	public void testParseInvalidDotAccess( String expression ) {
+		expression = unreplaceParentheses( expression );
+		System.out.println( "Invalid Dot Access: " + expression );
+		ParsingResult result = parser.parseExpression( expression );
+		if ( result.isCorrect() ) {
+			throw new AssertionError( "Invalid Dot Access -- " + expression + " -- PASSED" );
+		}
+	}
+
+	@ParameterizedTest( name = "Invalid Array Access {index} -- {0}" )
+	@MethodSource( "invalidArrayAccessProvider" )
+	public void testParseInvalidArrayAccess( String expression ) {
+		expression = unreplaceParentheses( expression );
+		System.out.println( "Invalid Array Access: " + expression );
+		ParsingResult result = parser.parseExpression( expression );
+		if ( result.isCorrect() ) {
+			throw new AssertionError( "Invalid Array Access -- " + expression + " -- PASSED" );
+		}
+	}
+
+	private static String replaceParentheses( String expression ) {
+		return expression.replace( "(", "[[" ).replace( ")", "]]" );
+	}
+
+	private static String unreplaceParentheses( String expression ) {
+		return expression.replace( "[[", "(" ).replace( "]]", ")" );
+	}
+
+}

--- a/src/test/java/TestCases/phase3/FunctionMeta.cfc
+++ b/src/test/java/TestCases/phase3/FunctionMeta.cfc
@@ -10,7 +10,7 @@ component {
 	 * @brad wood
 	 * @param1.luis majano
 	 */
-	function foo( param1 ) {}
+	function foo( param1 ) {
 
 	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/async/ThreadNewTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/async/ThreadNewTest.java
@@ -1,0 +1,66 @@
+package ortus.boxlang.runtime.bifs.global.async;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+
+public class ThreadNewTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can start a thread using the threadNew() bif" )
+	@Test
+	public void testCanStartThread() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+				result = null;
+				threadNew( () => {
+					printLn( "thread is done!" );
+					sleep( 1000 );
+					result = "done";
+				} );
+				printLn( "thread tag done" );
+				sleep( 2000 );
+				printLn( "test is done done" );
+		    """,
+		    context,
+		    BoxSourceType.CFSCRIPT
+		);
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isEqualTo( "done" );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/io/ExpandPathTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/io/ExpandPathTest.java
@@ -211,7 +211,6 @@ public class ExpandPathTest {
 	public void testMappingInterceptor() {
 		instance.getInterceptorService().register( data -> {
 			String path = data.getAsString( Key.path );
-			System.out.println( "onMissingMapping expanding: " + path );
 			if ( path.equals( "/brads/test/path/to/expand" ) ) {
 				data.put( Key.resolvedFilePath,
 				    ResolvedFilePath.of(

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXArrayTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXArrayTest.java
@@ -1,0 +1,145 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.Array;
+
+public class ToBXArrayTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can collect a stream into an array" )
+	@Test
+	public void testCanCollect() {
+		instance.executeSource(
+		    """
+		       foods = [ 'apples', 'bananas', 'pizza', 'tacos' ];
+		    result = foods.stream().toBXArray();
+		            """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Array );
+		assertThat( ( variables.getAsArray( result ) ).size() ).isEqualTo( 4 );
+		assertThat( ( variables.getAsArray( result ) ).get( 0 ) ).isEqualTo( "apples" );
+		assertThat( ( variables.getAsArray( result ) ).get( 1 ) ).isEqualTo( "bananas" );
+		assertThat( ( variables.getAsArray( result ) ).get( 2 ) ).isEqualTo( "pizza" );
+		assertThat( ( variables.getAsArray( result ) ).get( 3 ) ).isEqualTo( "tacos" );
+	}
+
+	@DisplayName( "It can collect a parallel stream into an array" )
+	@Test
+	public void testCanCollectParallel() {
+		instance.executeSource(
+		    """
+		       foods = [ 'apples', 'bananas', 'pizza', 'tacos' ];
+		    result = foods.stream().parallel().toBXArray();
+		            """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Array );
+		assertThat( ( variables.getAsArray( result ) ).size() ).isEqualTo( 4 );
+		assertThat( ( variables.getAsArray( result ) ).get( 0 ) ).isEqualTo( "apples" );
+		assertThat( ( variables.getAsArray( result ) ).get( 1 ) ).isEqualTo( "bananas" );
+		assertThat( ( variables.getAsArray( result ) ).get( 2 ) ).isEqualTo( "pizza" );
+		assertThat( ( variables.getAsArray( result ) ).get( 3 ) ).isEqualTo( "tacos" );
+	}
+
+	@DisplayName( "It can collect an int stream into an array" )
+	@Test
+	public void testCanCollectInt() {
+		instance.executeSource(
+		    """
+		      import java.util.stream.IntStream;
+		    result = IntStream.range(1, 6).toBXArray();
+		                """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Array );
+		assertThat( ( variables.getAsArray( result ) ).size() ).isEqualTo( 5 );
+		assertThat( ( variables.getAsArray( result ) ).get( 0 ) ).isEqualTo( 1 );
+		assertThat( ( variables.getAsArray( result ) ).get( 1 ) ).isEqualTo( 2 );
+		assertThat( ( variables.getAsArray( result ) ).get( 2 ) ).isEqualTo( 3 );
+		assertThat( ( variables.getAsArray( result ) ).get( 3 ) ).isEqualTo( 4 );
+		assertThat( ( variables.getAsArray( result ) ).get( 4 ) ).isEqualTo( 5 );
+	}
+
+	@DisplayName( "It can collect an long stream into an array" )
+	@Test
+	public void testCanCollectLong() {
+		instance.executeSource(
+		    """
+		      import java.util.stream.LongStream;
+		    result = LongStream.range(1, 6).toBXArray();
+		                """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Array );
+		assertThat( ( variables.getAsArray( result ) ).size() ).isEqualTo( 5 );
+		assertThat( ( variables.getAsArray( result ) ).get( 0 ) ).isEqualTo( 1 );
+		assertThat( ( variables.getAsArray( result ) ).get( 1 ) ).isEqualTo( 2 );
+		assertThat( ( variables.getAsArray( result ) ).get( 2 ) ).isEqualTo( 3 );
+		assertThat( ( variables.getAsArray( result ) ).get( 3 ) ).isEqualTo( 4 );
+		assertThat( ( variables.getAsArray( result ) ).get( 4 ) ).isEqualTo( 5 );
+	}
+
+	@DisplayName( "It can collect an double stream into an array" )
+	@Test
+	public void testCanCollectDouble() {
+		instance.executeSource(
+		    """
+		      import java.util.stream.DoubleStream;
+		    result = DoubleStream.of(100).toBXArray();
+		                """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Array );
+		assertThat( ( variables.getAsArray( result ) ).size() ).isEqualTo( 1 );
+		assertThat( ( variables.getAsArray( result ) ).get( 0 ) ).isEqualTo( 100 );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXListTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXListTest.java
@@ -1,0 +1,91 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+
+public class ToBXListTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can collect a stream into a list" )
+	@Test
+	public void testCanCollect() {
+		instance.executeSource(
+		    """
+		       foods = [ 'apples', 'bananas', 'pizza', true ];
+		    result = foods.stream().toBXList();
+		            """,
+		    context );
+		assertTrue( variables.get( result ) instanceof String );
+		assertThat( variables.get( result ) ).isEqualTo( "apples,bananas,pizza,true" );
+	}
+
+	@DisplayName( "It can collect a stream into a list using delimiter" )
+	@Test
+	public void testCanCollectDelimiter() {
+		instance.executeSource(
+		    """
+		          foods = [ 'apples', 'bananas', 'pizza', true ];
+		       result = foods.stream().toBXList( '|' );
+
+		    result2 = [ "www", "google", "com" ].stream().toBXList( "." )
+		               """,
+		    context );
+		assertTrue( variables.get( result ) instanceof String );
+		assertThat( variables.get( result ) ).isEqualTo( "apples|bananas|pizza|true" );
+		assertTrue( variables.get( Key.of( "result2" ) ) instanceof String );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "www.google.com" );
+
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXQueryTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXQueryTest.java
@@ -1,0 +1,86 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.Query;
+
+public class ToBXQueryTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can collect a stream into a query" )
+	@Test
+	public void testCanCollect() {
+		instance.executeSource(
+		    """
+		    qry = queryNew( "name,title", "varchar,varchar" );
+		    [
+		    	{ name: "Brad", title: "Developer" },
+		    	{ name: "Luis", title: "CEO" },
+		    	{ name: "Jorge", title: "PM" }
+		    ].stream().toBXQuery( qry );
+
+		    result = qry;
+		                 """,
+		    context );
+		assertTrue( variables.get( result ) instanceof Query );
+		assertThat( ( variables.getAsQuery( result ) ).size() ).isEqualTo( 3 );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 0 ).get( "name" ) ).isEqualTo( "Brad" );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 0 ).get( "title" ) ).isEqualTo( "Developer" );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 1 ).get( "name" ) ).isEqualTo( "Luis" );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 1 ).get( "title" ) ).isEqualTo( "CEO" );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 2 ).get( "name" ) ).isEqualTo( "Jorge" );
+		assertThat( ( variables.getAsQuery( result ) ).getRowAsStruct( 2 ).get( "title" ) ).isEqualTo( "PM" );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXStructTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/stream/ToBXStructTest.java
@@ -1,0 +1,90 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IStruct;
+
+public class ToBXStructTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can collect a stream into a struct" )
+	@Test
+	public void testCanCollect() {
+		instance.executeSource(
+		    """
+		       foods = [ 'apples' : 'healthy', 'bananas' : 'healthy', 'pizza' : 'junk', 'tacos' : 'junk' ];
+		    result = foods.entrySet().stream().filter( e -> e.getValue() == 'healthy' ).toBXStruct();
+		            """,
+		    context );
+		assertTrue( variables.get( result ) instanceof IStruct );
+		assertThat( ( variables.getAsStruct( result ) ).keySet().size() ).isEqualTo( 2 );
+		assertThat( ( variables.getAsStruct( result ) ).keySet() ).containsExactly( Key.of( "apples" ), Key.of( "bananas" ) );
+	}
+
+	@DisplayName( "It can collect a stream into a sorted struct" )
+	@Test
+	public void testCanCollectSorted() {
+		instance.executeSource(
+		    """
+		       foods = [ 'd' : '', 'c' : '', 'b' : '', 'a' : '' ];
+		    result = foods.entrySet().stream().toBXStruct( "sorted" );
+		            """,
+		    context );
+		assertTrue( variables.get( result ) instanceof IStruct );
+		assertThat( ( variables.getAsStruct( result ) ).keySet().size() ).isEqualTo( 4 );
+		assertThat( ( variables.getAsStruct( result ) ).keySet().toArray() )
+		    .isEqualTo( new Object[] { Key.of( "a" ), Key.of( "b" ), Key.of( "c" ), Key.of( "d" ) } );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
+++ b/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
@@ -45,6 +45,7 @@ public class BoxCacheProviderTest {
 	@BeforeAll
 	static void setup() {
 		Mockito.when( cacheService.getTaskScheduler() ).thenReturn( executorRecord );
+		Mockito.when( cacheService.getRuntime() ).thenReturn( Mockito.mock( ortus.boxlang.runtime.BoxRuntime.class ) );
 
 		boxCache = new BoxCacheProvider();
 		boxCache.configure( cacheService, config );

--- a/src/test/java/ortus/boxlang/runtime/components/system/ExitTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/ExitTest.java
@@ -238,15 +238,14 @@ public class ExitTest {
 
 		instance.executeSource(
 		    """
-		    	 request.loopCount=0;
+		    request.loopCount=0;
 		    result = "";
-		          request.exitMethod="loop"
-		          module template="src/test/java/ortus/boxlang/runtime/components/system/ExitTests/module.bxm" {
-		         result &= "body";
-		       }
-		       result &= "aftermodule";
-		          }
-		                        """,
+		    request.exitMethod="loop"
+		    module template="src/test/java/ortus/boxlang/runtime/components/system/ExitTests/module.bxm" {
+		    	result &= "body";
+		    }
+		    result &= "aftermodule";
+		                          """,
 		    context );
 		assertThat( variables.getAsString( result ) ).isEqualTo( "startbodybeforeendbodyendaftermodule" );
 	}

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -239,6 +239,20 @@ class DatasourceConfigTest {
 		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", hikariConfig.getJdbcUrl() );
 	}
 
+	@DisplayName( "It can use 'dbdriver' in place of 'driver', for CFConfig support" )
+	@Test
+	void testDBDriverKeyForCFConfigSyntax() {
+		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
+		    "dbdriver", "postgresql",
+		    "host", "127.0.0.1",
+		    "port", 5432,
+		    "database", "foo"
+		) );
+		HikariConfig		hikariConfig	= datasource.toHikariConfig();
+
+		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", hikariConfig.getJdbcUrl() );
+	}
+
 	@DisplayName( "It casts numeric values correctly upon instantation" )
 	@Test
 	void testNumericCasting() {

--- a/src/test/java/ortus/boxlang/runtime/events/InterceptorPoolTest.java
+++ b/src/test/java/ortus/boxlang/runtime/events/InterceptorPoolTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.MockInterceptor;
@@ -21,7 +22,7 @@ public class InterceptorPoolTest {
 
 	@BeforeEach
 	void setupBeforeEach() {
-		pool = new InterceptorPool( "bdd" );
+		pool = new InterceptorPool( "bdd", BoxRuntime.getInstance() );
 	}
 
 	@DisplayName( "Test it can get build a pool" )

--- a/src/test/java/ortus/boxlang/runtime/scripting/BoxScriptingEngineTest.java
+++ b/src/test/java/ortus/boxlang/runtime/scripting/BoxScriptingEngineTest.java
@@ -8,6 +8,7 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import javax.script.Bindings;
 import javax.script.CompiledScript;
@@ -127,6 +128,22 @@ public class BoxScriptingEngineTest {
 		assertThat( modifiedBindings.get( "newAge" ) ).isEqualTo( 2 );
 		assertThat( engine.getRequestBindings().get( "nameTest" ) ).isEqualTo( "World" );
 		assertThat( engine.getServerBindings().get( "nameTest" ) ).isEqualTo( "World" );
+	}
+
+	@DisplayName( "Eval a script with FI bindings" )
+	@Test
+	public void testEvalWithFIBindings() throws ScriptException {
+		Bindings bindings = engine.createBindings();
+		bindings.put( "isEven", ( Predicate<Integer> ) ( n ) -> n % 2 == 0 );
+
+		// @formatter:off
+		Object result = engine
+		    .eval( """
+		           request.result = [1,2,3,4,5,6,7,8,9,10].filter( isEven )
+				  
+		           """, bindings );
+		// @formatter:on
+		assertThat( result ).isEqualTo( Array.of( 2, 4, 6, 8, 10 ) );
 	}
 
 	@DisplayName( "Compile a script" )

--- a/src/test/java/ortus/boxlang/runtime/util/FQNTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/FQNTest.java
@@ -1,0 +1,38 @@
+package ortus.boxlang.runtime.util;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Paths;
+
+@Disabled( "Not a single test is passing - I'm probably doing it wrong!" )
+public class FQNTest {
+
+	@DisplayName( "Can convert an absolute path to a full package/class path" )
+	@Test
+	void testItCanParseAbsolutePathToString() {
+		FQN fqn = new FQN( Paths.get( "/src/test/java/ortus/boxlang/runtime/util/FQNTest.java" ) );
+		assertEquals( "src.test.java.ortus.boxlang.runtime.util.FQNTest", fqn.toString() );
+	}
+	@DisplayName( "Can convert an absolute path to just a package path" )
+	@Test
+	void testItCanParseAbsolutePathToPackage() {
+		FQN fqn = new FQN( Paths.get( "/src/test/java/ortus/boxlang/runtime/util/FQNTest.java" ) );
+		assertEquals( "src.test.java.ortus.boxlang.runtime.util", fqn.getPackageString() );
+	}
+
+	@DisplayName( "Can convert a file path with prefix to a relative package name" )
+	@Test
+	void testItCanParseRelativePrefixedPathToString() {
+		FQN fqn = new FQN( Paths.get( "src/test/java/" ), Paths.get( "ortus/boxlang/runtime/util/FQNTest.java" ) );
+		assertEquals( "src.test.java.ortus.boxlang.runtime.util.FQNTest", fqn.toString() );
+	}
+
+	@DisplayName( "Can convert a file path with prefix to a relative package name" )
+	@Test
+	void testItCanParseRelativePrefixedPathToPackagePath() {
+		FQN fqn = new FQN( Paths.get( "src/test/java/" ), Paths.get( "ortus/boxlang/runtime/util/FQNTest.java" ) );
+		assertEquals( "src.test.java.ortus.boxlang.runtime.util", fqn.getPackageString() );
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/util/FQNTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/FQNTest.java
@@ -1,4 +1,5 @@
 package ortus.boxlang.runtime.util;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ public class FQNTest {
 		FQN fqn = new FQN( Paths.get( "/src/test/java/ortus/boxlang/runtime/util/FQNTest.java" ) );
 		assertEquals( "src.test.java.ortus.boxlang.runtime.util.FQNTest", fqn.toString() );
 	}
+
 	@DisplayName( "Can convert an absolute path to just a package path" )
 	@Test
 	void testItCanParseAbsolutePathToPackage() {


### PR DESCRIPTION
BoxLang Betas are released weekly.  This is our fifth beta marker.  Here are the release notes.
Improvements
[BL-376](https://ortussolutions.atlassian.net/browse/BL-376) web support error template only shows details of exceptions if IN debug mode else secure by default
[BL-392](https://ortussolutions.atlassian.net/browse/BL-392) Consolidate the runtime into services without the need of getInstance()
New Features
[BL-374](https://ortussolutions.atlassian.net/browse/BL-374) threadNew() bif to complete the thread bifs that was always missing
[BL-388](https://ortussolutions.atlassian.net/browse/BL-388) Stream type and collector member methods
[BL-390](https://ortussolutions.atlassian.net/browse/BL-390) orThrow( type, message ) for attempts
[BL-391](https://ortussolutions.atlassian.net/browse/BL-391) ifSuccessful() alias to ifPresent() on attempts
Bugs
[BL-373](https://ortussolutions.atlassian.net/browse/BL-373) Parser detection for unparsed tokens only works if there are 2 or more tokens left
[BL-377](https://ortussolutions.atlassian.net/browse/BL-377) Declaring UDFs in function context doesn't always work
[BL-378](https://ortussolutions.atlassian.net/browse/BL-378) CFConfig datasources aren't importing due to lack of support for the 'dbdriver' key
[BL-379](https://ortussolutions.atlassian.net/browse/BL-379) Runtime can deadlock due to syncronized methods
[BL-380](https://ortussolutions.atlassian.net/browse/BL-380) NPE calling isNumeric()
[BL-381](https://ortussolutions.atlassian.net/browse/BL-381) JSONSerialize() errors when useSecureJSONPrefix not a boolean
[BL-385](https://ortussolutions.atlassian.net/browse/BL-385) Cannot call getWriter(), getOutputStream() already called
[BL-386](https://ortussolutions.atlassian.net/browse/BL-386) empty url vars coming through as null
Tasks
[BL-372](https://ortussolutions.atlassian.net/browse/BL-372) Create tests for al valid and invalid dot and array access expressions

[BL-376]: https://ortussolutions.atlassian.net/browse/BL-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-392]: https://ortussolutions.atlassian.net/browse/BL-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-374]: https://ortussolutions.atlassian.net/browse/BL-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-388]: https://ortussolutions.atlassian.net/browse/BL-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-390]: https://ortussolutions.atlassian.net/browse/BL-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-391]: https://ortussolutions.atlassian.net/browse/BL-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-373]: https://ortussolutions.atlassian.net/browse/BL-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-377]: https://ortussolutions.atlassian.net/browse/BL-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ