### PR TITLE
Bl 143 writedump label support

### DIFF
--- a/src/main/resources/dump/html/Array.bxm
+++ b/src/main/resources/dump/html/Array.bxm
@@ -10,11 +10,17 @@
 					onclick="this.toggleAttribute( 'open' );this.nextElementSibling.classList.toggle( 'd-none' )"
 					onkeyup="if( event.key === 'Enter' ){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle( 'd-none' );}"
 				>
-					<strong>Array: #var.len()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						Array: #var.len()# items
+					</strong>
 				</caption>
 			<bx:else>
 				<caption class="bx-dhAy">
-					<strong>Array: #var.len()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						Array: #var.len()# items
+					</strong>
 				</caption>
 			</bx:if>
 			<tbody

--- a/src/main/resources/dump/html/Boolean.bxm
+++ b/src/main/resources/dump/html/Boolean.bxm
@@ -1,7 +1,12 @@
 <!--- Boolean template --->
 <bx:output>
 	<div class="bx-dump" title="#encodeForHTML( posInCode )#">
-		<span class="bx-dwSv"><span class="bx-dhSv">Boolean:</span>
-		<span>#encodeForHTML( var )#</span>
+		<span class="bx-dwSv">
+			<span class="bx-dhSv">
+				<bx:if label.len() >#label# - </bx:if>
+				Boolean:
+			</span>
+			<span>#encodeForHTML( var )#</span>
+		</span>
 	</div>
 </bx:output>

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -17,7 +17,10 @@
 				onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 				onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 			>
-				<strong>Box Class: #encodeForHTML( md.name )#</strong><br/>
+				<strong>
+					<bx:if label.len() >#label# - </bx:if>
+					Box Class: #encodeForHTML( md.name )#
+				</strong><br/>
 				<bx:if find( ".", hint ) >
 					#left( encodeForHTML( hint ), find( ".", hint ) - 1 )#
 				<bx:else>

--- a/src/main/resources/dump/html/Class.bxm
+++ b/src/main/resources/dump/html/Class.bxm
@@ -9,7 +9,10 @@
 				onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 				onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 			>
-				<strong>#encodeForHTML( var.getClass().getSimpleName() )#</strong>
+				<strong>
+					<bx:if label.len() >#label# - </bx:if>
+					#encodeForHTML( var.getClass().getSimpleName() )#
+				</strong>
 			</caption>
 			<tbody
 				<bx:if !expand>class="d-none"</bx:if>

--- a/src/main/resources/dump/html/DateTime.bxm
+++ b/src/main/resources/dump/html/DateTime.bxm
@@ -2,7 +2,10 @@
 <bx:output>
 <div class="bx-dump" title="#encodeForHTML( posInCode )#">
 	<span class="bx-dwSv">
-		<span class="bx-dhSv">Datetime:</span>
+		<span class="bx-dhSv">
+			<bx:if label.len() >#label# - </bx:if>
+			Datetime:
+		</span>
 		<span>#encodeForHTML( DateTimeFormat( var, "full" ) )#</span>
 	</span>
 </div>

--- a/src/main/resources/dump/html/Dump.css
+++ b/src/main/resources/dump/html/Dump.css
@@ -178,6 +178,7 @@
 	width: 1.2rem;
 	position: absolute;
 	left: .25rem;
+	top: calc(50% - 0.51rem);
 	transform: rotate(-90deg);
 	background-image: var(--bx-icon-chevron);
 	background-position: right center;

--- a/src/main/resources/dump/html/List.bxm
+++ b/src/main/resources/dump/html/List.bxm
@@ -10,11 +10,17 @@
 					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 				>
-					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						#var.getClass().getSimpleName()#: #var.size()# items
+					</strong>
 				</caption>
 			<bx:else>
 				<caption>
-					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						#var.getClass().getSimpleName()#: #var.size()# items
+					</strong>
 				</caption>
 			</bx:if>
 			<tbody

--- a/src/main/resources/dump/html/Map.bxm
+++ b/src/main/resources/dump/html/Map.bxm
@@ -10,11 +10,17 @@
 					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 				>
-					<strong>#var.getClass().getSimpleName()#: #var.size()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						#var.getClass().getSimpleName()#: #var.size()# items
+					</strong>
 				</caption>
 			<bx:else>
 				<caption>
-					<strong>#var.getClass().getSimpleName()#: #var.len()# items</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						#var.getClass().getSimpleName()#: #var.len()# items
+					</strong>
 				</caption>
 			</bx:if>
 			<tbody

--- a/src/main/resources/dump/html/Null.bxm
+++ b/src/main/resources/dump/html/Null.bxm
@@ -2,7 +2,10 @@
 <bx:output>
 	<div class="bx-dump" title="#encodeForHTML( posInCode )#">
 		<span class="bx-dwSv">
-			<span class="bx-dhSv">NULL:</span>
+			<span class="bx-dhSv">
+				<bx:if label.len() >#label# - </bx:if>
+				NULL:
+			</span>
 			<span>&lt;null&gt;</span>
 		</span>
 	</div>

--- a/src/main/resources/dump/html/Number.bxm
+++ b/src/main/resources/dump/html/Number.bxm
@@ -2,7 +2,10 @@
 <bx:output>
 <div class="bx-dump" title="#encodeForHTML( posInCode )#">
 	<span class="bx-dwSv">
-		<span class="bx-dhSv">Number:</span>
+		<span class="bx-dhSv">
+			<bx:if label.len() >#label# - </bx:if>
+			Number:
+		</span>
 		<span> #encodeForHTML( var )#</span>
 	</span>
 </div>

--- a/src/main/resources/dump/html/Query.bxm
+++ b/src/main/resources/dump/html/Query.bxm
@@ -9,7 +9,10 @@
 					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');this.nextElementSibling.nextElementSibling.classList.toggle('d-none')"
 					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');this.nextElementSibling.nextElementSibling.classList.toggle('d-none');}"
 				>
-					<strong>Query: #var.recordcount# rows</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						Query: #var.recordcount# rows
+					</strong>
 				</caption>
 				<thead 
 					<bx:if !expand>class="d-none"</bx:if>

--- a/src/main/resources/dump/html/String.bxm
+++ b/src/main/resources/dump/html/String.bxm
@@ -2,7 +2,10 @@
 <bx:output>
 	<div class="bx-dump" title="#encodeForHTML( posInCode )#">
 		<span class="bx-dwSv">
-			<span class="bx-dhSv">String:</span>
+			<span class="bx-dhSv">
+				<bx:if label.len() >#label# - </bx:if>
+				String:
+			</span>
 			<span>#encodeForHTML( var )#</span>
 		</span>
 	</div>

--- a/src/main/resources/dump/html/StringBuffer.bxm
+++ b/src/main/resources/dump/html/StringBuffer.bxm
@@ -2,7 +2,10 @@
 <bx:output>
 	<div class="bx-dump" title="#encodeForHTML( posInCode )#">
 		<span class="bx-dwSv">
-			<span class="bx-dhSv">String Buffer:</span>
+			<span class="bx-dhSv">
+				<bx:if label.len() >#label# - </bx:if>
+				String Buffer:
+			</span>
 			<span> #encodeForHTML( var.toString() )#</span>
 		</span>
 	</div>

--- a/src/main/resources/dump/html/Struct.bxm
+++ b/src/main/resources/dump/html/Struct.bxm
@@ -14,11 +14,17 @@
 						onclick="this.toggleAttribute( 'open' ); this.nextElementSibling.classList.toggle( 'd-none' )"
 						onkeyup="if( event.key === 'Enter' ){ this.toggleAttribute( 'open' ); this.nextElementSibling.classList.toggle( 'd-none' );}"
 					>
-						<strong>#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items</strong>
+						<strong>
+							<bx:if label.len() >#label# - </bx:if>
+							#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items
+						</strong>
 					</caption>
 				<bx:else>
 					<caption>
-						<strong>#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items</strong>
+						<strong>
+							<bx:if label.len() >#label# - </bx:if>
+							#encodeForHTML( var.getName().getName().toUpperCase() )# Scope: #var.len()# items
+						</strong>
 					</caption>
 				</bx:if>
 
@@ -32,11 +38,17 @@
 						onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 						onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 					>
-						<strong>Struct: #var.len()# items</strong>
+						<strong>
+							<bx:if label.len() >#label# - </bx:if>
+							Struct: #var.len()# items
+						</strong>
 					</caption>
 				<bx:else>
 					<caption>
-						<strong>Struct: #var.len()# items</strong>
+						<strong>
+							<bx:if label.len() >#label# - </bx:if>
+							Struct: #var.len()# items
+						</strong>
 					</caption>
 				</bx:if>
 			</bx:if>

--- a/src/main/resources/dump/html/Throwable.bxm
+++ b/src/main/resources/dump/html/Throwable.bxm
@@ -11,7 +11,10 @@
 					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 				>
-					<strong>Error: #encodeForHTML( var.getType() )#</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						Error: #encodeForHTML( var.getType() )#
+					</strong>
 				</caption>
 			<bx:else>
 				<caption
@@ -20,7 +23,10 @@
 					onclick="this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none')"
 					onkeyup="if(event.key === 'Enter'){ this.toggleAttribute('open');this.nextElementSibling.classList.toggle('d-none');}"
 				>
-					<strong>Error: #var.getClass().getName()#</strong>
+					<strong>
+						<bx:if label.len() >#label# - </bx:if>
+						Error: #var.getClass().getName()#
+					</strong>
 				</caption>
 			</bx:if>
 			<!--- Throwable BODY --->


### PR DESCRIPTION
# Description

Adds the dump label to the Dump, before the type.

<img width="194" alt="image" src="https://github.com/user-attachments/assets/b20d9f58-eb1c-4e12-8c1e-9040a552ee97">


## Jira Issues

[All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.](https://ortussolutions.atlassian.net/browse/BL-143)

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL/issues


## Type of change

Please delete options that are not relevant.

- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
