### PR TITLE
Upgrade the BoxCompiler and CFCompiler 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.ArrayList
 
 // https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_packaging
 plugins {
@@ -184,7 +186,6 @@ application {
     mainClass = "ortus.boxlang.runtime.BoxRunner"
 }
 
-import org.apache.tools.ant.filters.ReplaceTokens
 processResources {
 	// Replace @build.date@ with the current date in META-INF/version.properties file
 	filter( ReplaceTokens, tokens: [ 'build.date': new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( new Date() ) ] )
@@ -223,6 +224,12 @@ shadowJar {
 		exclude( dependency( "ch.qos.logback:.*:.*" ) )
 		exclude( dependency( "com.zaxxer:.*:.*" ) )
 		exclude( dependency( "com.fasterxml.jackson.jr:.*:.*" ) )
+	}
+}
+
+test {
+	testLogging {
+		events "FAILED", "STANDARD_ERROR"
 	}
 }
 
@@ -265,8 +272,6 @@ task createDistributionFile( type: Zip ){
  * Task moves the contents of the `libs` folder to the `distributions` folder
  and must run after build
  */
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 task libsToDistro( type: Copy ) {
 	dependsOn build, createDistributionFile
 
@@ -512,7 +517,7 @@ spotless {
     java {
 		target fileTree( "." ) {
             include "**/*.java"
-            exclude "**/build/**", "bin/**", "examples/**", "src/main/java/ortus/boxlang/runtime/testing/**"
+            exclude "**/build/**", "bin/**", "examples/**", "src/main/java/ortus/boxlang/runtime/testing/**", "src/main/gen/**", "src/main/antlr/gen"
         }
         eclipse().configFile( "workbench/ortus-java-style.xml" )
 		toggleOffOn()

--- a/src/main/antlr/BoxScriptLexer.g4
+++ b/src/main/antlr/BoxScriptLexer.g4
@@ -1,165 +1,179 @@
 lexer grammar BoxScriptLexer;
 
+// $antlr-format alignTrailingComments true
+// $antlr-format maxEmptyLinesToKeep 1
+// $antlr-format columnLimit 150
+// $antlr-format reflowComments false
+// $antlr-format useTab false
+// $antlr-format allowShortRulesOnASingleLine true
+// $antlr-format allowShortBlocksOnASingleLine true
+// $antlr-format allowShortBlocksOnASingleLine true
+// $antlr-format minEmptyLines 0
+// $antlr-format alignSemicolons ownLine
+// $antlr-format alignColons trailing
+// $antlr-format singleLineOverrulesHangingColon true
+// $antlr-format alignLexerCommands true
+// $antlr-format alignLabels true
+// $antlr-format alignTrailers true
 options {
-	caseInsensitive = true;
+    caseInsensitive = true;
 }
 
-ABSTRACT: 'ABSTRACT';
-ANY: 'ANY';
-ARRAY: 'ARRAY';
-AS: 'AS';
-ASSERT: 'ASSERT';
-BOOLEAN: 'BOOLEAN';
-BREAK: 'BREAK';
-CASE: 'CASE';
-CASTAS: 'CASTAS';
-CATCH: 'CATCH';
-CONTAIN: 'CONTAIN';
-CONTAINS: 'CONTAINS';
-CONTINUE: 'CONTINUE';
-DEFAULT: 'DEFAULT';
-DO: 'DO';
-DOES: 'DOES';
-ELIF: 'ELIF';
-ELSE: 'ELSE';
-EQV: 'EQV';
-FALSE: 'FALSE';
-FINAL: 'FINAL';
-FINALLY: 'FINALLY';
-FOR: 'FOR';
-FUNCTION: 'FUNCTION';
-GREATER: 'GREATER';
-IF: 'IF';
-IMP: 'IMP';
-IMPORT: 'IMPORT';
-IN: 'IN';
-INCLUDE: 'INCLUDE';
-INSTANCEOF: 'INSTANCEOF';
-INTERFACE: 'INTERFACE';
-IS: 'IS';
-JAVA: 'JAVA';
-LESS: 'LESS';
-MESSAGE: 'MESSAGE';
-MOD: 'MOD';
-NEW: 'NEW';
-NULL: 'NULL';
-NUMERIC: 'NUMERIC';
-PARAM: 'PARAM';
-PACKAGE: 'PACKAGE';
-PRIVATE: 'PRIVATE';
-PROPERTY: 'PROPERTY';
-PUBLIC: 'PUBLIC';
-QUERY: 'QUERY';
-REMOTE: 'REMOTE';
-REQUIRED: 'REQUIRED';
-RETHROW: 'RETHROW';
-RETURN: 'RETURN';
-REQUEST: 'REQUEST';
-SERVER: 'SERVER';
-SETTING: 'SETTING';
-STATIC: 'STATIC';
-STRING: 'STRING';
-STRUCT: 'STRUCT';
-SWITCH: 'SWITCH';
-THAN: 'THAN';
-THROW: 'THROW';
-TO: 'TO';
-TRUE: 'TRUE';
-TRY: 'TRY';
-TYPE: 'TYPE';
-VAR: 'VAR';
-VARIABLES: 'VARIABLES';
-WHEN: 'WHEN';
-WHILE: 'WHILE';
-XOR: 'XOR';
+ABSTRACT   : 'ABSTRACT';
+ANY        : 'ANY';
+ARRAY      : 'ARRAY';
+AS         : 'AS';
+ASSERT     : 'ASSERT';
+BOOLEAN    : 'BOOLEAN';
+BREAK      : 'BREAK';
+CASE       : 'CASE';
+CASTAS     : 'CASTAS';
+CATCH      : 'CATCH';
+CONTAIN    : 'CONTAIN';
+CONTAINS   : 'CONTAINS';
+CONTINUE   : 'CONTINUE';
+DEFAULT    : 'DEFAULT';
+DO         : 'DO';
+DOES       : 'DOES';
+ELIF       : 'ELIF';
+ELSE       : 'ELSE';
+EQV        : 'EQV';
+FALSE      : 'FALSE';
+FINAL      : 'FINAL';
+FINALLY    : 'FINALLY';
+FOR        : 'FOR';
+FUNCTION   : 'FUNCTION';
+GREATER    : 'GREATER';
+IF         : 'IF';
+IMP        : 'IMP';
+IMPORT     : 'IMPORT';
+IN         : 'IN';
+INCLUDE    : 'INCLUDE';
+INSTANCEOF : 'INSTANCEOF';
+INTERFACE  : 'INTERFACE';
+IS         : 'IS';
+JAVA       : 'JAVA';
+LESS       : 'LESS';
+MESSAGE    : 'MESSAGE';
+MOD        : 'MOD';
+NEW        : 'NEW';
+NULL       : 'NULL';
+NUMERIC    : 'NUMERIC';
+PARAM      : 'PARAM';
+PACKAGE    : 'PACKAGE';
+PRIVATE    : 'PRIVATE';
+PROPERTY   : 'PROPERTY';
+PUBLIC     : 'PUBLIC';
+QUERY      : 'QUERY';
+REMOTE     : 'REMOTE';
+REQUIRED   : 'REQUIRED';
+RETHROW    : 'RETHROW';
+RETURN     : 'RETURN';
+REQUEST    : 'REQUEST';
+SERVER     : 'SERVER';
+SETTING    : 'SETTING';
+STATIC     : 'STATIC';
+STRING     : 'STRING';
+STRUCT     : 'STRUCT';
+SWITCH     : 'SWITCH';
+THAN       : 'THAN';
+THROW      : 'THROW';
+TO         : 'TO';
+TRUE       : 'TRUE';
+TRY        : 'TRY';
+TYPE       : 'TYPE';
+VAR        : 'VAR';
+VARIABLES  : 'VARIABLES';
+WHEN       : 'WHEN';
+WHILE      : 'WHILE';
+XOR        : 'XOR';
 
-CLASS_NAME: 'CLASS';
+CLASS: 'CLASS';
 
-AND: 'AND';
-AMPAMP: '&&';
+AND    : 'AND';
+AMPAMP : '&&';
 
-EQ: 'EQ';
-EQUAL: 'EQUAL';
-EQEQ: '==';
+EQ    : 'EQ';
+EQUAL : 'EQUAL';
+EQEQ  : '==';
 
-GT: 'GT';
-GTSIGN: '>';
+GT     : 'GT';
+GTSIGN : '>';
 
-GTE: 'GTE';
-GE: 'GE';
-GTESIGN: '>=';
+GTE     : 'GTE';
+GE      : 'GE';
+GTESIGN : '>=';
 
-LT: 'LT';
-LTSIGN: '<';
+LT     : 'LT';
+LTSIGN : '<';
 
-LTE: 'LTE';
-LE: 'LE';
-LTESIGN: '<=';
+LTE     : 'LTE';
+LE      : 'LE';
+LTESIGN : '<=';
 
-NEQ: 'NEQ';
-BANGEQUAL: '!=';
-LESSTHANGREATERTHAN: '<>';
+NEQ                 : 'NEQ';
+BANGEQUAL           : '!=';
+LESSTHANGREATERTHAN : '<>';
 
-NOT: 'NOT';
-BANG: '!';
+NOT  : 'NOT';
+BANG : '!';
 
-OR: 'OR';
-PIPEPIPE: '||';
+OR       : 'OR';
+PIPEPIPE : '||';
 
-AMPERSAND: '&';
-ARROW: '->';
-AT: '@';
-BACKSLASH: '\\';
-COMMA: ',';
-COLON: ':';
-COLONCOLON: '::';
-DOT: '.';
-ELVIS: '?:';
-EQUALSIGN: '=';
-LBRACE: '{';
-RBRACE: '}';
-LPAREN: '(';
-RPAREN: ')';
-LBRACKET: '[';
-RBRACKET: ']';
-ARROW_RIGHT: '=>';
-MINUS: '-';
-MINUSMINUS: '--';
-PIPE: '|';
-PERCENT: '%';
-POWER: '^';
-QM: '?';
-SEMICOLON: ';';
-SLASH: '/';
-STAR: '*';
-CONCATEQUAL: '&=';
-PLUSEQUAL: '+=';
-MINUSEQUAL: '-=';
-STAREQUAL: '*=';
-SLASHEQUAL: '/=';
-MODEQUAL: '%=';
-PLUS: '+';
-PLUSPLUS: '++';
-TEQ: '===';
+AMPERSAND   : '&';
+ARROW       : '->';
+AT          : '@';
+BACKSLASH   : '\\';
+COMMA       : ',';
+COLON       : ':';
+COLONCOLON  : '::';
+DOT         : '.';
+ELVIS       : '?:';
+EQUALSIGN   : '=';
+LBRACE      : '{';
+RBRACE      : '}';
+LPAREN      : '(';
+RPAREN      : ')';
+LBRACKET    : '[';
+RBRACKET    : ']';
+ARROW_RIGHT : '=>';
+MINUS       : '-';
+MINUSMINUS  : '--';
+PIPE        : '|';
+PERCENT     : '%';
+POWER       : '^';
+QM          : '?';
+SEMICOLON   : ';';
+SLASH       : '/';
+STAR        : '*';
+CONCATEQUAL : '&=';
+PLUSEQUAL   : '+=';
+MINUSEQUAL  : '-=';
+STAREQUAL   : '*=';
+SLASHEQUAL  : '/=';
+MODEQUAL    : '%=';
+PLUS        : '+';
+PLUSPLUS    : '++';
+TEQ         : '===';
 
 // BITWISE OPERATORS
-BITWISE_OR: 'b|';
-BITWISE_AND: 'b&';
-BITWISE_XOR: 'b^';
-BITWISE_COMPLEMENT: 'b~';
-BITWISE_SIGNED_LEFT_SHIFT: 'b<<';
-BITWISE_SIGNED_RIGHT_SHIFT: 'b>>';
-BITWISE_UNSIGNED_RIGHT_SHIFT: 'b>>>';
+BITWISE_OR                   : 'b|';
+BITWISE_AND                  : 'b&';
+BITWISE_XOR                  : 'b^';
+BITWISE_COMPLEMENT           : 'b~';
+BITWISE_SIGNED_LEFT_SHIFT    : 'b<<';
+BITWISE_SIGNED_RIGHT_SHIFT   : 'b>>';
+BITWISE_UNSIGNED_RIGHT_SHIFT : 'b>>>';
 
 // ANY NEW LEXER RULES FOR AN ENGLISH WORD NEEDS ADDED TO THE identifer RULE IN THE PARSER
 
-ICHAR_1:
-	'#' {_modeStack.contains(hashMode)}? -> type(ICHAR), popMode, popMode;
-ICHAR: '#';
+ICHAR_1 : '#' {_modeStack.contains(hashMode)}? -> type(ICHAR), popMode, popMode;
+ICHAR   : '#';
 
-WS: (' ' | '\t' | '\f')+ -> channel(HIDDEN);
-NEWLINE: ('\n' | '\r')+ (' ' | '\t' | '\f' | '\n' | '\r')* -> channel(HIDDEN);
-JAVADOC_COMMENT: '/**' .*? '*/' -> channel(HIDDEN);
+WS              : (' ' | '\t' | '\f')+                              -> channel(HIDDEN);
+NEWLINE         : ('\n' | '\r')+ (' ' | '\t' | '\f' | '\n' | '\r')* -> channel(HIDDEN);
+JAVADOC_COMMENT : '/**' .*? '*/'                                    -> channel(HIDDEN);
 
 COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
 
@@ -169,46 +183,36 @@ OPEN_QUOTE: '"' -> pushMode(quotesMode);
 
 OPEN_SINGLE: '\'' -> type(OPEN_QUOTE), pushMode(squotesMode);
 
-fragment DIGIT: [0-9];
-fragment E_SIGN: [e];
-fragment E_NOTATION: E_SIGN [+-]? DIGIT+;
-FLOAT_LITERAL:
-	DIGIT+ DOT DIGIT* (E_NOTATION)?
-	| DIGIT+ E_NOTATION;
+fragment DIGIT     : [0-9];
+fragment DOT_FLOAT : '.' DIGIT+ ([e] [+-]? DIGIT+)? | DIGIT+ [e] [+-]? DIGIT+;
+FLOAT_LITERAL      : DIGIT+ DOT_FLOAT;
+DOT_FLOAT_LITERAL  : DOT_FLOAT;
+INTEGER_LITERAL    : DIGIT+;
 
-FLOAT_LITERAL_DECIMAL_ONLY_E_NOTATION: DOT DIGIT+ E_NOTATION;
-
-FLOAT_LITERAL_DECIMAL_ONLY: DOT DIGIT+;
-
-INTEGER_LITERAL: DIGIT+;
 IDENTIFIER: [a-z_$]+ ( [_]+ | [a-z]+ | DIGIT)*;
 
 COMPONENT_ISLAND_START: '```' -> pushMode(componentIsland);
 
+// Any character that is not matched in any other rule is an error.
+// However, we don't want the lexer to throw an error, we want the parser to
+// throw an error. So, we eat bad characters into their own token
+BADC: .;
+
 mode componentIsland;
-
-COMPONENT_ISLAND_END: '```' -> popMode;
-
-COMPONENT_ISLAND_BODY: .+?;
+COMPONENT_ISLAND_END  : '```' -> popMode;
+COMPONENT_ISLAND_BODY : .+?;
 
 mode squotesMode;
-CLOSE_SQUOTE: '\'' -> type(CLOSE_QUOTE), popMode;
-
-SHASHHASH: '##' -> type(HASHHASH);
-
-SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
-
-SHASH:
-	'#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
+CLOSE_SQUOTE    : '\''               -> type(CLOSE_QUOTE), popMode;
+SHASHHASH       : '##'               -> type(HASHHASH);
+SSTRING_LITERAL : (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
+SHASH           : '#'                -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
 
 mode quotesMode;
-CLOSE_QUOTE: '"' -> popMode;
-
-HASHHASH: '##';
-STRING_LITERAL: (~["#]+ | '""')+;
-
-HASH:
-	'#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
+CLOSE_QUOTE    : '"' -> popMode;
+HASHHASH       : '##';
+STRING_LITERAL : (~["#]+ | '""')+;
+HASH           : '#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
 
 mode hashMode;
 HANY: [.]+ -> popMode, skip;

--- a/src/main/antlr/BoxTemplateGrammar.g4
+++ b/src/main/antlr/BoxTemplateGrammar.g4
@@ -1,7 +1,10 @@
+
+
+
 parser grammar BoxTemplateGrammar;
 
 options {
-	tokenVocab = BoxTemplateLexer;
+    tokenVocab = BoxTemplateLexer;
 }
 
 // Top-level template rule.
@@ -10,57 +13,66 @@ template: statements EOF?;
 // <b>My Name is #qry.name#.</b> We can match as much non interpolated text but we need each
 // interpolated expression to be its own rule to ensure they output in the right order.
 textContent: (nonInterpolatedText | comment)+
-	| ( comment* interpolatedExpression comment*);
+    | ( comment* interpolatedExpression comment*)
+;
 
 // <!--- comment ---> or <!--- comment <!--- nested comment ---> comment --->
 comment:
-	COMMENT_START (COMMENT_TEXT | COMMENT_START)* COMMENT_END;
+    COMMENT_START (COMMENT_TEXT | COMMENT_START)* COMMENT_END
+;
 
 // ANYTHING
 componentName: COMPONENT_NAME;
 
 // <bx:ANYTHING ... >
 genericOpenComponent:
-	COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_CLOSE;
+    COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_CLOSE
+;
 
 // <bx:ANYTHING />
 genericOpenCloseComponent:
-	COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_SLASH_CLOSE;
+    COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_SLASH_CLOSE
+;
 
 // </cfANYTHING>
 genericCloseComponent:
-	COMPONENT_OPEN SLASH_PREFIX componentName COMPONENT_CLOSE;
+    COMPONENT_OPEN SLASH_PREFIX componentName COMPONENT_CLOSE
+;
 
 // #bar#
 interpolatedExpression: ICHAR expression ICHAR;
 // Any text to be directly output
-nonInterpolatedText: (COMPONENT_OPEN | CONTENT_TEXT | whitespace)+;
+nonInterpolatedText: (COMPONENT_OPEN | CONTENT_TEXT | whitespace)+
+;
 
 whitespace: WS+;
 // bar or 1+2. The lexer keeps strings together so it doesnt end the expression prematurely
 expression: (EXPRESSION_PART | quotedString)+;
 
 attribute:
-	// foo="bar" foo=bar
-	attributeName COMPONENT_EQUALS attributeValue?
-	// foo (value will default to empty string)
-	| attributeName;
+    // foo="bar" foo=bar
+    attributeName COMPONENT_EQUALS attributeValue?
+    // foo (value will default to empty string)
+    | attributeName
+;
 
 // any attributes once we've gotten past the component name
 attributeName: ATTRIBUTE_NAME;
 
 // foo or.... "foo" or... 'foo' or... "#foo#" or... #foo#
 attributeValue:
-	unquotedValue
-	| quotedString
-	| interpolatedExpression;
+    unquotedValue
+    | quotedString
+    | interpolatedExpression
+;
 
 // foo
 unquotedValue: UNQUOTED_VALUE_PART+;
 
 // "text#expression#text" or ... 'text#expression#text'
 quotedString:
-	OPEN_QUOTE (quotedStringPart | interpolatedExpression)* CLOSE_QUOTE;
+    OPEN_QUOTE (quotedStringPart | interpolatedExpression)* CLOSE_QUOTE
+;
 
 quotedStringPart: STRING_LITERAL | HASHHASH;
 
@@ -68,50 +80,54 @@ quotedStringPart: STRING_LITERAL | HASHHASH;
 statements: (statement | script | textContent)*;
 
 statement:
-	boxImport
-	| function
-	// <bx:ANYTHING />
-	| genericOpenCloseComponent
-	// <bx:ANYTHING ... >
-	| genericOpenComponent
-	// </cfANYTHING>
-	| genericCloseComponent
-	| set
-	| return
-	| if
-	| try
-	| output
-	| while
-	| break
-	| continue
-	| include
-	| rethrow
-	| throw
-	| switch;
+    boxImport
+    | function
+    // <bx:ANYTHING />
+    | genericOpenCloseComponent
+    // <bx:ANYTHING ... >
+    | genericOpenComponent
+    // </cfANYTHING>
+    | genericCloseComponent
+    | set
+    | return
+    | if
+    | try
+    | output
+    | while
+    | break
+    | continue
+    | include
+    | rethrow
+    | throw
+    | switch
+;
 
 function:
-	// <bx:function name="foo" >
-	COMPONENT_OPEN PREFIX FUNCTION attribute* COMPONENT_CLOSE
-	// zero or more <bx:argument ... >
-	(whitespace | comment)* (argument (whitespace | comment)*)*
-	// code inside function
-	body = statements
-	// </cffunction>
-	COMPONENT_OPEN SLASH_PREFIX FUNCTION COMPONENT_CLOSE;
+    // <bx:function name="foo" >
+    COMPONENT_OPEN PREFIX FUNCTION attribute* COMPONENT_CLOSE
+    // zero or more <bx:argument ... >
+    (whitespace | comment)* (argument (whitespace | comment)*)*
+    // code inside function
+    body = statements
+    // </cffunction>
+    COMPONENT_OPEN SLASH_PREFIX FUNCTION COMPONENT_CLOSE
+;
 
 argument:
-	// <bx:argument name="param">
-	COMPONENT_OPEN PREFIX ARGUMENT attribute* (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    // <bx:argument name="param">
+    COMPONENT_OPEN PREFIX ARGUMENT attribute* (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 set:
-	// <bx:set expression> <bx:set expression />
-	COMPONENT_OPEN PREFIX SET expression (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    // <bx:set expression> <bx:set expression />
+    COMPONENT_OPEN PREFIX SET expression (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 scriptBody: SCRIPT_BODY*;
 // <bx:script> statements... </cfscript>
@@ -126,74 +142,80 @@ script: SCRIPT_OPEN scriptBody SCRIPT_END_BODY;
  <bx:return 20 / 7 />
  */
 return:
-	COMPONENT_OPEN PREFIX RETURN expression? (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    COMPONENT_OPEN PREFIX RETURN expression? (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 if:
-	// <bx:if ... >`
-	COMPONENT_OPEN PREFIX IF ifCondition = expression COMPONENT_CLOSE thenBody = statements
-	// Any number of <bx:elseif ... >
-	(
-		COMPONENT_OPEN PREFIX ELSEIF elseIfCondition += expression elseIfComponentClose +=
-			COMPONENT_CLOSE elseThenBody += statements
-	)*
-	// One optional <bx:else> 
-	(
-		COMPONENT_OPEN PREFIX ELSE (
-			COMPONENT_CLOSE
-			| COMPONENT_SLASH_CLOSE
-		) elseBody = statements
-	)?
-	// Closing </cfif>
-	COMPONENT_OPEN SLASH_PREFIX IF COMPONENT_CLOSE;
+    // <bx:if ... >`
+    COMPONENT_OPEN PREFIX IF ifCondition = expression COMPONENT_CLOSE thenBody = statements
+    // Any number of <bx:elseif ... >
+    (
+        COMPONENT_OPEN PREFIX ELSEIF elseIfCondition += expression elseIfComponentClose +=
+            COMPONENT_CLOSE elseThenBody += statements
+    )*
+    // One optional <bx:else>
+    (
+        COMPONENT_OPEN PREFIX ELSE (
+            COMPONENT_CLOSE
+            | COMPONENT_SLASH_CLOSE
+        ) elseBody = statements
+    )?
+    // Closing </cfif>
+    COMPONENT_OPEN SLASH_PREFIX IF COMPONENT_CLOSE
+;
 
 try:
-	// <bx:try>
-	COMPONENT_OPEN PREFIX TRY COMPONENT_CLOSE
-	// code inside try
-	statements
-	// <bx:catch> (zero or more)
-	(catchBlock statements)*
-	// <bx:finally> (zero or one)
-	finallyBlock? statements
-	// </cftry>
-	COMPONENT_OPEN SLASH_PREFIX TRY COMPONENT_CLOSE;
+    // <bx:try>
+    COMPONENT_OPEN PREFIX TRY COMPONENT_CLOSE
+    // code inside try
+    statements
+    // <bx:catch> (zero or more)
+    (catchBlock statements)*
+    // <bx:finally> (zero or one)
+    finallyBlock? statements
+    // </cftry>
+    COMPONENT_OPEN SLASH_PREFIX TRY COMPONENT_CLOSE
+;
 
 /*
  <bx:catch type="..."> ... </cfcatch>
  <bx:catch type="..." />
  */
 catchBlock:
-	(
-		// <bx:catch type="...">
-		COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_CLOSE
-		// code in catch
-		statements
-		// </cfcatch>
-		COMPONENT_OPEN SLASH_PREFIX CATCH COMPONENT_CLOSE
-	)
-	| COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_SLASH_CLOSE;
+    (
+        // <bx:catch type="...">
+        COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_CLOSE
+        // code in catch
+        statements
+        // </cfcatch>
+        COMPONENT_OPEN SLASH_PREFIX CATCH COMPONENT_CLOSE
+    )
+    | COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_SLASH_CLOSE
+;
 
 finallyBlock:
-	// <bx:finally>
-	COMPONENT_OPEN PREFIX FINALLY COMPONENT_CLOSE
-	// code in finally 
-	statements
-	// </cffinally>
-	COMPONENT_OPEN SLASH_PREFIX FINALLY COMPONENT_CLOSE;
+    // <bx:finally>
+    COMPONENT_OPEN PREFIX FINALLY COMPONENT_CLOSE
+    // code in finally
+    statements
+    // </cffinally>
+    COMPONENT_OPEN SLASH_PREFIX FINALLY COMPONENT_CLOSE
+;
 
 output:
-	// <bx:output />
-	OUTPUT_START attribute* COMPONENT_SLASH_CLOSE
-	|
-	// <bx:output> ... 
-	OUTPUT_START attribute* COMPONENT_CLOSE
-	// code in output
-	statements
-	// </cfoutput>
-	COMPONENT_OPEN SLASH_PREFIX OUTPUT_END;
+    // <bx:output />
+    OUTPUT_START attribute* COMPONENT_SLASH_CLOSE
+    |
+    // <bx:output> ...
+    OUTPUT_START attribute* COMPONENT_CLOSE
+    // code in output
+    statements
+    // </cfoutput>
+    COMPONENT_OPEN SLASH_PREFIX OUTPUT_END
+;
 
 /*
  <bx:import componentlib="..." prefix="...">
@@ -204,78 +226,87 @@ output:
  <bx:import prefix="java" name="com.foo.Bar" alias="bradLib">
  */
 boxImport:
-	COMPONENT_OPEN PREFIX IMPORT attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX IMPORT attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 while:
-	// <bx:while condition="" >
-	COMPONENT_OPEN PREFIX WHILE attribute* COMPONENT_CLOSE
-	// code inside while
-	statements
-	// </cfwhile>
-	COMPONENT_OPEN SLASH_PREFIX WHILE COMPONENT_CLOSE;
+    // <bx:while condition="" >
+    COMPONENT_OPEN PREFIX WHILE attribute* COMPONENT_CLOSE
+    // code inside while
+    statements
+    // </cfwhile>
+    COMPONENT_OPEN SLASH_PREFIX WHILE COMPONENT_CLOSE
+;
 
 // <bx:break> or... <bx:break />
 break:
-	COMPONENT_OPEN PREFIX BREAK label = attributeName? (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX BREAK label = attributeName? (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <bx:continue> or... <bx:continue />
 continue:
-	COMPONENT_OPEN PREFIX CONTINUE label = attributeName? (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX CONTINUE label = attributeName? (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <bx:include template="..."> or... <bx:include template="..." />
 include:
-	COMPONENT_OPEN PREFIX INCLUDE attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX INCLUDE attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <bx:rethrow> or... <bx:rethrow />
 rethrow:
-	COMPONENT_OPEN PREFIX RETHROW (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX RETHROW (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <bx:throw message="..." detail="..."> or... <bx:throw />
 throw:
-	COMPONENT_OPEN PREFIX THROW attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX THROW attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 switch:
-	// <bx:switch expression="...">
-	COMPONENT_OPEN PREFIX SWITCH attribute* COMPONENT_CLOSE
-	// <bx:case> or <bx:defaultcase> 
-	switchBody
-	// </cftry>
-	COMPONENT_OPEN SLASH_PREFIX SWITCH COMPONENT_CLOSE;
+    // <bx:switch expression="...">
+    COMPONENT_OPEN PREFIX SWITCH attribute* COMPONENT_CLOSE
+    // <bx:case> or <bx:defaultcase>
+    switchBody
+    // </cftry>
+    COMPONENT_OPEN SLASH_PREFIX SWITCH COMPONENT_CLOSE
+;
 
 switchBody: (statement | script | textContent | case)*;
 
 case:
-	(
-		// <bx:case value="...">
-		COMPONENT_OPEN PREFIX CASE attribute* COMPONENT_CLOSE
-		// code in case
-		statements
-		// </cfcase>
-		COMPONENT_OPEN SLASH_PREFIX CASE COMPONENT_CLOSE
-	)
-	| (
-		// <bx:defaultcase>
-		COMPONENT_OPEN PREFIX DEFAULTCASE COMPONENT_CLOSE
-		// code in default case
-		statements
-		// </cfdefaultcase >
-		COMPONENT_OPEN SLASH_PREFIX DEFAULTCASE COMPONENT_CLOSE
-	);
+    (
+        // <bx:case value="...">
+        COMPONENT_OPEN PREFIX CASE attribute* COMPONENT_CLOSE
+        // code in case
+        statements
+        // </cfcase>
+        COMPONENT_OPEN SLASH_PREFIX CASE COMPONENT_CLOSE
+    )
+    | (
+        // <bx:defaultcase>
+        COMPONENT_OPEN PREFIX DEFAULTCASE COMPONENT_CLOSE
+        // code in default case
+        statements
+        // </cfdefaultcase >
+        COMPONENT_OPEN SLASH_PREFIX DEFAULTCASE COMPONENT_CLOSE
+    )
+;

--- a/src/main/antlr/BoxTemplateLexer.g4
+++ b/src/main/antlr/BoxTemplateLexer.g4
@@ -1,7 +1,10 @@
+
+
+
 lexer grammar BoxTemplateLexer;
 
 options {
-	caseInsensitive = true;
+    caseInsensitive = true;
 }
 
 @members {
@@ -67,14 +70,16 @@ WS: (' ' | '\t' | '\r'? '\n')+;
 SCRIPT_OPEN: '<bx:script' .*? '>' -> pushMode(XFSCRIPT);
 
 OUTPUT_START:
-	'<bx:output' -> pushMode(POSSIBLE_COMPONENT), pushMode(COMPONENT_MODE), pushMode(OUTPUT_MODE);
+    '<bx:output' -> pushMode(POSSIBLE_COMPONENT), pushMode(COMPONENT_MODE), pushMode(OUTPUT_MODE)
+;
 
 COMPONENT_OPEN: '<' -> pushMode(POSSIBLE_COMPONENT);
 
 HASHHASH: '##' -> type(CONTENT_TEXT);
 
 ICHAR:
-	'#' {_modeStack.contains(OUTPUT_MODE)}? -> pushMode(EXPRESSION_MODE_STRING);
+    '#' {_modeStack.contains(OUTPUT_MODE)}? -> pushMode(EXPRESSION_MODE_STRING)
+;
 ICHAR_1: '#' -> type(CONTENT_TEXT);
 
 CONTENT_TEXT: ~[<#]+;
@@ -85,12 +90,14 @@ mode COMMENT_MODE;
 // If we reach an "ending" comment, but there are 2 or more TAG_COMMENT modes on the stack, this is
 // just the end of a nested comment so we emit a TAG_COMMENT_TEXT token instead.
 COMMENT_END_BUT_NOT_REALLY:
-	'--->' {countModes(COMMENT_MODE) > 1}? -> type(COMMENT_TEXT), popMode;
+    '--->' {countModes(COMMENT_MODE) > 1}? -> type(COMMENT_TEXT), popMode
+;
 
 COMMENT_END: '--->' -> popMode;
 
 COMMENT_START2:
-	'<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START)
+;
 
 COMMENT_TEXT: .+?;
 
@@ -100,16 +107,20 @@ mode COMMENT_QUIET;
 // If we reach an "ending" comment, but there are 2 or more TAG_COMMENT modes on the stack, this is
 // just the end of a nested comment so we emit a TAG_COMMENT_TEXT token instead.
 COMMENT_END_BUT_NOT_REALLY_QUIET:
-	'--->' {countModes(COMMENT_QUIET) > 1}? -> type(COMMENT_TEXT), channel(HIDDEN), popMode;
+    '--->' {countModes(COMMENT_QUIET) > 1}? -> type(COMMENT_TEXT), channel(HIDDEN), popMode
+;
 
 COMMENT_END_QUIET:
-	'--->' -> popMode, channel(HIDDEN), type(COMMENT_END);
+    '--->' -> popMode, channel(HIDDEN), type(COMMENT_END)
+;
 
 COMMENT_START_QUIET:
-	'<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START)
+;
 
 COMMENT_TEXT_QUIET:
-	.+? -> type(COMMENT_TEXT), channel(HIDDEN);
+    .+? -> type(COMMENT_TEXT), channel(HIDDEN)
+;
 
 // *********************************************************************************************************************
 mode COMPONENT_NAME_MODE;
@@ -121,16 +132,20 @@ ARGUMENT: 'argument' -> pushMode( COMPONENT_MODE );
 
 // return may or may not have an expression, so eat any leading whitespace now so it doesn't give us an expression part that's just a space
 RETURN:
-	'return' [ \t\r\n]* -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'return' [ \t\r\n]* -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 IF:
-	'if' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'if' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 ELSE: 'else' -> pushMode( COMPONENT_MODE );
 ELSEIF:
-	'elseif' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'elseif' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 SET:
-	'set ' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'set ' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 TRY: 'try' -> pushMode( COMPONENT_MODE );
 CATCH: 'catch' -> pushMode( COMPONENT_MODE );
@@ -148,16 +163,18 @@ CASE: 'case' -> pushMode( COMPONENT_MODE );
 DEFAULTCASE: 'defaultcase' -> pushMode( COMPONENT_MODE );
 
 COMPONENT_NAME:
-	COMPONENT_NameStartChar COMPONENT_NameChar* -> pushMode( COMPONENT_MODE );
+    COMPONENT_NameStartChar COMPONENT_NameChar* -> pushMode( COMPONENT_MODE )
+;
 
 fragment DIGIT: [0-9];
 
 fragment COMPONENT_NameChar:
-	COMPONENT_NameStartChar
-	| '_'
-	| '-'
-	| DIGIT
-	| ':';
+    COMPONENT_NameStartChar
+    | '_'
+    | '-'
+    | DIGIT
+    | ':'
+;
 
 fragment COMPONENT_NameStartChar: [a-z_];
 
@@ -166,7 +183,8 @@ mode COMPONENT_MODE;
 
 // Comments can live inside of a tag <cfTag <!--- comment ---> foo=bar >
 COMMENT_START1:
-	'<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START)
+;
 
 COMPONENT_CLOSE: '>' -> popMode, popMode, popMode;
 
@@ -183,11 +201,12 @@ COMPONENT_WHITESPACE: [ \t\r\n] -> skip;
 fragment ATTRIBUTE_DIGIT: [0-9];
 
 fragment ATTRIBUTE_NameChar:
-	ATTRIBUTE_NameStartChar
-	| '_'
-	| '-'
-	| ATTRIBUTE_DIGIT
-	| ':';
+    ATTRIBUTE_NameStartChar
+    | '_'
+    | '-'
+    | ATTRIBUTE_DIGIT
+    | ':'
+;
 
 fragment ATTRIBUTE_NameStartChar: [a-z_];
 
@@ -196,19 +215,24 @@ mode OUTPUT_MODE;
 
 // Source inside of an output tag is consumed in output mode
 COMMENT_START4:
-	'<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START)
+;
 
 COMPONENT_CLOSE_OUTPUT:
-	'>' -> pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE);
+    '>' -> pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE)
+;
 
 COMPONENT_SLASH_CLOSE_OUTPUT:
-	'/>' -> popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 COMPONENT_EQUALS_OUTPUT:
-	'=' -> pushMode(ATTVALUE), type(COMPONENT_EQUALS);
+    '=' -> pushMode(ATTVALUE), type(COMPONENT_EQUALS)
+;
 
 ATTRIBUTE_NAME_OUTPUT:
-	ATTRIBUTE_NameStartChar ATTRIBUTE_NameChar* -> type(ATTRIBUTE_NAME);
+    ATTRIBUTE_NameStartChar ATTRIBUTE_NameChar* -> type(ATTRIBUTE_NAME)
+;
 
 COMPONENT_WHITESPACE_OUTPUT: [ \t\r\n] -> skip;
 
@@ -219,7 +243,8 @@ IF2: 'if' -> type(IF);
 FUNCTION2: 'function' -> type(FUNCTION);
 // popping back to: POSSIBLE_COMPONENT -> DEFAULT_MODE -> OUTPUT_MODE -> COMPONENT -> POSSIBLE_COMPONENT -> DEFAULT_MODE
 OUTPUT_END:
-	'output>' -> popMode, popMode, popMode, popMode, popMode, popMode;
+    'output>' -> popMode, popMode, popMode, popMode, popMode, popMode
+;
 TRY2: 'try' -> type(TRY);
 CATCH2: 'catch' -> type(CATCH);
 FINALLY2: 'finally' -> type(FINALLY);
@@ -238,9 +263,11 @@ DEFAULTCASE2: 'defaultcase' -> type(DEFAULTCASE);
 COMPONENT_WHITESPACE_OUTPUT3: [ \t\r\n] -> skip;
 
 COMPONENT_NAME2:
-	COMPONENT_NameStartChar COMPONENT_NameChar* -> type(COMPONENT_NAME);
+    COMPONENT_NameStartChar COMPONENT_NameChar* -> type(COMPONENT_NAME)
+;
 COMPONENT_CLOSE2:
-	'>' -> popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 // *********************************************************************************************************************
 mode ATTVALUE;
@@ -248,27 +275,33 @@ mode ATTVALUE;
 COMPONENT_WHITESPACE_OUTPUT2: [ \t\r\n] -> skip;
 
 ICHAR20:
-	'#' -> type(ICHAR), pushMode(EXPRESSION_MODE_UNQUOTED_ATTVALUE);
+    '#' -> type(ICHAR), pushMode(EXPRESSION_MODE_UNQUOTED_ATTVALUE)
+;
 
 OPEN_QUOTE: '"' -> pushMode(quotesModeCOMPONENT);
 
 OPEN_SINGLE:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeCOMPONENT);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeCOMPONENT)
+;
 
 // If we're in a cfoutput tag, don't pop as far and stay in outut mode
 COMPONENT_CLOSE_OUTPUT2:
-	'>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE );
+    '>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE )
+;
 
 // If we're in a cfoutput tag, pop all the way out of the component
 COMPONENT_SLASH_CLOSE2:
-	'/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, type( COMPONENT_SLASH_CLOSE );
+    '/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, type( COMPONENT_SLASH_CLOSE )
+;
 
 // There may be no value, so we need to pop out of ATTVALUE if we find the end of the component
 COMPONENT_CLOSE5:
-	'>' -> popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 COMPONENT_SLASH_CLOSE3:
-	'/>' -> popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 UNQUOTED_VALUE_PART: . -> pushMode(UNQUOTED_VALUE_MODE);
 
@@ -277,24 +310,29 @@ mode UNQUOTED_VALUE_MODE;
 
 // first whitespace pops all the way out of ATTVALUE back to component mode
 COMPONENT_WHITESPACE_OUTPUT4:
-	[ \t\r\n] -> popMode, popMode, skip;
+    [ \t\r\n] -> popMode, popMode, skip
+;
 
 // If we're in a cfoutput tag, don't pop as far and stay in outut mode
 COMPONENT_CLOSE_OUTPUT3:
-	'>' {lastModeWas(OUTPUT_MODE,2)}? -> popMode, popMode, pushMode(DEFAULT_MODE), type(
-		COMPONENT_CLOSE);
+    '>' {lastModeWas(OUTPUT_MODE,2)}? -> popMode, popMode, pushMode(DEFAULT_MODE), type(
+        COMPONENT_CLOSE)
+;
 
 // If we find the end of the component, pop all the way out of the component
 COMPONENT_CLOSE3:
-	'>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 // If we're in a cfoutput tag, pop all the way out of the component
 COMPONENT_SLASH_CLOSE5:
-	'/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, popMode, type(
-		COMPONENT_SLASH_CLOSE );
+    '/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, popMode, type(
+        COMPONENT_SLASH_CLOSE )
+;
 
 COMPONENT_SLASH_CLOSE4:
-	'/>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 UNQUOTED_VALUE_PART2: . -> type(UNQUOTED_VALUE_PART);
 
@@ -306,10 +344,12 @@ FAT_ARROW: '=>' -> type(EXPRESSION_PART);
 SKINNY_ARROW: '->' -> type(EXPRESSION_PART);
 
 COMPONENT_SLASH_CLOSE1:
-	'/>' -> type(COMPONENT_SLASH_CLOSE), popMode, popMode, popMode, popMode;
+    '/>' -> type(COMPONENT_SLASH_CLOSE), popMode, popMode, popMode, popMode
+;
 
 COMPONENT_CLOSE1:
-	'>' -> type(COMPONENT_CLOSE), popMode, popMode, popMode, popMode;
+    '>' -> type(COMPONENT_CLOSE), popMode, popMode, popMode, popMode
+;
 
 EXPRESSION_PART: ~[-=>'"/]+;
 
@@ -320,10 +360,12 @@ EXPRESSION_PART6: '=' -> type(EXPRESSION_PART);
 EXPRESSION_PART7: '-' -> type(EXPRESSION_PART);
 
 OPEN_QUOTE2:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE2:
-	'\'' -> type(OPEN_QUOTE), pushMode(squotesModeExpression);
+    '\'' -> type(OPEN_QUOTE), pushMode(squotesModeExpression)
+;
 
 // *********************************************************************************************************************
 mode EXPRESSION_MODE_UNQUOTED_ATTVALUE;
@@ -332,10 +374,12 @@ ICHAR4: '#' -> type(ICHAR), popMode, popMode;
 STRING_EXPRESSION_PART2: ~[#'"]+ -> type(EXPRESSION_PART);
 
 OPEN_QUOTE4:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE4:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression)
+;
 
 // *********************************************************************************************************************
 mode EXPRESSION_MODE_STRING;
@@ -344,21 +388,24 @@ ICHAR1: '#' -> type(ICHAR), popMode;
 STRING_EXPRESSION_PART: ~[#'"]+ -> type(EXPRESSION_PART);
 
 OPEN_QUOTE3:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE3:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression)
+;
 
 // *********************************************************************************************************************
 mode squotesModeCOMPONENT;
 ICHAR2: '#' -> pushMode(EXPRESSION_MODE_STRING), type(ICHAR);
 CLOSE_SQUOTE:
-	'\'' {
+    '\'' {
 		//if ( modeNames [_modeStack.peek()].equals ("ATTVALUE")	) {
 			//System.out.println( "Extra POP (single)" );
 		//	popMode();
 		//	}
-		 } -> type( CLOSE_QUOTE), popMode, popMode;
+		 } -> type( CLOSE_QUOTE), popMode, popMode
+;
 
 SHASHHASH: '##' -> type(HASHHASH);
 SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
@@ -367,12 +414,13 @@ SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
 mode quotesModeCOMPONENT;
 ICHAR3: '#' -> type(ICHAR), pushMode(EXPRESSION_MODE_STRING);
 CLOSE_QUOTE:
-	'"' {  
+    '"' {  
 		//if (modeNames[_modeStack.peek()].equals( "ATTVALUE" )) {
 			//System.out.println( "Extra POP" );
 			//popMode();
 		//	} 
-		} -> popMode, popMode;
+		} -> popMode, popMode
+;
 
 HASHHASH1: '##' -> type(HASHHASH);
 STRING_LITERAL: (~["#]+ | '""')+;
@@ -398,7 +446,8 @@ mode XFSCRIPT;
 
 fragment COMPONENT_WHITESPACE2: [ \t\r\n]*;
 SCRIPT_END_BODY:
-	'</' COMPONENT_WHITESPACE2 'bx:script' COMPONENT_WHITESPACE2 '>' -> popMode;
+    '</' COMPONENT_WHITESPACE2 'bx:script' COMPONENT_WHITESPACE2 '>' -> popMode
+;
 
 SCRIPT_BODY: .+?;
 
@@ -409,7 +458,8 @@ PREFIX: 'bx:' -> pushMode(COMPONENT_NAME_MODE);
 SLASH_PREFIX: '/bx:' -> pushMode(END_COMPONENT);
 
 ICHAR7:
-	'#' {_modeStack.contains(OUTPUT_MODE)}? -> type(ICHAR), popMode, pushMode(EXPRESSION_MODE_STRING
-		);
+    '#' {_modeStack.contains(OUTPUT_MODE)}? -> type(ICHAR), popMode, pushMode(EXPRESSION_MODE_STRING
+        )
+;
 
 ANY: . -> type(CONTENT_TEXT), popMode;

--- a/src/main/antlr/CFScriptGrammar.g4
+++ b/src/main/antlr/CFScriptGrammar.g4
@@ -1,303 +1,303 @@
 parser grammar CFScriptGrammar;
 
+// Please note that this is still a WIP, but is essentially complete
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+// $antlr-format alignColons hanging, allowShortRulesOnASingleLine on, alignFirstTokens on
+
 options {
-	tokenVocab = CFScriptLexer;
+    tokenVocab = CFScriptLexer;
+    superClass = CFParserControl;
 }
 
-@members {
-	// This allows script components to be verified at parse time.
- 	public ortus.boxlang.runtime.services.ComponentService componentService = ortus.boxlang.runtime.BoxRuntime.getInstance().getComponentService();
+@header {
+	import ortus.boxlang.compiler.parser.CFParserControl;
  }
 
 // foo
-identifier: IDENTIFIER | reservedKeyword;
+identifier: IDENTIFIER | reservedKeyword
+    ;
 
-componentName:
-	// Ask the component service if the component exists
-	{ componentService.hasComponent( _input.LT(1).getText() ) }? identifier;
-
-// cfSomething
-prefixedIdentifier: PREFIXEDIDENTIFIER;
-
-// These are ONLY the scopes that always exist and never go away. All other scopes that may or may
-// not exist at runtime, are handled dynamically in the runtime.
-scope: REQUEST | VARIABLES | SERVER;
+componentName
+    :
+    // Ask the component service if the component exists and verify that this context is actually a component.
+    { isComponent(_input) }? identifier
+    ;
 
 // These are reserved words in the lexer, but are allowed to be an indentifer (variable name, method name)
-reservedKeyword:
-	scope
-	| ABSTRACT
-	| ANY
-	| ARRAY
-	| AS
-	| BOOLEAN
-	| BREAK
-	| CASE
-	| CASTAS
-	| CATCH
-	| CLASS_NAME
-	| CONTAIN
-	| CONTAINS
-	| CONTINUE
-	| DEFAULT
-	| DOES
-	| DO
-	| ELSE IF
-	| ELSE
-	| ELSEIF
-	| FALSE
-	| FINALLY
-	| FINAL
-	| FOR
-	| FUNCTION
-	| GREATER
-	| IF
-	| IN
-	| IMPORT
-	| INCLUDE
-	| INTERFACE
-	| INSTANCEOF
-	| IS
-	| JAVA
-	| LESS
-	| MOD
-	| MESSAGE
-	| NEW
-	| NULL
-	| NUMERIC
-	| PACKAGE
-	| PARAM
-	| PRIVATE
-	| PROPERTY
-	| PUBLIC
-	| QUERY
-	| REMOTE
-	| REQUIRED
-	| RETURN
-	| RETHROW
-	| SETTING
-	| STATIC
-	| STRING
-	| STRUCT
-	//| SWITCH --> Could possibly be a var name, but not a function/method name
-	| THAN
-	| TO
-	| THROW
-	| TYPE
-	| TRUE
-	| TRY
-	| VAR
-	| WHEN
-	| WHILE
-	| XOR
-	| EQV
-	| IMP
-	| AND
-	| EQ
-	| EQUAL
-	| GT
-	| GTE
-	| GE
-	| LT
-	| LTE
-	| LE
-	| NEQ
-	| NOT
-	| OR
-	| PREFIX
-	| PREFIXEDIDENTIFIER;
+reservedKeyword
+    : ABSTRACT
+    | AND
+    | ANY
+    | ARRAY
+    | AS
+    | BOOLEAN
+    | BREAK
+    | CASE
+    | CASTAS
+    | CATCH
+    | COMPONENT
+    | CONTAIN
+    | CONTAINS
+    | CONTINUE
+    | DEFAULT
+    | DO
+    | DOES
+    | ELSEIF
+    | ELSE IF? // TODO: May have to special case this :(
+    | EQ
+    | EQUAL
+    | EQV
+    | FALSE
+    | FINAL
+    | FINALLY
+    | FOR
+    | FUNCTION
+    | GE
+    | GREATER
+    | GT
+    | GTE
+    | IF
+    | IMP
+    | IMPORT
+    | IN
+    | INCLUDE
+    | INSTANCEOF
+    | INTERFACE
+    | IS
+    | JAVA
+    | LE
+    | LESS
+    | LT
+    | LTE
+    | MESSAGE
+    | MOD
+    | NEQ
+    | NEW
+    | NOT
+    | NULL
+    | NUMERIC
+    | OR
+    | PACKAGE
+    | PARAM
+    | PRIVATE
+    | PROPERTY
+    | PUBLIC
+    | QUERY
+    | REMOTE
+    | REQUEST
+    | REQUIRED
+    | RETHROW
+    | RETURN
+    | SERVER
+    | SETTING
+    | STATIC
+    | STRING
+    | STRUCT
+    // | SWITCH --> Could possibly be a var name, but not a function/method name
+    | THAN
+    | THROW
+    | TO
+    | TRUE
+    | TRY
+    | TYPE
+    | VAR
+    | VARIABLES
+    | WHEN
+    | WHILE
+    | XOR
+    | PREFIXEDIDENTIFIER // cfSomething
+    ;
 
-// marks the end of simple statements (no body)
-eos: SEMICOLON;
+// ANY NEW LEXER RULES IN DEFAULT MODE FOR WORDS NEED ADDED HERE
 
 // This is the top level rule for a class or an interface
-classOrInterface: boxClass | interface;
+// TODO: Should this not also end with EOF? Otherwise the parser will stop at the end of the class/interface even if junk follows
+classOrInterface: SEMICOLON* (boxClass | interface)
+    ;
 
 // This is the top level rule for a script of statements.
-script: functionOrStatement* | EOF;
+script: SEMICOLON* functionOrStatement* EOF
+    ;
 
-// import foo.bar.Baz;
-importStatement: IMPORT importFQN eos?;
+// Used for tests, to force the parser to look at all tokens and not just stop at the first expression
+testExpression: expression EOF
+    ;
 
-importFQN: stringLiteral | fqn (DOT STAR)?;
+// import java:foo.bar.Baz as myAlias;
+importStatement: IMPORT importFQN SEMICOLON*
+    ;
+
+importFQN: stringLiteral | fqn (DOT STAR)?
+    ;
 
 // include "myFile.bxm";
-include: INCLUDE expression;
+include: INCLUDE expression
+    ;
 
-// component {}
-boxClass:
-	importStatement* ABSTRACT? boxClassName postannotation* LBRACE property* classBody RBRACE;
+// class {}
+boxClass: importStatement* ABSTRACT? COMPONENT postAnnotation* LBRACE property* classBody RBRACE
+    ;
 
-// the actual word "component"
-boxClassName: CLASS_NAME;
+classBody: classBodyStatement*
+    ;
 
-staticInitializer: STATIC statementBlock;
+classBodyStatement: staticInitializer | functionOrStatement
+    ;
 
-classBody: ( staticInitializer | functionOrStatement)*;
+staticInitializer: STATIC normalStatementBlock
+    ;
 
 // interface {}
-interface:
-	importStatement* boxInterfaceName postannotation* LBRACE (
-		abstractFunction
-		| function
-	)* RBRACE;
+interface: importStatement* INTERFACE postAnnotation* LBRACE ( function)* RBRACE
+    ;
 
-// the actual word "interface"
-boxInterfaceName: INTERFACE;
-
-// function String foo( required integer param1=42 );
-abstractFunction: functionSignature ( postannotation)* eos?;
+// UDF or abstractFunction
+function: functionSignature postAnnotation* normalStatementBlock? SEMICOLON*
+    ;
 
 // public String myFunction( String foo, String bar )
-functionSignature:
-	modifiers? returnType? FUNCTION identifier LPAREN functionParamList? RPAREN;
+functionSignature: modifier* returnType? FUNCTION identifier LPAREN functionParamList? RPAREN
+    ;
 
-modifiers: (accessModifier | DEFAULT | STATIC | ABSTRACT | FINAL)+;
+modifier: accessModifier | DEFAULT | STATIC | ABSTRACT | FINAL
+    ;
 
 // String function foo() or MyClass function foo()
-returnType: type | identifier;
+returnType: type | identifier
+    ;
 
 // private String function foo()
-accessModifier: PUBLIC | PRIVATE | REMOTE | PACKAGE;
-
-// UDF
-function:
-	functionSignature (postannotation)* statementBlock
-	// This will "eat" random extra ; at the end of statements
-	eos*;
+accessModifier: PUBLIC | PRIVATE | REMOTE | PACKAGE
+    ;
 
 // Declared arguments for a function
-functionParamList: functionParam (COMMA functionParam)* COMMA?;
+functionParamList: functionParam (COMMA functionParam)* COMMA?
+    ;
 
 // required String param1="default" inject="something"
-functionParam: (REQUIRED)? (type)? identifier (
-		EQUALSIGN expression
-	)? postannotation*;
+functionParam: REQUIRED? type? identifier (EQUALSIGN expression)? postAnnotation*
+    ;
+
+// @MyAnnotation "value". This is BL specific, so it's disabled in the CF grammar, but defined here
+// in the base grammar for better rule reuse.
+preAnnotation: AT fqn annotation*
+    ;
+
+arrayLiteral: LBRACKET expressionList? RBRACKET
+    ;
 
 // foo=bar baz="bum"
-postannotation:
-	key = identifier (
-		(EQUALSIGN | COLON) value = attributeSimple
-	)?;
+postAnnotation: identifier ((EQUALSIGN | COLON) attributeSimple)?
+    ;
 
 // This allows [1, 2, 3], "foo", or foo Adobe allows more chars than an identifer, Lucee allows darn
 // near anything, but ANTLR is incapable of matching any tokens until the next whitespace. The
 // literalExpression is just a BoxLang flourish to allow for more flexible expressions.
-attributeSimple: literalExpression | identifier | fqn;
+attributeSimple: annotation | identifier | fqn
+    ;
 
-type:
-	(
-		NUMERIC
-		| STRING
-		| BOOLEAN
-		| CLASS_NAME
-		| INTERFACE
-		| ARRAY
-		| STRUCT
-		| QUERY
-		| fqn
-		| ANY
-	) (LBRACKET RBRACKET)?;
+annotation: atoms | stringLiteral | structExpression | arrayLiteral
+    ;
 
-// Allow any statement or a function.  TODO: This may need to be changed if functions are allowed inside of functions
-functionOrStatement: function | abstractFunction | statement;
+type
+    : (NUMERIC | STRING | BOOLEAN | COMPONENT | INTERFACE | ARRAY | STRUCT | QUERY | fqn | ANY) (
+        LBRACKET RBRACKET
+    )?
+    ;
+
+// Allow any statement or a function.
+// TODO: This may need to be changed if functions are allowed inside of functions
+functionOrStatement: function | statement
+    ;
 
 // property name="foo" type="string" default="bar" inject="something";
-property: PROPERTY postannotation* eos;
+// Because a property is not seen as a normal statement, we have to add SEMICOLON here :(
+property: PROPERTY postAnnotation* SEMICOLON*
+    ;
 
-// function() {} or () => {}
-anonymousFunction: closure;
-
-closure:
-	// function( param, param ) {}
-	FUNCTION LPAREN functionParamList? RPAREN (postannotation)* statementBlock
-	// ( param, param ) => {}
-	| LPAREN functionParamList? RPAREN (postannotation)* ARROW_RIGHT statement
-	// param => {}
-	| identifier ARROW_RIGHT statement;
+// function() {} or () => {} or () -> {}
+anonymousFunction
+    :
+    // function( param, param ) {}
+    FUNCTION LPAREN functionParamList? RPAREN (postAnnotation)* normalStatementBlock # closureFunc
+    // ( param, param ) => {}, param => {} (param, param) -> {}, param -> {}
+    | (LPAREN functionParamList? RPAREN | identifier) (postAnnotation)* op = (ARROW | ARROW_RIGHT) statementOrBlock # lambdaFunc
+    ;
 
 // { statement; statement; }
-statementBlock: LBRACE (statement)* RBRACE eos?;
+statementBlock: LBRACE statement+ RBRACE SEMICOLON*
+    ;
+
+// { statement; statement; }
+emptyStatementBlock: LBRACE RBRACE SEMICOLON*
+    ;
+
+normalStatementBlock: LBRACE statement* RBRACE
+    ;
+
+statementOrBlock: emptyStatementBlock | statement
+    ;
 
 // Any top-level statement that can be in a block.
-statement:
-	// This will "eat" random extra ; at the start of statements
-	eos* (
-		importStatement
-		| function
-		| do
-		| for
-		| if
-		| switch
-		| try
-		| while
-		// throw is really a component or a simple statement, but the `throw new
-		// java:com.foo.Bar();` case needs checked PRIOR to the component case, which needs checked
-		// prior to simple statements due to its ambiguity
-		| throw
-		// include is really a component or a simple statement, but the `include expression;` case
-		// needs checked PRIOR to the component case, which needs checked prior to simple statements
-		// due to its ambiguity
-		| include
-		// component needs to be checked BEFORE simple statement, which includes expressions, and
-		// will detect things like abort; as a access expression or cfinclude( template="..." ) as a
-		// function invocation
-		| component
-		// Must be before simple statement so {foo=bar} is a statement block, not a struct literal 
-		| statementBlock
-		| simpleStatement
-		| componentIsland
-	)
-	// This will "eat" random extra ; at the end of statements
-	eos*;
+statement
+    : SEMICOLON* (
+        importStatement
+        | if
+        | switch
+        | try
+        | while
+        | for
+        | do
+        // throw would parser as a component or a simple statement, but the `throw new
+        // java:com.foo.Bar();` case needs checked PRIOR to the component case, which needs checked
+        // prior to simple statements due to its ambiguity
+        | throw
+        // include is really a component or a simple statement, but the `include expression;` case
+        // needs checked PRIOR to the compnent case, which needs checked prior to expression
+        | include
+        | statementBlock
+        | component
+        | simpleStatement
+        | expressionStatement // Allows for statements like complicated.thing.foo.bar--
+        | emptyStatementBlock
+        | componentIsland
+    ) SEMICOLON*
+    ;
+
+varDecl: varModifier+ expression
+    ;
+
+// Note that we use op= because this may become a set if modifiers other than VAR are added:
+// op=(VAR | FINAL | PRIVATE) etc
+varModifier: op = VAR
+    ;
 
 // Simple statements have no body
-simpleStatement: (
-		variableDeclaration
-		| break
-		| continue
-		| rethrow
-		| param
-		| incrementDecrementStatement
-		| return
-		| expression
-	) eos?;
+simpleStatement: break | continue | rethrow | param | return | not
+    ;
 
-/*
- ++foo
- foo++
- --foo
- foo--
- */
-incrementDecrementStatement:
-	PLUSPLUS accessExpression		# preIncrement
-	| accessExpression PLUSPLUS		# postIncrement
-	| MINUSMINUS accessExpression	# preDecremenent
-	| accessExpression MINUSMINUS	# postDecrement;
+// NOT ( expression ) is a special case when a statement as everything else should
+// be seen as a function call. A quirk of the language, but easy to cater for
+not: NOT expression
+    ;
 
-// var foo = bar
-assignment:
-	VAR? assignmentLeft (
-		EQUALSIGN
-		| PLUSEQUAL
-		| MINUSEQUAL
-		| STAREQUAL
-		| SLASHEQUAL
-		| MODEQUAL
-		| CONCATEQUAL
-	) assignmentRight;
+// http url="google.com" {}?
+component
+    : PREFIXEDIDENTIFIER LPAREN (componentAttribute COMMA?)* RPAREN normalStatementBlock?
+    | componentName componentAttribute* normalStatementBlock?
+    ;
 
-assignmentLeft: accessExpression | ICHAR accessExpression ICHAR;
-assignmentRight: expression;
-
-// var foo
-variableDeclaration: VAR identifier;
+componentAttribute: identifier ((EQUALSIGN | COLON) expression)?
+    ;
 
 // Arguments are zero or more named args, or zero or more positional args, but not both (validated in the AST-building stage).
-argumentList:
-	(namedArgument | positionalArgument) (
-		COMMA (namedArgument | positionalArgument)
-	)* COMMA?;
+argumentList: argument (COMMA argument)* COMMA?
+    ;
+
+argument: (namedArgument | positionalArgument)
+    ;
 
 /*
  func( foo = bar, baz = qux )
@@ -306,10 +306,12 @@ argumentList:
  func(
  'foo' : bar, 'baz' : qux )
  */
-namedArgument: (identifier | stringLiteral) (EQUALSIGN | COLON) expression;
+namedArgument: (identifier | stringLiteral) (EQUALSIGN | COLON) expression
+    ;
 
 // func( foo, bar, baz )
-positionalArgument: expression;
+positionalArgument: expression
+    ;
 
 // The generic component syntax won't capture all access expressions so we need this rule too param
 /*
@@ -317,14 +319,13 @@ positionalArgument: expression;
  param foo.bar="baz";
  param String foo.bar;
  */
-param: PARAM type? accessExpression ( EQUALSIGN expression)?;
+param: PARAM type? expressionStatement
+    ; // Expression will capture x=y
 
 // We support if blocks with or without else blocks, and if statements without else blocks. That's
 // it - no other valid if constructs.
-if:
-	IF LPAREN expression RPAREN ifStmt = statement (
-		ELSE elseStmt = statement
-	)?;
+if: IF LPAREN expression RPAREN ifStmt = statementOrBlock (ELSE elseStmt = statementOrBlock)?
+    ;
 
 /*
  for( var i = 0; i < 10; i++ ) {}
@@ -337,52 +338,51 @@ if:
  or...
  for( var foo in bar ) echo(i)
  */
-for:
-	(label = identifier COLON)? FOR LPAREN VAR? accessExpression IN expression RPAREN statement
-	| (label = identifier COLON)? FOR LPAREN forAssignment? eos forCondition? eos forIncrement?
-		RPAREN statement;
-
-// The assignment expression (var i = 0) in a for(var i = 0; i < 10; i++ ) loop
-forAssignment: expression;
-
-// The condition expression (i < 10) in a for(var i = 0; i < 10; i++ ) loop
-forCondition: expression;
-
-// The increment expression (i++) in a for(var i = 0; i < 10; i++ ) loop
-forIncrement: expression;
+for
+    : preFix? FOR LPAREN (
+        VAR? expression IN expression
+        | expression? SEMICOLON expression? SEMICOLON expression?
+    ) RPAREN statementOrBlock
+    ;
 
 /*
  do {
  statement;
  } while( expression );
  */
-do: (label = identifier COLON)? DO statement WHILE LPAREN expression RPAREN;
+do: preFix? DO statementOrBlock WHILE LPAREN expression RPAREN
+    ;
 
 /*
  while( expression ) {
  statement;
  }
  */
-while:
-	(label = identifier COLON)? WHILE LPAREN condition = expression RPAREN statement;
+while: preFix? WHILE LPAREN expression RPAREN statementOrBlock
+    ;
 
 // break label;
-break: BREAK identifier?;
+break: BREAK identifier?
+    ;
 
 // continue label
-continue: CONTINUE identifier?;
+continue: CONTINUE identifier?
+    ;
 
 /*
  return;
  return foo;
  */
-return: RETURN expression?;
+return: RETURN expression?
+    ;
 
 // rethrow;
-rethrow: RETHROW;
+rethrow: RETHROW
+    ;
 
-// throw Exception; Yes, CF does support this, at least in the form of throw "My message";
-throw: THROW expression;
+// throw Exception;
+throw: THROW expression
+    ;
 
 /*
  switch( expression ) {
@@ -394,286 +394,198 @@ throw: THROW expression;
  }
  }
  */
-switch: SWITCH LPAREN expression RPAREN LBRACE (case)* RBRACE;
+switch: SWITCH LPAREN expression RPAREN LBRACE case* RBRACE
+    ;
 
 /*
  case 1:
  statement;
  break;
  */
-case:
-	CASE (expression) COLON statement*?
-	| DEFAULT COLON statement*?;
+case: (CASE expression | DEFAULT) COLON statementOrBlock*
+    ;
 
 /*
  ```
  <bx:set components="here">
  ```
  */
-componentIsland:
-	COMPONENT_ISLAND_START componentIslandBody COMPONENT_ISLAND_END;
-componentIslandBody: COMPONENT_ISLAND_BODY*;
+componentIsland: COMPONENT_ISLAND_START componentIslandBody COMPONENT_ISLAND_END
+    ;
+
+componentIslandBody: COMPONENT_ISLAND_BODY*
+    ;
 
 /*
  try {
- 
+
  } catch( e ) {
  } finally {
  }
  */
-try: TRY statementBlock ( catch_)* finally_?;
+try: TRY normalStatementBlock catches* finallyBlock?
+    ;
 
 // catch( e ) {}
-catch_:
-	CATCH LPAREN catchType? (PIPE catchType)* VAR? expression RPAREN statementBlock;
+catches
+    : CATCH LPAREN ct += expression? (PIPE ct += expression)* VAR? ex = expression RPAREN normalStatementBlock
+    ;
 
 // finally {}
-finally_: FINALLY statementBlock;
-
-/*
- foo.bar.Baz
- or...
- "foo.bar.Baz"
- */
-catchType: stringLiteral | fqn;
+finallyBlock: FINALLY normalStatementBlock
+    ;
 
 /*
  "foo"
  or...
  'foo'
  */
-stringLiteral:
-	OPEN_QUOTE (stringLiteralPart | ICHAR (expression) ICHAR)* CLOSE_QUOTE;
+stringLiteral: OPEN_QUOTE (stringLiteralPart | ICHAR (expression) ICHAR)* CLOSE_QUOTE
+    ;
 
-stringLiteralPart: STRING_LITERAL | HASHHASH;
-
-// 42
-integerLiteral: INTEGER_LITERAL;
-
-// 3.14159
-floatLiteral:
-	FLOAT_LITERAL
-	| floatLiteralDecimalOnly
-	| FLOAT_LITERAL_DECIMAL_ONLY_E_NOTATION;
-
-floatLiteralDecimalOnly: FLOAT_LITERAL_DECIMAL_ONLY;
-
-// true | false
-booleanLiteral: TRUE | FALSE;
-
-// [1,2,3]
-arrayExpression: LBRACKET arrayValues? RBRACKET;
-
-// value, value, value
-arrayValues: expression (COMMA expression)* COMMA?;
+stringLiteralPart: STRING_LITERAL | HASHHASH
+    ;
 
 // { foo: "bar", baz = "bum" }
-structExpression:
-	LBRACE structMembers? RBRACE
-	| LBRACKET structMembers RBRACKET
-	| LBRACKET (COLON | EQUALSIGN) RBRACKET;
+structExpression
+    : LBRACE structMembers? RBRACE
+    | LBRACKET structMembers RBRACKET
+    | LBRACKET (COLON | EQUALSIGN) RBRACKET
+    ;
 
-structMembers: structMember (COMMA structMember)* COMMA?;
+structMembers: structMember (COMMA structMember)* COMMA?
+    ;
 
 /*
- foo.bar : baz
  foo : bar
  42 : bar
  "foo" : bar
  */
-structMember:
-	structKeyFqn (COLON | EQUALSIGN) expression
-	| structKeyIdentifer (COLON | EQUALSIGN) expression
-	| integerLiteral ( COLON | EQUALSIGN) expression
-	| stringLiteral (COLON | EQUALSIGN) expression;
+structMember: structKey (COLON | EQUALSIGN) expression
+    ;
 
-// Like an identifer, but allows a number in front
-structKeyIdentifer: integerLiteral? identifier;
+structKey:  structKeyIdentifer | fqn | stringLiteral | INTEGER_LITERAL
+    ;
 
-// foo.bar.Baz
-structKeyFqn: (identifier DOT)+ identifier;
+// Like an identifer, but allows a number in front... sigh
+structKeyIdentifer: INTEGER_LITERAL? identifier
+    ;
 
-// +foo -bar b~baz
-unary: (MINUS | PLUS) expression;
-
-// new java:String( param1 )
-new:
-	NEW (identifier COLON)? (fqn | stringLiteral) LPAREN argumentList? RPAREN;
+new: NEW preFix? (fqn | stringLiteral) LPAREN argumentList? RPAREN
+    ;
 
 // foo.bar.Baz
-fqn: (identifier DOT)* identifier;
+fqn: (identifier DOT)* identifier
+    ;
 
-// ternary and non-ternary are broken out to handle nested ternarys correctly assignment is
-// DUPLICATED inside of expression and this is correct and desired
-expression: assignment | ternary | notTernaryExpression;
+expressionStatement
+    : anonymousFunction # exprStatAnonymousFunction // function() {} or () => {} or () -> {}
+    | el2               # exprStatInvocable
+    ;
 
-// foo ? bar : baz
-ternary: notTernaryExpression QM expression COLON expression;
+// This is used to allow for headless access to a component, such as .foo.bar.baz, which is not allowed
+// as standalone statement. Without this separation there is too much ambiguity in things like
+// param foo.bar = "baz";
+// which will allow .bar = baz to be a separate statement and think param foo is a component
+expression
+    : anonymousFunction                             # exprAnonymousFunction // function() {} or () => {} or () -> {}
+    | el2                                           # invocable
+    | DOT identifier (LPAREN argumentList? RPAREN)? # exprHeadless
+    ;
 
-// All other expressions other than ternary
-notTernaryExpression:
-	// foo = bar
-	assignment
-	// null
-	| NULL
-	| anonymousFunction
-	| notOrBang notTernaryExpression
-	| staticAccessExpression
-	| accessExpression
-	| unary
-	| pre = PLUSPLUS notTernaryExpression
-	| pre = MINUSMINUS notTernaryExpression
-	| notTernaryExpression post = PLUSPLUS
-	| notTernaryExpression post = MINUSMINUS
-	| ICHAR notTernaryExpression ICHAR // #expression# outside of a string
-	| notTernaryExpression ( POWER) notTernaryExpression
-	| notTernaryExpression (
-		STAR
-		| SLASH
-		| PERCENT
-		| MOD
-		| BACKSLASH
-	) notTernaryExpression
-	| notTernaryExpression (PLUS | MINUS) notTernaryExpression
-	| notTernaryExpression XOR notTernaryExpression
-	| left = notTernaryExpression AMPERSAND right = notTernaryExpression
-	| notTernaryExpression (
-		eq
-		| gte
-		| gt
-		| lte
-		| lt
-		| neq
-		| EQV
-		| IMP
-		| CONTAINS
-		| NOT CONTAINS
-		| TEQ
-	) notTernaryExpression // Comparision
-	| notTernaryExpression ELVIS notTernaryExpression // Elvis operator
-	| notTernaryExpression IS notTernaryExpression // IS operator
-	| notTernaryExpression DOES NOT CONTAIN notTernaryExpression
-	| notTernaryExpression and notTernaryExpression
-	| notTernaryExpression or notTernaryExpression;
-// Logical
+// Universal expression rule. This is the top level rule for all expressions. It's left recursive, covers
+// precedence, implements precedence climbing, and handles all other expressions. This is the only rule needed for
+// all expressions.
+//
+// Precedence is implemented here by placing the highest precedence expressions at the top of the rule, and the very
+// lowest at the bottom. This is a form of precedence climbing, which is what ANTLR ends up genmerating, but
+// it saves us from teh tedious manual expansion required of LL grammars and looks more like the LALR grammars
+// that yacc/bison process.
+//
+// Note the use of labels allows our visitor to know what it is visiting without complicated token checking etc
+el2
+    : LPAREN expression RPAREN                                              # exprPrecedence
+    | new                                                                   # exprNew          // new foo.bar.Baz()
+    | el2 LPAREN argumentList? RPAREN                                       # exprFunctionCall // foo(bar, baz)
+    | el2 QM? DOT el2                                                       # exprDotAccess    // xc.y?.z.recursive
+    | el2 QM? DOT_FLOAT_LITERAL                                             # exprDotFloat     // xc.y?.z.recursive
+    | el2 LBRACKET expression RBRACKET                                      # exprArrayAccess  // foo[bar]
+    | <assoc = right> op = (NOT | BANG | MINUS | PLUS) el2                  # exprUnary        //  !foo, -foo, +foo
+    | <assoc = right> op = (PLUSPLUS | MINUSMINUS | BITWISE_COMPLEMENT) el2 # exprPrefix       // ++foo, --foo, ~foo
+    | el2 op = (PLUSPLUS | MINUSMINUS)                                      # exprPostfix      // foo++, bar--
+    | el2 COLONCOLON el2                                                    # exprStaticAccess // foo::bar
+    | el2 POWER el2                                                         # exprPower        // foo ^ bar
+    | el2 op = (STAR | SLASH | PERCENT | MOD | BACKSLASH) el2               # exprMult         // foo * bar
+    | el2 op = (PLUS | MINUS) el2                                           # exprAdd          // foo + bar
+    | el2 XOR el2                                                           # exprXor          // foo XOR bar
+    | el2 AMPERSAND el2                                                     # exprCat          // foo & bar - string concatenation
+    | el2 binOps el2                                                        # exprBinary       // foo eqv bar
+    | el2 relOps el2                                                        # exprRelational   // foo > bar
+    | el2 (EQ | EQUAL | EQEQ | IS) el2                                      # exprEqual        // foo == bar
+    | el2 ELVIS el2                                                         # exprElvis        // Elvis operator
+    | el2 DOES NOT CONTAIN el2                                              # exprNotContains  // foo DOES NOT CONTAIN bar
+    | el2 (AND | AMPAMP) el2                                                # exprAnd          // foo AND bar
+    | el2 (OR | PIPEPIPE) el2                                               # exprOr           // foo OR bar
 
-and: AND | AMPAMP;
+    // Ternary operations are right associative, which means that if they are nested,
+    // the rightmost operation is evaluated first.
+    | <assoc = right> el2 QM el2 COLON el2 # exprTernary // foo ? bar : baz
+    | atoms                                # exprAtoms   // foo, 42, true, false, null, [1,2,3], {foo:bar}
 
-eq: EQ | EQUAL | EQEQ;
+    // el2 elements that have no operators so will be selected in order other than LL(*) solving
+    | ICHAR el2 ICHAR # exprOutString    // #el2# not within a string literal
+    | literals        # exprLiterals     // "bar", [1,2,3], {foo:bar}
+    | arrayLiteral    # exprArrayLiteral // [1,2,3]
+    // Evaluate assign here so that we can assign the result of an el2 to a variable
+    | el2 op = (
+        EQUALSIGN
+        | PLUSEQUAL
+        | MINUSEQUAL
+        | STAREQUAL
+        | SLASHEQUAL
+        | MODEQUAL
+        | CONCATEQUAL
+    ) expression                                 # exprAssign     // foo = bar
+    | { isVar(_input) }? varModifier+ expression # exprVarDecl    // var foo = bar
+    | identifier                                 # exprIdentifier // foo
+    ;
 
-gt: GT | GTSIGN | GREATER THAN;
+// Use this instead of redoing it as arrayValues, arguments etc.
+expressionList: expression (COMMA expression)* COMMA?
+    ;
 
-gte:
-	GTE
-	| GE
-	| GTESIGN
-	| GREATER THAN OR EQ TO
-	| GREATER THAN OR EQUAL TO;
-
-lt: LT | LTSIGN | LESS THAN;
-
-lte:
-	LTE
-	| LE
-	| LTESIGN
-	| LESS THAN OR EQ TO
-	| LESS THAN OR EQUAL TO;
-
-neq: NEQ | IS NOT | BANGEQUAL | LESSTHANGREATERTHAN;
-
-notOrBang: NOT | BANG;
-
-or: OR | PIPEPIPE;
+atoms: a = (NULL | TRUE | FALSE | INTEGER_LITERAL | FLOAT_LITERAL | DOT_FLOAT_LITERAL)
+    ;
 
 // All literal expressions
-literalExpression:
-	integerLiteral
-	| floatLiteral
-	| stringLiteral
-	| booleanLiteral
-	| structExpression
-	| arrayExpression;
+literals: stringLiteral | structExpression
+    ;
 
-// These can be the "start" an access expression. Basically, you need one of these in order to chain
-// dotAccess, arrayAccess, methodInvokation, etc. Note some expressions can't have access slapped
-// onto them unless they are contained in parens. i.e. (1 + 2).toString() since 1 + 2.toString()
-// would mean something totally different.
-objectExpression:
-	LPAREN expression RPAREN
-	| functionInvokation
-	| literalExpression
-	| new
-	| identifier;
+// Relational operators as their own rule so we can have the visitor generate theAST
+relOps
+    : LESS THAN OR (EQ | EQUAL) TO
+    | GREATER THAN OR (EQ | EQUAL) TO
+    | GREATER THAN
+    | GT
+    | GTSIGN
+    | GTE
+    | GE
+    | GTESIGN
+    | TEQ
+    | LTE
+    | LE
+    | LTESIGN
+    | LT
+    | LTSIGN
+    | LESS THAN
+    | NEQ
+    | IS NOT
+    | BANGEQUAL
+    | LESSTHANGREATERTHAN
+    ;
 
-staticObjectExpression: identifier | fqn;
+binOps: EQV | IMP | CONTAINS | NOT CONTAINS
+    ;
 
-// "access" an expression with array notation (doesn't mean the object is an array per se)
-arrayAccess: LBRACKET expression RBRACKET;
-
-// "access" an expression with dot notation
-dotAccess: QM? ((DOT identifier) | floatLiteralDecimalOnly);
-
-// "access" an expression with static notation obj::field or obj::123
-staticAccess: COLONCOLON (identifier | integerLiteral);
-
-// invoke a method on an expression as obj.foo() or obj["foo"]()
-methodInvokation:
-	QM? DOT functionInvokation
-	| arrayAccess invokationExpression;
-
-// invoke a static method on an expression as obj::foo()
-staticMethodInvokation: COLONCOLON functionInvokation;
-
-// a top level function which must be an identifier
-functionInvokation: identifier invokationExpression;
-
-// Used to invoke an expression as a function
-invokationExpression: LPAREN argumentList? RPAREN;
-
-// Access expressions represent any expression which can be "accessed" in some way by directly
-// chaining method invokation, dot access, array access, etc. This rule is recursive, matching any
-// number of chained access expressions. This is important to avoid recsion in the grammar.
-accessExpression:
-	objectExpression (
-		methodInvokation
-		| dotAccess
-		| arrayAccess
-		| invokationExpression
-	)*;
-
-staticAccessExpression:
-	staticObjectExpression (
-		staticAccess
-		| staticMethodInvokation
-	);
-
-// foo="bar" baz="bum" qux
-componentAttributes: (componentAttribute)*;
-
-componentAttribute:
-	identifier ((EQUALSIGN | COLON) expression)?;
-
-// foo="bar", baz="bum"
-delimitedComponentAttributes: (componentAttribute) (
-		COMMA? componentAttribute
-	)*;
-
-component:
-	// http url="google.com" {}
-	(componentName componentAttributes statementBlock)
-	// http url="google.com";
-	| (componentName componentAttributes eos)
-	// cfhttp( url="google.com", timeout=20 ){}   -- Only needed for CF parser
-	| (
-		prefixedIdentifier LPAREN delimitedComponentAttributes RPAREN statementBlock
-	)
-	// cfhttp( url="google.com", timeout=20 )   -- Only needed for CF parser
-	| (
-		prefixedIdentifier LPAREN delimitedComponentAttributes RPAREN
-	)
-	// cfhttp( url="google.com" timeout=20 ){}   -- Only needed for CF parser
-	| (
-		prefixedIdentifier LPAREN componentAttributes RPAREN statementBlock
-	)
-	// cfhttp( url="google.com" timeout=20 )   -- Only needed for CF parser
-	| (prefixedIdentifier LPAREN componentAttributes RPAREN);
+preFix: identifier COLON
+    ;

--- a/src/main/antlr/CFScriptLexer.g4
+++ b/src/main/antlr/CFScriptLexer.g4
@@ -1,11 +1,25 @@
 lexer grammar CFScriptLexer;
 
+// $antlr-format alignTrailingComments true
+// $antlr-format maxEmptyLinesToKeep 1
+// $antlr-format columnLimit 150
+// $antlr-format reflowComments false
+// $antlr-format useTab false
+// $antlr-format allowShortRulesOnASingleLine true
+// $antlr-format allowShortBlocksOnASingleLine true
+// $antlr-format allowShortBlocksOnASingleLine true
+// $antlr-format minEmptyLines 0
+// $antlr-format alignSemicolons ownLine
+// $antlr-format alignColons trailing
+// $antlr-format singleLineOverrulesHangingColon true
+// $antlr-format alignLexerCommands true
+// $antlr-format alignLabels true
+// $antlr-format alignTrailers true
 options {
-	caseInsensitive = true;
+    caseInsensitive = true;
 }
 
 @members {
-
 	private int countModes(int mode) {
 		int count = 0;
 		for ( int m : _modeStack.toArray() ) {
@@ -17,192 +31,189 @@ options {
 	}
 }
 
-ABSTRACT: 'ABSTRACT';
-ANY: 'ANY';
-ARRAY: 'ARRAY';
-AS: 'AS';
-BOOLEAN: 'BOOLEAN';
-BREAK: 'BREAK';
-CASE: 'CASE';
-CASTAS: 'CASTAS';
-CATCH: 'CATCH';
-CONTAIN: 'CONTAIN';
-CONTAINS: 'CONTAINS';
-CONTINUE: 'CONTINUE';
-DEFAULT: 'DEFAULT';
-DO: 'DO';
-DOES: 'DOES';
-ELSE: 'ELSE';
-ELSEIF: 'ELSEIF';
-EQV: 'EQV';
-FALSE: 'FALSE';
-FINALLY: 'FINALLY';
-FINAL: 'FINAL';
-FOR: 'FOR';
-FUNCTION: 'FUNCTION';
-GREATER: 'GREATER';
-IF: 'IF';
-IMP: 'IMP';
-IMPORT: 'IMPORT';
-IN: 'IN';
-INCLUDE: 'INCLUDE';
-INSTANCEOF: 'INSTANCEOF';
-INTERFACE: 'INTERFACE';
-IS: 'IS';
-JAVA: 'JAVA';
-LESS: 'LESS';
-MESSAGE: 'MESSAGE';
-MOD: 'MOD';
-NEW: 'NEW';
-NULL: 'NULL';
-NUMERIC: 'NUMERIC';
-PARAM: 'PARAM';
-PACKAGE: 'PACKAGE';
-PRIVATE: 'PRIVATE';
-PROPERTY: 'PROPERTY';
-PUBLIC: 'PUBLIC';
-QUERY: 'QUERY';
-REMOTE: 'REMOTE';
-REQUIRED: 'REQUIRED';
-RETHROW: 'RETHROW';
-RETURN: 'RETURN';
-REQUEST: 'REQUEST';
-SERVER: 'SERVER';
-SETTING: 'SETTING';
-STATIC: 'STATIC';
-STRING: 'STRING';
-STRUCT: 'STRUCT';
-SWITCH: 'SWITCH';
-THAN: 'THAN';
-THROW: 'THROW';
-TO: 'TO';
-TRUE: 'TRUE';
-TRY: 'TRY';
-TYPE: 'TYPE';
-VAR: 'VAR';
-VARIABLES: 'VARIABLES';
-WHEN: 'WHEN';
-WHILE: 'WHILE';
-XOR: 'XOR';
+ABSTRACT   : 'ABSTRACT';
+ANY        : 'ANY';
+ARRAY      : 'ARRAY';
+AS         : 'AS';
+BOOLEAN    : 'BOOLEAN';
+BREAK      : 'BREAK';
+CASE       : 'CASE';
+CASTAS     : 'CASTAS';
+CATCH      : 'CATCH';
+CONTAIN    : 'CONTAIN';
+CONTAINS   : 'CONTAINS';
+CONTINUE   : 'CONTINUE';
+DEFAULT    : 'DEFAULT';
+DO         : 'DO';
+DOES       : 'DOES';
+ELSEIF     : 'ELSEIF';
+ELSE       : 'ELSE';
+EQV        : 'EQV';
+FALSE      : 'FALSE';
+FINAL      : 'FINAL';
+FINALLY    : 'FINALLY';
+FOR        : 'FOR';
+FUNCTION   : 'FUNCTION';
+GREATER    : 'GREATER';
+IF         : 'IF';
+IMP        : 'IMP';
+IMPORT     : 'IMPORT';
+IN         : 'IN';
+INCLUDE    : 'INCLUDE';
+INSTANCEOF : 'INSTANCEOF';
+INTERFACE  : 'INTERFACE';
+IS         : 'IS';
+JAVA       : 'JAVA';
+LESS       : 'LESS';
+MESSAGE    : 'MESSAGE';
+MOD        : 'MOD';
+NEW        : 'NEW';
+NULL       : 'NULL';
+NUMERIC    : 'NUMERIC';
+PARAM      : 'PARAM';
+PACKAGE    : 'PACKAGE';
+PRIVATE    : 'PRIVATE';
+PROPERTY   : 'PROPERTY';
+PUBLIC     : 'PUBLIC';
+QUERY      : 'QUERY';
+REMOTE     : 'REMOTE';
+REQUIRED   : 'REQUIRED';
+RETHROW    : 'RETHROW';
+RETURN     : 'RETURN';
+REQUEST    : 'REQUEST';
+SERVER     : 'SERVER';
+SETTING    : 'SETTING';
+STATIC     : 'STATIC';
+STRING     : 'STRING';
+STRUCT     : 'STRUCT';
+SWITCH     : 'SWITCH';
+THAN       : 'THAN';
+THROW      : 'THROW';
+TO         : 'TO';
+TRUE       : 'TRUE';
+TRY        : 'TRY';
+TYPE       : 'TYPE';
+VAR        : 'VAR';
+VARIABLES  : 'VARIABLES';
+WHEN       : 'WHEN';
+WHILE      : 'WHILE';
+XOR        : 'XOR';
 
-CLASS_NAME: 'COMPONENT';
+COMPONENT: 'COMPONENT';
 
-AND: 'AND';
-AMPAMP: '&&';
+AND    : 'AND';
+AMPAMP : '&&';
 
-EQ: 'EQ';
-EQUAL: 'EQUAL';
-EQEQ: '==';
+EQ    : 'EQ';
+EQUAL : 'EQUAL';
+EQEQ  : '==';
 
-GT: 'GT';
-GTSIGN: '>';
+GT     : 'GT';
+GTSIGN : '>';
 
-GTE: 'GTE';
-GE: 'GE';
-GTESIGN: '>=';
+GTE     : 'GTE';
+GE      : 'GE';
+GTESIGN : '>=';
 
-LT: 'LT';
-LTSIGN: '<';
+LT     : 'LT';
+LTSIGN : '<';
 
-LTE: 'LTE';
-LE: 'LE';
-LTESIGN: '<=';
+LTE     : 'LTE';
+LE      : 'LE';
+LTESIGN : '<=';
 
-NEQ: 'NEQ';
-BANGEQUAL: '!=';
-LESSTHANGREATERTHAN: '<>';
+NEQ                 : 'NEQ';
+BANGEQUAL           : '!=';
+LESSTHANGREATERTHAN : '<>';
 
-NOT: 'NOT';
-BANG: '!';
+NOT  : 'NOT';
+BANG : '!';
 
-OR: 'OR';
-PIPEPIPE: '||';
+OR       : 'OR';
+PIPEPIPE : '||';
 
-AMPERSAND: '&';
-ARROW: '->';
-AT: '@';
-BACKSLASH: '\\';
-COMMA: ',';
-COLON: ':';
-COLONCOLON: '::';
-DOT: '.';
-ELVIS: '?:';
-EQUALSIGN: '=';
-LBRACE: '{';
-RBRACE: '}';
-LPAREN: '(';
-RPAREN: ')';
-LBRACKET: '[';
-RBRACKET: ']';
-ARROW_RIGHT: '=>';
-MINUS: '-';
-MINUSMINUS: '--';
-PIPE: '|';
-PERCENT: '%';
-POWER: '^';
-QM: '?';
-SEMICOLON: ';';
-SLASH: '/';
-STAR: '*';
-CONCATEQUAL: '&=';
-PLUSEQUAL: '+=';
-MINUSEQUAL: '-=';
-STAREQUAL: '*=';
-SLASHEQUAL: '/=';
-MODEQUAL: '%=';
-PLUS: '+';
-PLUSPLUS: '++';
-TEQ: '===';
-PREFIX: 'CF';
+AMPERSAND   : '&';
+ARROW       : '->';
+AT          : '@';
+BACKSLASH   : '\\';
+COMMA       : ',';
+COLON       : ':';
+COLONCOLON  : '::';
+DOT         : '.';
+ELVIS       : '?:';
+EQUALSIGN   : '=';
+LBRACE      : '{';
+RBRACE      : '}';
+LPAREN      : '(';
+RPAREN      : ')';
+LBRACKET    : '[';
+RBRACKET    : ']';
+ARROW_RIGHT : '=>';
+MINUS       : '-';
+MINUSMINUS  : '--';
+PIPE        : '|';
+PERCENT     : '%';
+POWER       : '^';
+QM          : '?';
+SEMICOLON   : ';';
+SLASH       : '/';
+STAR        : '*';
+CONCATEQUAL : '&=';
+PLUSEQUAL   : '+=';
+MINUSEQUAL  : '-=';
+STAREQUAL   : '*=';
+SLASHEQUAL  : '/=';
+MODEQUAL    : '%=';
+PLUS        : '+';
+PLUSPLUS    : '++';
+TEQ         : '===';
 
 // BITWISE OPERATORS
-BITWISE_OR: 'b|';
-BITWISE_AND: 'b&';
-BITWISE_XOR: 'b^';
-BITWISE_COMPLEMENT: 'b~';
-BITWISE_SIGNED_LEFT_SHIFT: 'b<<';
-BITWISE_SIGNED_RIGHT_SHIFT: 'b>>';
-BITWISE_UNSIGNED_RIGHT_SHIFT: 'b>>>';
+BITWISE_OR                   : 'b|';
+BITWISE_AND                  : 'b&';
+BITWISE_XOR                  : 'b^';
+BITWISE_COMPLEMENT           : 'b~';
+BITWISE_SIGNED_LEFT_SHIFT    : 'b<<';
+BITWISE_SIGNED_RIGHT_SHIFT   : 'b>>';
+BITWISE_UNSIGNED_RIGHT_SHIFT : 'b>>>';
+
+// This totally should not be allowed in script, but Lucee allows it and it's in code :/
+
+TAG_COMMENT_START: '<!---' -> pushMode(TAG_COMMENT), channel(HIDDEN);
 
 // ANY NEW LEXER RULES FOR AN ENGLISH WORD NEEDS ADDED TO THE identifer RULE IN THE PARSER
 
-ICHAR_1:
-	'#' {_modeStack.contains(hashMode)}? -> type(ICHAR), popMode, popMode;
-ICHAR: '#';
+ICHAR_1 : '#' {_modeStack.contains(hashMode)}? -> type(ICHAR), popMode, popMode;
+ICHAR   : '#';
 
-WS: (' ' | '\t' | '\f')+ -> channel(HIDDEN);
-NEWLINE: ('\n' | '\r')+ (' ' | '\t' | '\f' | '\n' | '\r')* -> channel(HIDDEN);
-JAVADOC_COMMENT: '/**' .*? '*/' -> channel(HIDDEN);
+WS              : (' ' | '\t' | '\f')+                              -> channel(HIDDEN);
+NEWLINE         : ('\n' | '\r')+ (' ' | '\t' | '\f' | '\n' | '\r')* -> channel(HIDDEN);
+JAVADOC_COMMENT : '/**' .*? '*/'                                    -> channel(HIDDEN);
 
 COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
 
 LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
 
-// This totally should not be allowed in script, but Lucee allows it and it's in code :/ 
-
-TAG_COMMENT_START:
-	'<!---' -> pushMode(TAG_COMMENT), channel(HIDDEN);
-
 OPEN_QUOTE: '"' -> pushMode(quotesMode);
 
 OPEN_SINGLE: '\'' -> type(OPEN_QUOTE), pushMode(squotesMode);
 
-fragment DIGIT: [0-9];
-fragment E_SIGN: [e];
-fragment E_NOTATION: E_SIGN [+-]? DIGIT+;
-FLOAT_LITERAL:
-	DIGIT+ DOT DIGIT* (E_NOTATION)?
-	| DIGIT+ E_NOTATION;
+fragment DIGIT     : [0-9];
+fragment DOT_FLOAT : '.' DIGIT+ ([e] [+-]? DIGIT+)? | DIGIT+ [e] [+-]? DIGIT+;
+FLOAT_LITERAL      : DIGIT+ DOT_FLOAT;
+DOT_FLOAT_LITERAL  : DOT_FLOAT;
+INTEGER_LITERAL    : DIGIT+;
 
-FLOAT_LITERAL_DECIMAL_ONLY_E_NOTATION: DOT DIGIT+ E_NOTATION;
-
-FLOAT_LITERAL_DECIMAL_ONLY: DOT DIGIT+;
-
-INTEGER_LITERAL: DIGIT+;
-PREFIXEDIDENTIFIER: PREFIX IDENTIFIER;
-IDENTIFIER: [a-z_$]+ ( [_]+ | [a-z]+ | DIGIT)*;
+fragment ID_BODY   : [a-z_$]+ ( [_]+ | [a-z]+ | DIGIT)*;
+PREFIXEDIDENTIFIER : 'CF' ID_BODY;
+IDENTIFIER         : ID_BODY;
 
 COMPONENT_ISLAND_START: '```' -> pushMode(componentIsland);
+
+// Any character that is not matched in any other rule is an error.
+// However, we don't want the lexer to throw an error, we want the parser to
+// throw an error. So, we eat bad characters into their own token
+BADC: .;
 
 // *********************************************************************************************************************
 
@@ -211,45 +222,38 @@ mode TAG_COMMENT;
 // If we reach an "ending" comment, but there are 2 or more TAG_COMMENT modes on the stack, this is
 // just the end of a nested comment so we emit a TAG_COMMENT_TEXT token instead.
 TAG_COMMENT_END_BUT_NOT_REALLY:
-	'--->' {countModes(TAG_COMMENT) > 1}? -> type(TAG_COMMENT_TEXT), popMode, channel(HIDDEN);
+    '--->' {countModes(TAG_COMMENT) > 1}? -> type(TAG_COMMENT_TEXT), popMode, channel(HIDDEN)
+;
 
 TAG_COMMENT_END: '--->' -> popMode, channel(HIDDEN);
 
 TAG_COMMENT_START2:
-	'<!---' -> pushMode(TAG_COMMENT), type(TAG_COMMENT_START), channel(HIDDEN);
+    '<!---' -> pushMode(TAG_COMMENT), type(TAG_COMMENT_START), channel(HIDDEN)
+;
 
 TAG_COMMENT_TEXT: .+? -> channel(HIDDEN);
 
 // *********************************************************************************************************************
 
 mode componentIsland;
-
-COMPONENT_ISLAND_END: '```' -> popMode;
-
-COMPONENT_ISLAND_BODY: .+?;
+COMPONENT_ISLAND_END  : '```' -> popMode;
+COMPONENT_ISLAND_BODY : .+?;
 
 // *********************************************************************************************************************
 
 mode squotesMode;
-CLOSE_SQUOTE: '\'' -> type(CLOSE_QUOTE), popMode;
-
-SHASHHASH: '##' -> type(HASHHASH);
-
-SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
-
-SHASH:
-	'#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
+CLOSE_SQUOTE    : '\''               -> type(CLOSE_QUOTE), popMode;
+SHASHHASH       : '##'               -> type(HASHHASH);
+SSTRING_LITERAL : (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
+SHASH           : '#'                -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
 
 // *********************************************************************************************************************
 
 mode quotesMode;
-CLOSE_QUOTE: '"' -> popMode;
-
-HASHHASH: '##';
-STRING_LITERAL: (~["#]+ | '""')+;
-
-HASH:
-	'#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
+CLOSE_QUOTE    : '"' -> popMode;
+HASHHASH       : '##';
+STRING_LITERAL : (~["#]+ | '""')+;
+HASH           : '#' -> type(ICHAR), pushMode(hashMode), pushMode(DEFAULT_MODE);
 
 // *********************************************************************************************************************
 

--- a/src/main/antlr/CFTemplateGrammar.g4
+++ b/src/main/antlr/CFTemplateGrammar.g4
@@ -1,7 +1,10 @@
+
+
+
 parser grammar CFTemplateGrammar;
 
 options {
-	tokenVocab = CFTemplateLexer;
+    tokenVocab = CFTemplateLexer;
 }
 
 // Top-level template rule.  Consists of imports and other statements.
@@ -9,67 +12,77 @@ template: statements EOF?;
 
 // Top-level class or interface rule.
 classOrInterface:
-	// Leading text will be ignored
-	textContent* (
-		component
-		| interface
-		| (whitespace? script whitespace?)
-	) EOF?;
+    // Leading text will be ignored
+    textContent* (
+        component
+        | interface
+        | (whitespace? script whitespace?)
+    ) EOF?
+;
 
 // <b>My Name is #qry.name#.</b> We can match as much non interpolated text but we need each
 // interpolated expression to be its own rule to ensure they output in the right order.
 textContent: (nonInterpolatedText | comment)+
-	| ( comment* interpolatedExpression comment*);
+    | ( comment* interpolatedExpression comment*)
+;
 
 // <!--- comment ---> or <!--- comment <!--- nested comment ---> comment --->
 comment:
-	COMMENT_START (COMMENT_TEXT | COMMENT_START)* COMMENT_END;
+    COMMENT_START (COMMENT_TEXT | COMMENT_START)* COMMENT_END
+;
 
 // ANYTHING
 componentName: COMPONENT_NAME;
 
 // <cfANYTHING ... >
 genericOpenComponent:
-	COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_CLOSE;
+    COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_CLOSE
+;
 
 // <cfANYTHING />
 genericOpenCloseComponent:
-	COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_SLASH_CLOSE;
+    COMPONENT_OPEN PREFIX componentName attribute* COMPONENT_SLASH_CLOSE
+;
 
 // </cfANYTHING>
 genericCloseComponent:
-	COMPONENT_OPEN SLASH_PREFIX componentName COMPONENT_CLOSE;
+    COMPONENT_OPEN SLASH_PREFIX componentName COMPONENT_CLOSE
+;
 
 // #bar#
 interpolatedExpression: ICHAR expression ICHAR;
 // Any text to be directly output
-nonInterpolatedText: (COMPONENT_OPEN | CONTENT_TEXT | whitespace)+;
+nonInterpolatedText: (COMPONENT_OPEN | CONTENT_TEXT | whitespace)+
+;
 
 whitespace: WS+;
 // bar or 1+2. The lexer keeps strings together so it doesnt end the expression prematurely
 expression: (EXPRESSION_PART | quotedString)+;
 
 attribute:
-	// foo="bar" foo=bar
-	attributeName COMPONENT_EQUALS attributeValue?
-	// foo (value will default to empty string)
-	| attributeName;
+    // foo="bar" foo=bar
+    attributeName COMPONENT_EQUALS attributeValue?
+    // foo (value will default to empty string)
+    | attributeName
+;
 
 // any attributes once we've gotten past the component name
 attributeName: ATTRIBUTE_NAME;
 
 // foo or.... "foo" or... 'foo' or... "#foo#" or... #foo#
 attributeValue:
-	unquotedValue
-	| quotedString
-	| interpolatedExpression;
+    unquotedValue
+    | quotedString
+    | interpolatedExpression
+;
 
 // foo
 unquotedValue: UNQUOTED_VALUE_PART+;
 
 // "text#expression#text" or ... 'text#expression#text'
 quotedString:
-	OPEN_QUOTE (quotedStringPart | interpolatedExpression)* CLOSE_QUOTE;
+    OPEN_QUOTE (quotedStringPart | interpolatedExpression)* CLOSE_QUOTE
+;
 
 quotedStringPart: STRING_LITERAL | HASHHASH;
 
@@ -77,77 +90,84 @@ quotedStringPart: STRING_LITERAL | HASHHASH;
 statements: (statement | script | textContent)*;
 
 statement:
-	boxImport
-	| function
-	// <cfANYTHING />
-	| genericOpenCloseComponent
-	// <cfANYTHING ... >
-	| genericOpenComponent
-	// </cfANYTHING>
-	| genericCloseComponent
-	| set
-	| return
-	| if
-	| try
-	| output
-	| while
-	| break
-	| continue
-	| include
-	| rethrow
-	| throw
-	| switch;
+    boxImport
+    | function
+    // <cfANYTHING />
+    | genericOpenCloseComponent
+    // <cfANYTHING ... >
+    | genericOpenComponent
+    // </cfANYTHING>
+    | genericCloseComponent
+    | set
+    | return
+    | if
+    | try
+    | output
+    | while
+    | break
+    | continue
+    | include
+    | rethrow
+    | throw
+    | switch
+;
 
 component:
-	(whitespace | comment)* (boxImport (whitespace | comment)*)*
-	// <cfcomponent ... >
-	COMPONENT_OPEN PREFIX COMPONENT attribute* COMPONENT_CLOSE
-	// <cfproperty name="..."> (zero or more)
-	((whitespace | comment)* property)*
-	// code in pseudo-constructor
-	statements
-	// </cfcomponent>
-	COMPONENT_OPEN SLASH_PREFIX COMPONENT COMPONENT_CLOSE textContent*;
+    (whitespace | comment)* (boxImport (whitespace | comment)*)*
+    // <cfcomponent ... >
+    COMPONENT_OPEN PREFIX COMPONENT attribute* COMPONENT_CLOSE
+    // <cfproperty name="..."> (zero or more)
+    ((whitespace | comment)* property)*
+    // code in pseudo-constructor
+    statements
+    // </cfcomponent>
+    COMPONENT_OPEN SLASH_PREFIX COMPONENT COMPONENT_CLOSE textContent*
+;
 
 // <cfproperty name="..."> or... <cfproperty name="..." />
 property:
-	COMPONENT_OPEN PREFIX PROPERTY attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX PROPERTY attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 interface:
-	whitespace? (boxImport whitespace?)*
-	// <cfinterface ... >
-	COMPONENT_OPEN PREFIX INTERFACE attribute* COMPONENT_CLOSE
-	// Code in interface 
-	(whitespace | function | comment)*
-	// </cfinterface>
-	COMPONENT_OPEN SLASH_PREFIX INTERFACE COMPONENT_CLOSE textContent*;
+    whitespace? (boxImport whitespace?)*
+    // <cfinterface ... >
+    COMPONENT_OPEN PREFIX INTERFACE attribute* COMPONENT_CLOSE
+    // Code in interface
+    (whitespace | function | comment)*
+    // </cfinterface>
+    COMPONENT_OPEN SLASH_PREFIX INTERFACE COMPONENT_CLOSE textContent*
+;
 
 function:
-	// <cffunction name="foo" >
-	COMPONENT_OPEN PREFIX FUNCTION attribute* COMPONENT_CLOSE
-	// zero or more <cfargument ... >
-	((nonInterpolatedText | comment)* argument)* whitespace?
-	// code inside function
-	body = statements
-	// </cffunction>
-	COMPONENT_OPEN SLASH_PREFIX FUNCTION COMPONENT_CLOSE;
+    // <cffunction name="foo" >
+    COMPONENT_OPEN PREFIX FUNCTION attribute* COMPONENT_CLOSE
+    // zero or more <cfargument ... >
+    ((nonInterpolatedText | comment)* argument)* whitespace?
+    // code inside function
+    body = statements
+    // </cffunction>
+    COMPONENT_OPEN SLASH_PREFIX FUNCTION COMPONENT_CLOSE
+;
 
 argument:
-	// <cfargument name="param">
-	COMPONENT_OPEN PREFIX ARGUMENT attribute* (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    // <cfargument name="param">
+    COMPONENT_OPEN PREFIX ARGUMENT attribute* (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 set:
-	// <cfset expression> <cfset expression />
-	COMPONENT_OPEN PREFIX SET expression (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    // <cfset expression> <cfset expression />
+    COMPONENT_OPEN PREFIX SET expression (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 scriptBody: SCRIPT_BODY*;
 // <cfscript> statements... </cfscript>
@@ -162,74 +182,80 @@ script: SCRIPT_OPEN scriptBody SCRIPT_END_BODY;
  <cfreturn 20 / 7 />
  */
 return:
-	COMPONENT_OPEN PREFIX RETURN expression? (
-		COMPONENT_SLASH_CLOSE
-		| COMPONENT_CLOSE
-	);
+    COMPONENT_OPEN PREFIX RETURN expression? (
+        COMPONENT_SLASH_CLOSE
+        | COMPONENT_CLOSE
+    )
+;
 
 if:
-	// <cfif ... >`
-	COMPONENT_OPEN PREFIX IF ifCondition = expression COMPONENT_CLOSE thenBody = statements
-	// Any number of <cfelseif ... >
-	(
-		COMPONENT_OPEN PREFIX ELSEIF elseIfCondition += expression elseIfComponentClose +=
-			COMPONENT_CLOSE elseThenBody += statements
-	)*
-	// One optional <cfelse> 
-	(
-		COMPONENT_OPEN PREFIX ELSE (
-			COMPONENT_CLOSE
-			| COMPONENT_SLASH_CLOSE
-		) elseBody = statements
-	)?
-	// Closing </cfif>
-	COMPONENT_OPEN SLASH_PREFIX IF COMPONENT_CLOSE;
+    // <cfif ... >`
+    COMPONENT_OPEN PREFIX IF ifCondition = expression COMPONENT_CLOSE thenBody = statements
+    // Any number of <cfelseif ... >
+    (
+        COMPONENT_OPEN PREFIX ELSEIF elseIfCondition += expression elseIfComponentClose +=
+            COMPONENT_CLOSE elseThenBody += statements
+    )*
+    // One optional <cfelse>
+    (
+        COMPONENT_OPEN PREFIX ELSE (
+            COMPONENT_CLOSE
+            | COMPONENT_SLASH_CLOSE
+        ) elseBody = statements
+    )?
+    // Closing </cfif>
+    COMPONENT_OPEN SLASH_PREFIX IF COMPONENT_CLOSE
+;
 
 try:
-	// <cftry>
-	COMPONENT_OPEN PREFIX TRY COMPONENT_CLOSE
-	// code inside try
-	statements
-	// <cfcatch> (zero or more)
-	(catchBlock statements)*
-	// <cffinally> (zero or one)
-	finallyBlock? statements
-	// </cftry>
-	COMPONENT_OPEN SLASH_PREFIX TRY COMPONENT_CLOSE;
+    // <cftry>
+    COMPONENT_OPEN PREFIX TRY COMPONENT_CLOSE
+    // code inside try
+    statements
+    // <cfcatch> (zero or more)
+    (catchBlock statements)*
+    // <cffinally> (zero or one)
+    finallyBlock? statements
+    // </cftry>
+    COMPONENT_OPEN SLASH_PREFIX TRY COMPONENT_CLOSE
+;
 
 /*
  <cfcatch type="..."> ... </cfcatch>
  <cfcatch type="..." />
  */
 catchBlock:
-	(
-		// <cfcatch type="...">
-		COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_CLOSE
-		// code in catch
-		statements
-		// </cfcatch>
-		COMPONENT_OPEN SLASH_PREFIX CATCH COMPONENT_CLOSE
-	)
-	| COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_SLASH_CLOSE;
+    (
+        // <cfcatch type="...">
+        COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_CLOSE
+        // code in catch
+        statements
+        // </cfcatch>
+        COMPONENT_OPEN SLASH_PREFIX CATCH COMPONENT_CLOSE
+    )
+    | COMPONENT_OPEN PREFIX CATCH attribute* COMPONENT_SLASH_CLOSE
+;
 
 finallyBlock:
-	// <cffinally>
-	COMPONENT_OPEN PREFIX FINALLY COMPONENT_CLOSE
-	// code in finally 
-	statements
-	// </cffinally>
-	COMPONENT_OPEN SLASH_PREFIX FINALLY COMPONENT_CLOSE;
+    // <cffinally>
+    COMPONENT_OPEN PREFIX FINALLY COMPONENT_CLOSE
+    // code in finally
+    statements
+    // </cffinally>
+    COMPONENT_OPEN SLASH_PREFIX FINALLY COMPONENT_CLOSE
+;
 
 output:
-	// <cfoutput />
-	OUTPUT_START attribute* COMPONENT_SLASH_CLOSE
-	|
-	// <cfoutput> ... 
-	OUTPUT_START attribute* COMPONENT_CLOSE
-	// code in output
-	statements
-	// </cfoutput>
-	COMPONENT_OPEN SLASH_PREFIX OUTPUT_END;
+    // <cfoutput />
+    OUTPUT_START attribute* COMPONENT_SLASH_CLOSE
+    |
+    // <cfoutput> ...
+    OUTPUT_START attribute* COMPONENT_CLOSE
+    // code in output
+    statements
+    // </cfoutput>
+    COMPONENT_OPEN SLASH_PREFIX OUTPUT_END
+;
 
 /*
  <cfimport componentlib="..." prefix="...">
@@ -239,78 +265,87 @@ output:
  <cfimport prefix="java" name="com.foo.Bar" alias="bradLib">
  */
 boxImport:
-	COMPONENT_OPEN PREFIX IMPORT attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX IMPORT attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 while:
-	// <cfwhile condition="" >
-	COMPONENT_OPEN PREFIX WHILE attribute* COMPONENT_CLOSE
-	// code inside while
-	statements
-	// </cfwhile>
-	COMPONENT_OPEN SLASH_PREFIX WHILE COMPONENT_CLOSE;
+    // <cfwhile condition="" >
+    COMPONENT_OPEN PREFIX WHILE attribute* COMPONENT_CLOSE
+    // code inside while
+    statements
+    // </cfwhile>
+    COMPONENT_OPEN SLASH_PREFIX WHILE COMPONENT_CLOSE
+;
 
 // <cfbreak> or... <cfbreak />
 break:
-	COMPONENT_OPEN PREFIX BREAK label = attributeName? (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX BREAK label = attributeName? (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <cfcontinue> or... <cfcontinue />
 continue:
-	COMPONENT_OPEN PREFIX CONTINUE label = attributeName? (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX CONTINUE label = attributeName? (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <cfinclude template="..."> or... <cfinclude template="..." />
 include:
-	COMPONENT_OPEN PREFIX INCLUDE attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX INCLUDE attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <cfrethrow> or... <cfrethrow />
 rethrow:
-	COMPONENT_OPEN PREFIX RETHROW (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX RETHROW (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 // <cfthrow message="..." detail="..."> or... <cfthrow />
 throw:
-	COMPONENT_OPEN PREFIX THROW attribute* (
-		COMPONENT_CLOSE
-		| COMPONENT_SLASH_CLOSE
-	);
+    COMPONENT_OPEN PREFIX THROW attribute* (
+        COMPONENT_CLOSE
+        | COMPONENT_SLASH_CLOSE
+    )
+;
 
 switch:
-	// <cfswitch expression="...">
-	COMPONENT_OPEN PREFIX SWITCH attribute* COMPONENT_CLOSE
-	// <cfcase> or <cfdefaultcase> 
-	switchBody
-	// </cftry>
-	COMPONENT_OPEN SLASH_PREFIX SWITCH COMPONENT_CLOSE;
+    // <cfswitch expression="...">
+    COMPONENT_OPEN PREFIX SWITCH attribute* COMPONENT_CLOSE
+    // <cfcase> or <cfdefaultcase>
+    switchBody
+    // </cftry>
+    COMPONENT_OPEN SLASH_PREFIX SWITCH COMPONENT_CLOSE
+;
 
 switchBody: (statement | script | textContent | case)*;
 
 case:
-	(
-		// <cfcase value="...">
-		COMPONENT_OPEN PREFIX CASE attribute* COMPONENT_CLOSE
-		// code in case
-		statements
-		// </cfcase>
-		COMPONENT_OPEN SLASH_PREFIX CASE COMPONENT_CLOSE
-	)
-	| (
-		// <cfdefaultcase>
-		COMPONENT_OPEN PREFIX DEFAULTCASE COMPONENT_CLOSE
-		// code in default case
-		statements
-		// </cfdefaultcase >
-		COMPONENT_OPEN SLASH_PREFIX DEFAULTCASE COMPONENT_CLOSE
-	);
+    (
+        // <cfcase value="...">
+        COMPONENT_OPEN PREFIX CASE attribute* COMPONENT_CLOSE
+        // code in case
+        statements
+        // </cfcase>
+        COMPONENT_OPEN SLASH_PREFIX CASE COMPONENT_CLOSE
+    )
+    | (
+        // <cfdefaultcase>
+        COMPONENT_OPEN PREFIX DEFAULTCASE COMPONENT_CLOSE
+        // code in default case
+        statements
+        // </cfdefaultcase >
+        COMPONENT_OPEN SLASH_PREFIX DEFAULTCASE COMPONENT_CLOSE
+    )
+;

--- a/src/main/antlr/CFTemplateLexer.g4
+++ b/src/main/antlr/CFTemplateLexer.g4
@@ -1,7 +1,10 @@
+
+
+
 lexer grammar CFTemplateLexer;
 
 options {
-	caseInsensitive = true;
+    caseInsensitive = true;
 }
 
 @members {
@@ -80,14 +83,16 @@ WS: (' ' | '\t' | '\r'? '\n')+;
 SCRIPT_OPEN: '<cfscript' .*? '>' -> pushMode(XFSCRIPT);
 
 OUTPUT_START:
-	'<cfoutput' -> pushMode(POSSIBLE_COMPONENT), pushMode(COMPONENT_MODE), pushMode(OUTPUT_MODE);
+    '<cfoutput' -> pushMode(POSSIBLE_COMPONENT), pushMode(COMPONENT_MODE), pushMode(OUTPUT_MODE)
+;
 
 COMPONENT_OPEN: '<' -> pushMode(POSSIBLE_COMPONENT);
 
 HASHHASH: '##' -> type(CONTENT_TEXT);
 
 ICHAR:
-	'#' {_modeStack.contains(OUTPUT_MODE)}? -> pushMode(EXPRESSION_MODE_STRING);
+    '#' {_modeStack.contains(OUTPUT_MODE)}? -> pushMode(EXPRESSION_MODE_STRING)
+;
 ICHAR_1: '#' -> type(CONTENT_TEXT);
 
 CONTENT_TEXT: ~[<#]+;
@@ -98,12 +103,14 @@ mode COMMENT_MODE;
 // If we reach an "ending" comment, but there are 2 or more TAG_COMMENT modes on the stack, this is
 // just the end of a nested comment so we emit a TAG_COMMENT_TEXT token instead.
 COMMENT_END_BUT_NOT_REALLY:
-	'--->' {countModes(COMMENT_MODE) > 1}? -> type(COMMENT_TEXT), popMode;
+    '--->' {countModes(COMMENT_MODE) > 1}? -> type(COMMENT_TEXT), popMode
+;
 
 COMMENT_END: '--->' -> popMode;
 
 COMMENT_START2:
-	'<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START)
+;
 
 COMMENT_TEXT: .+?;
 
@@ -113,16 +120,20 @@ mode COMMENT_QUIET;
 // If we reach an "ending" comment, but there are 2 or more TAG_COMMENT modes on the stack, this is
 // just the end of a nested comment so we emit a TAG_COMMENT_TEXT token instead.
 COMMENT_END_BUT_NOT_REALLY_QUIET:
-	'--->' {countModes(COMMENT_QUIET) > 1}? -> type(COMMENT_TEXT), channel(HIDDEN), popMode;
+    '--->' {countModes(COMMENT_QUIET) > 1}? -> type(COMMENT_TEXT), channel(HIDDEN), popMode
+;
 
 COMMENT_END_QUIET:
-	'--->' -> popMode, channel(HIDDEN), type(COMMENT_END);
+    '--->' -> popMode, channel(HIDDEN), type(COMMENT_END)
+;
 
 COMMENT_START_QUIET:
-	'<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START)
+;
 
 COMMENT_TEXT_QUIET:
-	.+? -> type(COMMENT_TEXT), channel(HIDDEN);
+    .+? -> type(COMMENT_TEXT), channel(HIDDEN)
+;
 
 // *********************************************************************************************************************
 mode COMMENT_EXPRESSION;
@@ -130,7 +141,8 @@ mode COMMENT_EXPRESSION;
 COMMENT_END3: '--->' -> popMode, type(EXPRESSION_PART);
 
 COMMENT_START3:
-	'<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART);
+    '<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART)
+;
 
 COMMENT_TEXT2: .+? -> type(EXPRESSION_PART);
 
@@ -146,16 +158,20 @@ ARGUMENT: 'argument' -> pushMode( COMPONENT_MODE );
 
 // return may or may not have an expression, so eat any leading whitespace now so it doesn't give us an expression part that's just a space
 RETURN:
-	'return' [ \t\r\n]* -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'return' [ \t\r\n]* -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 IF:
-	'if' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'if' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 ELSE: 'else' -> pushMode( COMPONENT_MODE );
 ELSEIF:
-	'elseif' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'elseif' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 SET:
-	'set ' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT);
+    'set ' -> pushMode( COMPONENT_MODE ), pushMode(EXPRESSION_MODE_COMPONENT)
+;
 
 TRY: 'try' -> pushMode( COMPONENT_MODE );
 CATCH: 'catch' -> pushMode( COMPONENT_MODE );
@@ -173,16 +189,18 @@ CASE: 'case' -> pushMode( COMPONENT_MODE );
 DEFAULTCASE: 'defaultcase' -> pushMode( COMPONENT_MODE );
 
 COMPONENT_NAME:
-	COMPONENT_NameStartChar COMPONENT_NameChar* -> pushMode( COMPONENT_MODE );
+    COMPONENT_NameStartChar COMPONENT_NameChar* -> pushMode( COMPONENT_MODE )
+;
 
 fragment DIGIT: [0-9];
 
 fragment COMPONENT_NameChar:
-	COMPONENT_NameStartChar
-	| '_'
-	| '-'
-	| DIGIT
-	| ':';
+    COMPONENT_NameStartChar
+    | '_'
+    | '-'
+    | DIGIT
+    | ':'
+;
 
 fragment COMPONENT_NameStartChar: [a-z_];
 
@@ -191,7 +209,8 @@ mode COMPONENT_MODE;
 
 // Comments can live inside of a tag <cfTag <!--- comment ---> foo=bar >
 COMMENT_START1:
-	'<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_QUIET), channel(HIDDEN), type(COMMENT_START)
+;
 
 COMPONENT_CLOSE: '>' -> popMode, popMode, popMode;
 
@@ -208,11 +227,12 @@ COMPONENT_WHITESPACE: [ \t\r\n] -> skip;
 fragment ATTRIBUTE_DIGIT: [0-9];
 
 fragment ATTRIBUTE_NameChar:
-	ATTRIBUTE_NameStartChar
-	| '_'
-	| '-'
-	| ATTRIBUTE_DIGIT
-	| ':';
+    ATTRIBUTE_NameStartChar
+    | '_'
+    | '-'
+    | ATTRIBUTE_DIGIT
+    | ':'
+;
 
 fragment ATTRIBUTE_NameStartChar: [a-z_];
 
@@ -221,19 +241,24 @@ mode OUTPUT_MODE;
 
 // Source inside of an output tag is consumed in output mode
 COMMENT_START4:
-	'<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START);
+    '<!---' -> pushMode(COMMENT_MODE), type(COMMENT_START)
+;
 
 COMPONENT_CLOSE_OUTPUT:
-	'>' -> pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE);
+    '>' -> pushMode(DEFAULT_MODE), type(COMPONENT_CLOSE)
+;
 
 COMPONENT_SLASH_CLOSE_OUTPUT:
-	'/>' -> popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 COMPONENT_EQUALS_OUTPUT:
-	'=' -> pushMode(ATTVALUE), type(COMPONENT_EQUALS);
+    '=' -> pushMode(ATTVALUE), type(COMPONENT_EQUALS)
+;
 
 ATTRIBUTE_NAME_OUTPUT:
-	ATTRIBUTE_NameStartChar ATTRIBUTE_NameChar* -> type(ATTRIBUTE_NAME);
+    ATTRIBUTE_NameStartChar ATTRIBUTE_NameChar* -> type(ATTRIBUTE_NAME)
+;
 
 COMPONENT_WHITESPACE_OUTPUT: [ \t\r\n] -> skip;
 
@@ -245,7 +270,8 @@ COMPONENT2: 'component' -> type(COMPONENT);
 FUNCTION2: 'function' -> type(FUNCTION);
 // popping back to: POSSIBLE_COMPONENT -> DEFAULT_MODE -> OUTPUT_MODE -> COMPONENT -> POSSIBLE_COMPONENT -> DEFAULT_MODE
 OUTPUT_END:
-	'output>' -> popMode, popMode, popMode, popMode, popMode, popMode;
+    'output>' -> popMode, popMode, popMode, popMode, popMode, popMode
+;
 INTERFACE2: 'interface' -> type(INTERFACE);
 TRY2: 'try' -> type(TRY);
 CATCH2: 'catch' -> type(CATCH);
@@ -265,9 +291,11 @@ DEFAULTCASE2: 'defaultcase' -> type(DEFAULTCASE);
 COMPONENT_WHITESPACE_OUTPUT3: [ \t\r\n] -> skip;
 
 COMPONENT_NAME2:
-	COMPONENT_NameStartChar COMPONENT_NameChar* -> type(COMPONENT_NAME);
+    COMPONENT_NameStartChar COMPONENT_NameChar* -> type(COMPONENT_NAME)
+;
 COMPONENT_CLOSE2:
-	'>' -> popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 // *********************************************************************************************************************
 mode ATTVALUE;
@@ -275,27 +303,33 @@ mode ATTVALUE;
 COMPONENT_WHITESPACE_OUTPUT2: [ \t\r\n] -> skip;
 
 ICHAR20:
-	'#' -> type(ICHAR), pushMode(EXPRESSION_MODE_UNQUOTED_ATTVALUE);
+    '#' -> type(ICHAR), pushMode(EXPRESSION_MODE_UNQUOTED_ATTVALUE)
+;
 
 OPEN_QUOTE: '"' -> pushMode(quotesModeCOMPONENT);
 
 OPEN_SINGLE:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeCOMPONENT);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeCOMPONENT)
+;
 
 // If we're in a cfoutput tag, don't pop as far and stay in outut mode
 COMPONENT_CLOSE_OUTPUT2:
-	'>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, pushMode(DEFAULT_MODE), type( COMPONENT_CLOSE );
+    '>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, pushMode(DEFAULT_MODE), type( COMPONENT_CLOSE )
+;
 
 // If we're in a cfoutput tag, pop all the way out of the component
 COMPONENT_SLASH_CLOSE2:
-	'/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, type( COMPONENT_SLASH_CLOSE );
+    '/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, type( COMPONENT_SLASH_CLOSE )
+;
 
 // There may be no value, so we need to pop out of ATTVALUE if we find the end of the component
 COMPONENT_CLOSE5:
-	'>' -> popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 COMPONENT_SLASH_CLOSE3:
-	'/>' -> popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 UNQUOTED_VALUE_PART: . -> pushMode(UNQUOTED_VALUE_MODE);
 
@@ -304,24 +338,29 @@ mode UNQUOTED_VALUE_MODE;
 
 // first whitespace pops all the way out of ATTVALUE back to component mode
 COMPONENT_WHITESPACE_OUTPUT4:
-	[ \t\r\n] -> popMode, popMode, skip;
+    [ \t\r\n] -> popMode, popMode, skip
+;
 
 // If we're in a cfoutput tag, don't pop as far and stay in outut mode
 COMPONENT_CLOSE_OUTPUT3:
-	'>' {lastModeWas(OUTPUT_MODE,2)}? -> popMode, popMode, pushMode(DEFAULT_MODE), type(
-		COMPONENT_CLOSE);
+    '>' {lastModeWas(OUTPUT_MODE,2)}? -> popMode, popMode, pushMode(DEFAULT_MODE), type(
+        COMPONENT_CLOSE)
+;
 
 // If we find the end of the component, pop all the way out of the component
 COMPONENT_CLOSE3:
-	'>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE);
+    '>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_CLOSE)
+;
 
 // If we're in a cfoutput tag, pop all the way out of the component
 COMPONENT_SLASH_CLOSE5:
-	'/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, popMode, type(
-		COMPONENT_SLASH_CLOSE );
+    '/>' {lastModeWas(OUTPUT_MODE,1)}? -> popMode, popMode, popMode, popMode, type(
+        COMPONENT_SLASH_CLOSE )
+;
 
 COMPONENT_SLASH_CLOSE4:
-	'/>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE);
+    '/>' -> popMode, popMode, popMode, popMode, popMode, type(COMPONENT_SLASH_CLOSE)
+;
 
 UNQUOTED_VALUE_PART2: . -> type(UNQUOTED_VALUE_PART);
 
@@ -332,10 +371,12 @@ mode EXPRESSION_MODE_COMPONENT;
 FAT_ARROW: '=>' -> type(EXPRESSION_PART);
 
 COMPONENT_SLASH_CLOSE1:
-	'/>' -> type(COMPONENT_SLASH_CLOSE), popMode, popMode, popMode, popMode;
+    '/>' -> type(COMPONENT_SLASH_CLOSE), popMode, popMode, popMode, popMode
+;
 
 COMPONENT_CLOSE1:
-	'>' -> type(COMPONENT_CLOSE), popMode, popMode, popMode, popMode;
+    '>' -> type(COMPONENT_CLOSE), popMode, popMode, popMode, popMode
+;
 
 EXPRESSION_PART: ~[=>'"/<]+;
 
@@ -346,13 +387,16 @@ EXPRESSION_PART3: '<' -> type(EXPRESSION_PART);
 EXPRESSION_PART6: '=' -> type(EXPRESSION_PART);
 
 OPEN_QUOTE2:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE2:
-	'\'' -> type(OPEN_QUOTE), pushMode(squotesModeExpression);
+    '\'' -> type(OPEN_QUOTE), pushMode(squotesModeExpression)
+;
 
 COMMENT_START6:
-	'<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART);
+    '<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART)
+;
 
 // *********************************************************************************************************************
 mode EXPRESSION_MODE_UNQUOTED_ATTVALUE;
@@ -363,13 +407,16 @@ STRING_EXPRESSION_PART2: ~[#'"<]+ -> type(EXPRESSION_PART);
 EXPRESSION_PART4: '<' -> type(EXPRESSION_PART);
 
 OPEN_QUOTE4:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE4:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression)
+;
 
 COMMENT_START5:
-	'<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART);
+    '<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART)
+;
 
 // *********************************************************************************************************************
 mode EXPRESSION_MODE_STRING;
@@ -380,24 +427,28 @@ STRING_EXPRESSION_PART: ~[#'"<]+ -> type(EXPRESSION_PART);
 EXPRESSION_PART5: '<' -> type(EXPRESSION_PART);
 
 OPEN_QUOTE3:
-	'"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE);
+    '"' -> pushMode(quotesModeExpression), type(OPEN_QUOTE)
+;
 
 OPEN_SINGLE3:
-	'\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression);
+    '\'' -> type( OPEN_QUOTE ), pushMode(squotesModeExpression)
+;
 
 COMMENT_START7:
-	'<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART);
+    '<!---' -> pushMode(COMMENT_EXPRESSION), type(EXPRESSION_PART)
+;
 
 // *********************************************************************************************************************
 mode squotesModeCOMPONENT;
 ICHAR2: '#' -> pushMode(EXPRESSION_MODE_STRING), type(ICHAR);
 CLOSE_SQUOTE:
-	'\'' {
+    '\'' {
 		//if ( modeNames [_modeStack.peek()].equals ("ATTVALUE")	) {
 			//System.out.println( "Extra POP (single)" );
 		//	popMode();
 		//	}
-		 } -> type( CLOSE_QUOTE), popMode, popMode;
+		 } -> type( CLOSE_QUOTE), popMode, popMode
+;
 
 SHASHHASH: '##' -> type(HASHHASH);
 SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
@@ -406,12 +457,13 @@ SSTRING_LITERAL: (~['#]+ | '\'\'')+ -> type(STRING_LITERAL);
 mode quotesModeCOMPONENT;
 ICHAR3: '#' -> type(ICHAR), pushMode(EXPRESSION_MODE_STRING);
 CLOSE_QUOTE:
-	'"' {  
+    '"' {  
 		//if (modeNames[_modeStack.peek()].equals( "ATTVALUE" )) {
 			//System.out.println( "Extra POP" );
 			//popMode();
 		//	} 
-		} -> popMode, popMode;
+		} -> popMode, popMode
+;
 
 HASHHASH1: '##' -> type(HASHHASH);
 STRING_LITERAL: (~["#]+ | '""')+;
@@ -437,7 +489,8 @@ mode XFSCRIPT;
 
 fragment COMPONENT_WHITESPACE2: [ \t\r\n]*;
 SCRIPT_END_BODY:
-	'</' COMPONENT_WHITESPACE2 'cfscript' COMPONENT_WHITESPACE2 '>' -> popMode;
+    '</' COMPONENT_WHITESPACE2 'cfscript' COMPONENT_WHITESPACE2 '>' -> popMode
+;
 
 SCRIPT_BODY: .+?;
 
@@ -448,7 +501,8 @@ PREFIX: 'cf' -> pushMode(COMPONENT_NAME_MODE);
 SLASH_PREFIX: '/cf' -> pushMode(END_COMPONENT);
 
 ICHAR7:
-	'#' {_modeStack.contains(OUTPUT_MODE)}? -> type(ICHAR), popMode, pushMode(EXPRESSION_MODE_STRING
-		);
+    '#' {_modeStack.contains(OUTPUT_MODE)}? -> type(ICHAR), popMode, pushMode(EXPRESSION_MODE_STRING
+        )
+;
 
 ANY: . -> type(CONTENT_TEXT), popMode;

--- a/src/main/antlr/DocGrammar.g4
+++ b/src/main/antlr/DocGrammar.g4
@@ -1,68 +1,80 @@
+
+
+
 parser grammar DocGrammar;
 
 options {
-	tokenVocab = DocLexer;
+    tokenVocab = DocLexer;
 }
 
 documentation:
-	skipWhitespace* DOC_START skipWhitespace* documentationContent? NEWLINE? DOC_END? NEWLINE?;
+    skipWhitespace* DOC_START skipWhitespace* documentationContent? NEWLINE? DOC_END? NEWLINE?
+;
 
 documentationContent:
-	description skipWhitespace*
-	| skipWhitespace* tagSection
-	| description NEWLINE+ skipWhitespace* tagSection;
+    description skipWhitespace*
+    | skipWhitespace* tagSection
+    | description NEWLINE+ skipWhitespace* tagSection
+;
 
 space: SPACE;
 
 skipWhitespace: SPACE | NEWLINE;
 
 description:
-	descriptionLine (
-		(descriptionNewline | space)+ descriptionLine
-	)*;
+    descriptionLine (
+        (descriptionNewline | space)+ descriptionLine
+    )*
+;
 
 descriptionLine:
-	SPACE? descriptionLineNoSpaceNoAt+ (
-		descriptionLineNoSpaceNoAt
-		| SPACE
-		| AT
-	)*;
+    SPACE? descriptionLineNoSpaceNoAt+ (
+        descriptionLineNoSpaceNoAt
+        | SPACE
+        | AT
+    )*
+;
 
 descriptionLineNoSpaceNoAt:
-	TEXT_CONTENT
-	| NAME
-	| STAR
-	| SLASH
-	| DOC_START;
+    TEXT_CONTENT
+    | NAME
+    | STAR
+    | SLASH
+    | DOC_START
+;
 
 descriptionNewline: NEWLINE;
 
 tagSection: blockTag+;
 
 blockTag:
-	SPACE? AT blockTagName SPACE? blockTagContent* NEWLINE*;
+    SPACE? AT blockTagName SPACE? blockTagContent* NEWLINE*
+;
 
 blockTagName: NAME;
 
 blockTagContent:
-	blockTagText
-	| ( NEWLINE+ blockTagTextElementNoAt);
+    blockTagText
+    | ( NEWLINE+ blockTagTextElementNoAt)
+;
 
 blockTagText: blockTagTextElementNoAt blockTagTextElement*;
 
 blockTagTextElement:
-	TEXT_CONTENT
-	| NAME
-	| SPACE
-	| STAR
-	| SLASH
-	| DOC_START
-	| AT;
+    TEXT_CONTENT
+    | NAME
+    | SPACE
+    | STAR
+    | SLASH
+    | DOC_START
+    | AT
+;
 
 blockTagTextElementNoAt:
-	TEXT_CONTENT
-	| NAME
-	| SPACE
-	| STAR
-	| SLASH
-	| DOC_START;
+    TEXT_CONTENT
+    | NAME
+    | SPACE
+    | STAR
+    | SLASH
+    | DOC_START
+;

--- a/src/main/antlr/DocLexer.g4
+++ b/src/main/antlr/DocLexer.g4
@@ -1,11 +1,15 @@
+
+
+
 lexer grammar DocLexer;
 
 NAME: [a-zA-Z.0-9]+;
 
 NEWLINE:
-	'\n' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?
-	| '\r\n' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?
-	| '\r' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?;
+    '\n' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?
+    | '\r\n' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?
+    | '\r' (SPACE? (STAR {_input.LA(1) != '/'}?)+)?
+;
 
 SPACE: (' ' | '\t')+;
 

--- a/src/main/java/ortus/boxlang/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/Boxpiler.java
@@ -1,17 +1,8 @@
 package ortus.boxlang.compiler;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.Parser;
@@ -26,6 +17,14 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ParseException;
 import ortus.boxlang.runtime.util.FRTransService;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class Boxpiler implements IBoxpiler {
 
@@ -59,8 +58,7 @@ public abstract class Boxpiler implements IBoxpiler {
 		if ( BoxRuntime.getInstance().inDebugMode() && Files.exists( this.classGenerationDirectory ) ) {
 			try {
 				logger.debug( "Running in debugmode, first startup cleaning out class generation directory: " + classGenerationDirectory );
-				if ( false )
-					FileUtils.cleanDirectory( classGenerationDirectory.toFile() );
+				FileUtils.cleanDirectory( classGenerationDirectory.toFile() );
 			} catch ( IOException e ) {
 				throw new BoxRuntimeException( "Error cleaning out class generation directory on first run", e );
 			}

--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/expression/BoxComparisonOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/expression/BoxComparisonOperationTransformer.java
@@ -1,14 +1,14 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,14 +17,10 @@
  */
 package ortus.boxlang.compiler.asmboxpiler.transformer.expression;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
-
 import ortus.boxlang.compiler.asmboxpiler.Transpiler;
 import ortus.boxlang.compiler.asmboxpiler.transformer.AbstractTransformer;
 import ortus.boxlang.compiler.asmboxpiler.transformer.ReturnValueContext;
@@ -32,14 +28,11 @@ import ortus.boxlang.compiler.asmboxpiler.transformer.TransformerContext;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.expression.BoxComparisonOperation;
 import ortus.boxlang.compiler.ast.expression.BoxComparisonOperator;
-import ortus.boxlang.runtime.operators.EqualsEquals;
-import ortus.boxlang.runtime.operators.EqualsEqualsEquals;
-import ortus.boxlang.runtime.operators.GreaterThan;
-import ortus.boxlang.runtime.operators.GreaterThanEqual;
-import ortus.boxlang.runtime.operators.LessThan;
-import ortus.boxlang.runtime.operators.LessThanEqual;
-import ortus.boxlang.runtime.operators.NotEqualsEquals;
+import ortus.boxlang.runtime.operators.*;
 import ortus.boxlang.runtime.types.exceptions.ExpressionException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BoxComparisonOperationTransformer extends AbstractTransformer {
 
@@ -66,7 +59,7 @@ public class BoxComparisonOperationTransformer extends AbstractTransformer {
 			dispatcher = GreaterThanEqual.class;
 		} else if ( operation.getOperator() == BoxComparisonOperator.LessThan ) {
 			dispatcher = LessThan.class;
-		} else if ( operation.getOperator() == BoxComparisonOperator.LesslThanEqual ) {
+		} else if ( operation.getOperator() == BoxComparisonOperator.LessThanEquals ) {
 			dispatcher = LessThanEqual.class;
 		} else {
 			throw new ExpressionException( "not implemented", operation );
@@ -75,11 +68,8 @@ public class BoxComparisonOperationTransformer extends AbstractTransformer {
 		List<AbstractInsnNode> nodes = new ArrayList<>();
 		nodes.addAll( left );
 		nodes.addAll( right );
-		nodes.add( new MethodInsnNode( Opcodes.INVOKESTATIC,
-		    Type.getInternalName( dispatcher ),
-		    "invoke",
-		    Type.getMethodDescriptor( Type.getType( Boolean.class ), Type.getType( Object.class ), Type.getType( Object.class ) ),
-		    false ) );
+		nodes.add( new MethodInsnNode( Opcodes.INVOKESTATIC, Type.getInternalName( dispatcher ), "invoke",
+		    Type.getMethodDescriptor( Type.getType( Boolean.class ), Type.getType( Object.class ), Type.getType( Object.class ) ), false ) );
 		return nodes;
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/ast/BoxNode.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/BoxNode.java
@@ -1,18 +1,28 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 package ortus.boxlang.compiler.ast;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSON.Feature;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import ortus.boxlang.compiler.ast.comment.BoxComment;
+import ortus.boxlang.compiler.ast.comment.BoxDocComment;
+import ortus.boxlang.compiler.ast.statement.BoxAnnotation;
+import ortus.boxlang.compiler.ast.statement.BoxImport;
+import ortus.boxlang.compiler.ast.visitor.BoxVisitable;
+import ortus.boxlang.compiler.ast.visitor.PrettyPrintBoxVisitor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,17 +30,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
-import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.ob.JSON.Feature;
-import com.fasterxml.jackson.jr.ob.JSONObjectException;
-
-import ortus.boxlang.compiler.ast.comment.BoxComment;
-import ortus.boxlang.compiler.ast.comment.BoxDocComment;
-import ortus.boxlang.compiler.ast.statement.BoxAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxImport;
-import ortus.boxlang.compiler.ast.visitor.BoxVisitable;
-import ortus.boxlang.compiler.ast.visitor.PrettyPrintBoxVisitor;
 
 /**
  * Base class for the BoxLang AST Nodes
@@ -98,7 +97,8 @@ public abstract class BoxNode implements BoxVisitable {
 		this.parent = parent;
 		if ( parent != null ) {
 			if ( !parent.children.contains( this ) )
-				parent.getChildren().add( this );
+				parent.getChildren()
+				    .add( this );
 		}
 	}
 
@@ -131,7 +131,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Get the last documentation comment
-	 * 
+	 *
 	 * @return the last documentation comment
 	 */
 	public BoxDocComment getDocComment() {
@@ -150,9 +150,9 @@ public abstract class BoxNode implements BoxVisitable {
 	 * node they appear before, unless the comment appears at the end of the same line the
 	 * node appears on, in which case the commend will associate with that node on the same line.
 	 * Any remaining comments left will be associated with the outer-most node.
-	 * 
+	 *
 	 * @param incomingComments the list of comments to associate
-	 * 
+	 *
 	 * @return this node with the comments associated
 	 */
 	public BoxNode associateComments( List<BoxComment> incomingComments ) {
@@ -169,7 +169,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Provided a list of comments, sorted in the order the appeared in the source code.
-	 * 
+	 *
 	 * @param incomingComments the list of comments to associate
 	 */
 	private void _associateComments( List<BoxComment> incomingComments ) {
@@ -179,7 +179,7 @@ public abstract class BoxNode implements BoxVisitable {
 	/**
 	 * The same as _associateComments(), but will LEAVE any comments left in the list after this
 	 * node for the next node to claim.
-	 * 
+	 *
 	 * @param incomingComments   the list of comments to associate
 	 * @param lastNodeOnThisLine true if this node is the last node on the line
 	 */
@@ -232,9 +232,19 @@ public abstract class BoxNode implements BoxVisitable {
 					return 0;
 					// throw new BoxRuntimeException( a.getClass().getName() + " position is null " + a.getSourceText() );
 				}
-				int lineDiff = a.getPosition().getStart().getLine() - b.getPosition().getStart().getLine();
+				int lineDiff = a.getPosition()
+				    .getStart()
+				    .getLine()
+				    - b.getPosition()
+				        .getStart()
+				        .getLine();
 				if ( lineDiff == 0 ) {
-					return a.getPosition().getStart().getColumn() - b.getPosition().getStart().getColumn();
+					return a.getPosition()
+					    .getStart()
+					    .getColumn()
+					    - b.getPosition()
+					        .getStart()
+					        .getColumn();
 				}
 				return lineDiff;
 			} );
@@ -248,7 +258,8 @@ public abstract class BoxNode implements BoxVisitable {
 					continue;
 				}
 				// If we are the last child, or the next child starts on a different line, then we are the last node on this line
-				lastNodeOnThisLine = i == children.size() - 1 || !children.get( i + 1 ).startsOnEndLineOf( child );
+				lastNodeOnThisLine = i == children.size() - 1 || !children.get( i + 1 )
+				    .startsOnEndLineOf( child );
 				child._associateComments( incomingComments, lastNodeOnThisLine );
 			}
 
@@ -293,51 +304,63 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Check if this node is before another node
-	 * 
+	 *
 	 * @param node the node to compare to
-	 * 
+	 *
 	 * @return true if this node is before the other node
 	 */
 	public boolean isBefore( BoxNode node ) {
 		if ( this.getPosition() == null || node.getPosition() == null ) {
 			return false;
 		}
-		int	thisEndLine		= this.getPosition().getEnd().getLine();
-		int	thisEndCol		= this.getPosition().getEnd().getColumn();
-		int	nodeStartLine	= node.getPosition().getStart().getLine();
-		int	nodeStartCol	= node.getPosition().getStart().getColumn();
+		int	thisEndLine		= this.getPosition()
+		    .getEnd()
+		    .getLine();
+		int	thisEndCol		= this.getPosition()
+		    .getEnd()
+		    .getColumn();
+		int	nodeStartLine	= node.getPosition()
+		    .getStart()
+		    .getLine();
+		int	nodeStartCol	= node.getPosition()
+		    .getStart()
+		    .getColumn();
 
-		return thisEndLine < nodeStartLine
-		    || ( thisEndLine == nodeStartLine
-		        && thisEndCol <= nodeStartCol );
+		return thisEndLine < nodeStartLine || ( thisEndLine == nodeStartLine && thisEndCol <= nodeStartCol );
 	}
 
 	/**
 	 * Check if this node is after another node
-	 * 
+	 *
 	 * @param node the node to compare to
-	 * 
+	 *
 	 * @return true if this node is after the other node
 	 */
 	public boolean isAfter( BoxNode node ) {
 		if ( this.getPosition() == null || node.getPosition() == null ) {
 			return false;
 		}
-		int	thisStartLine	= this.getPosition().getStart().getLine();
-		int	thisStartCol	= this.getPosition().getStart().getColumn();
-		int	nodeEndLine		= node.getPosition().getEnd().getLine();
-		int	nodeEndCol		= node.getPosition().getEnd().getColumn();
+		int	thisStartLine	= this.getPosition()
+		    .getStart()
+		    .getLine();
+		int	thisStartCol	= this.getPosition()
+		    .getStart()
+		    .getColumn();
+		int	nodeEndLine		= node.getPosition()
+		    .getEnd()
+		    .getLine();
+		int	nodeEndCol		= node.getPosition()
+		    .getEnd()
+		    .getColumn();
 
-		return thisStartLine > nodeEndLine
-		    || ( thisStartLine == nodeEndLine
-		        && thisStartCol >= nodeEndCol );
+		return thisStartLine > nodeEndLine || ( thisStartLine == nodeEndLine && thisStartCol >= nodeEndCol );
 	}
 
 	/**
 	 * Check if this node is inside another node
-	 * 
+	 *
 	 * @param node the node to compare to
-	 * 
+	 *
 	 * @return true if this node is inside the other node
 	 */
 	public boolean isInside( BoxNode node ) {
@@ -349,41 +372,49 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Check if this node starts on the end line of another node
-	 * 
+	 *
 	 * @param node the node to compare to
-	 * 
+	 *
 	 * @return true if this node starts on the end line of the other node
 	 */
 	public boolean startsOnEndLineOf( BoxNode node ) {
 		if ( this.getPosition() == null || node.getPosition() == null ) {
 			return false;
 		}
-		int	thisStartLine	= this.getPosition().getStart().getLine();
-		int	nodeEndLine		= node.getPosition().getEnd().getLine();
+		int	thisStartLine	= this.getPosition()
+		    .getStart()
+		    .getLine();
+		int	nodeEndLine		= node.getPosition()
+		    .getEnd()
+		    .getLine();
 		return thisStartLine == nodeEndLine;
 	}
 
 	/**
 	 * Check if this node starts on the end line of another node
-	 * 
+	 *
 	 * @param node the node to compare to
-	 * 
+	 *
 	 * @return true if this node starts on the end line of the other node
 	 */
 	public boolean endsOnSameLineAs( BoxNode node ) {
 		if ( this.getPosition() == null || node.getPosition() == null ) {
 			return false;
 		}
-		int	thisEndLine	= this.getPosition().getEnd().getLine();
-		int	nodeEndLine	= node.getPosition().getEnd().getLine();
+		int	thisEndLine	= this.getPosition()
+		    .getEnd()
+		    .getLine();
+		int	nodeEndLine	= node.getPosition()
+		    .getEnd()
+		    .getLine();
 		return thisEndLine == nodeEndLine;
 	}
 
 	/**
 	 * Set the comments of the node
-	 * 
-	 * @param children the list of children
-	 * 
+	 *
+	 * @param comments the list of children
+	 *
 	 * @return the node with the children set
 	 */
 	public BoxNode setComments( List<BoxComment> comments ) {
@@ -394,9 +425,9 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Add a single comment
-	 * 
+	 *
 	 * @param comment the comment to add
-	 * 
+	 *
 	 * @return the node with the comment added
 	 */
 	public BoxNode addComment( BoxComment comment ) {
@@ -451,7 +482,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Find all decedant nodes of a given type that match the supplied predicate
-	 * 
+	 *
 	 * @param type      The class of node to look for
 	 * @param predicate A predicate to test the node
 	 *
@@ -471,7 +502,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Find all decedant nodes of a given type
-	 * 
+	 *
 	 * @param type The class of node to look for
 	 *
 	 * @return a list of nodes traversed
@@ -497,7 +528,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Walk the ancestors of a node to look for one of a specific type
-	 * 
+	 *
 	 * @param type The class of ancestor to look for
 	 *
 	 * @return The requested ancestor node, null if none found
@@ -510,7 +541,7 @@ public abstract class BoxNode implements BoxVisitable {
 	 * Walk the ancestors of a node to look for one of a specific type.
 	 * This can return the current node, as opposed to getFirstAncestorOfType
 	 * which starts with the parent
-	 * 
+	 *
 	 * @param type The class of ancestor to look for
 	 *
 	 * @return The requested ancestor node, null if none found
@@ -521,7 +552,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Walk the ancestors of a node to look for one of a specific type
-	 * 
+	 *
 	 * @param type      The class of ancestor to look for
 	 * @param predicate A predicate to test the ancestor
 	 *
@@ -540,7 +571,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Walk the ancestors of a node to look for one of a specific type
-	 * 
+	 *
 	 * @param type The classes of ancestors to look for
 	 *
 	 * @return The requested ancestor node, null if none found
@@ -560,7 +591,7 @@ public abstract class BoxNode implements BoxVisitable {
 
 	/**
 	 * Walk the ancestors of a node to look for one of a specific type
-	 * 
+	 *
 	 * @param type      The class of ancestor to look for
 	 * @param predicate A predicate to test the ancestor
 	 *
@@ -582,7 +613,9 @@ public abstract class BoxNode implements BoxVisitable {
 		if ( position != null ) {
 			map.put( "position", position.toMap() );
 		}
-		map.put( "comments", comments.stream().map( BoxNode::toMap ).toList() );
+		map.put( "comments", comments.stream()
+		    .map( BoxNode::toMap )
+		    .toList() );
 
 		return map;
 	}
@@ -599,7 +632,8 @@ public abstract class BoxNode implements BoxVisitable {
 
 	public String toJSON() {
 		try {
-			return JSON.std.with( Feature.PRETTY_PRINT_OUTPUT, Feature.WRITE_NULL_PROPERTIES ).asString( toMap() );
+			return JSON.std.with( Feature.PRETTY_PRINT_OUTPUT, Feature.WRITE_NULL_PROPERTIES )
+			    .asString( toMap() );
 		} catch ( JSONObjectException e ) {
 			e.printStackTrace();
 		} catch ( IOException e ) {
@@ -612,5 +646,28 @@ public abstract class BoxNode implements BoxVisitable {
 		PrettyPrintBoxVisitor visitor = new PrettyPrintBoxVisitor();
 		accept( visitor );
 		return visitor.getOutput();
+	}
+
+	/**
+	 * Returns a human-readable description of the node, which it manufactures from the class name.
+	 * <p>
+	 * While that is quite often good enough, override this method in subclasses to provide a better description
+	 * when this default does not work quite right.
+	 * </p>
+	 *
+	 * @return human readable description of the expression, for use in error messages etc
+	 */
+	public String getDescription() {
+		String className = getClass().getSimpleName();
+		if ( className.startsWith( "Box" ) ) {
+			className = className.substring( 3 );
+		}
+		var name = className.replaceAll( "([A-Z])", " $1" ).toLowerCase().trim();
+
+		if ( name.matches( "^[aeiou].*" ) ) {
+			return "an " + name;
+		} else {
+			return "a " + name;
+		}
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/Point.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/Point.java
@@ -25,8 +25,8 @@ import java.util.Map;
  */
 public class Point {
 
-	private final int	line;
-	private final int	column;
+	private int	line;
+	private int	column;
 
 	/**
 	 * Create a point
@@ -64,4 +64,15 @@ public class Point {
 		map.put( "column", column );
 		return map;
 	}
+
+	public Point setColumn( int column ) {
+		this.column = column;
+		return this;
+	}
+
+	public Point setLine( int line ) {
+		this.line = line;
+		return this;
+	}
+
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/Position.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/Position.java
@@ -74,11 +74,20 @@ public class Position {
 
 	/**
 	 * Set the end point
-	 * 
+	 *
 	 * @param end the end point of the region
 	 */
 	public void setEnd( Point end ) {
 		this.end = end;
+	}
+
+	/**
+	 * Set the end point
+	 *
+	 * @param start the end point of the region
+	 */
+	public void setStart( Point start ) {
+		this.start = start;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/compiler/ast/Source.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/Source.java
@@ -28,6 +28,8 @@ public abstract class Source {
 
 	public abstract Stream<String> getCodeAsStream();
 
+	public abstract String getCode();
+
 	protected static String escapeHTML( String s ) {
 		if ( s == null ) {
 			return "";

--- a/src/main/java/ortus/boxlang/compiler/ast/SourceFile.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/SourceFile.java
@@ -48,6 +48,20 @@ public class SourceFile extends Source {
 	}
 
 	/**
+	 * Essentially, only used for error messages
+	 * 
+	 * @return teh source code in the given file
+	 */
+	public String getCode() {
+		try {
+			return new String( Files.readAllBytes( file.toPath() ) );
+		} catch ( IOException e ) {
+			e.printStackTrace();
+		}
+		return "";
+	}
+
+	/**
 	 * String representation of a file source
 	 *
 	 * @return the absolute path of the File

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxArrayLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxArrayLiteral.java
@@ -17,22 +17,22 @@
  */
 package ortus.boxlang.compiler.ast.expression;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * AST Node representing an array literal.
  * An array literal is surrounded by square braces []
  * and contains zero or more comma-delimited expressions.
  * Example
- * 
+ *
  * <pre>
  * []
  * [1,2,3]
@@ -50,7 +50,7 @@ public class BoxArrayLiteral extends BoxExpression implements IBoxLiteral {
 
 	/**
 	 * Creates the AST node for an anonymous argument
-	 * 
+	 *
 	 * @param values     initialization values
 	 * @param position   position of the statement in the source code
 	 * @param sourceText source code that originated the Node
@@ -89,5 +89,10 @@ public class BoxArrayLiteral extends BoxExpression implements IBoxLiteral {
 
 	public BoxNode accept( ReplacingBoxVisitor v ) {
 		return v.visit( this );
+	}
+
+	@Override
+	public String getDescription() {
+		return "an array literal";
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxComparisonOperator.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxComparisonOperator.java
@@ -20,7 +20,7 @@ public enum BoxComparisonOperator {
 	GreaterThan,
 	GreaterThanEquals,
 	LessThan,
-	LesslThanEqual,
+	LessThanEquals,
 	NotEqual,
 	Contains,
 	TEqual;
@@ -35,7 +35,7 @@ public enum BoxComparisonOperator {
 				return ">=";
 			case LessThan :
 				return "<";
-			case LesslThanEqual :
+			case LessThanEquals :
 				return "<=";
 			case NotEqual :
 				return "!=";

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxFunctionInvocation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxFunctionInvocation.java
@@ -14,15 +14,15 @@
  */
 package ortus.boxlang.compiler.ast.expression;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * AST Node representing a fully qualified name
@@ -79,5 +79,10 @@ public class BoxFunctionInvocation extends BoxExpression {
 
 	public BoxNode accept( ReplacingBoxVisitor v ) {
 		return v.visit( this );
+	}
+
+	@Override
+	public String getDescription() {
+		return "a function invocation";
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxMethodInvocation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxMethodInvocation.java
@@ -68,6 +68,11 @@ public class BoxMethodInvocation extends BoxExpression {
 		this( name, obj, arguments, false, true, position, sourceText );
 	}
 
+	public BoxMethodInvocation( BoxIdentifier name, List<BoxArgument> arguments, Position position,
+	    String sourceText ) {
+		this( name, null, arguments, false, true, position, sourceText );
+	}
+
 	public BoxExpression getName() {
 		return name;
 	}

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxStructLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxStructLiteral.java
@@ -17,15 +17,15 @@
  */
 package ortus.boxlang.compiler.ast.expression;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * A struct literal comes in two forms, ordered and unordered (default).
@@ -92,5 +92,10 @@ public class BoxStructLiteral extends BoxExpression implements IBoxLiteral {
 
 	public BoxNode accept( ReplacingBoxVisitor v ) {
 		return v.visit( this );
+	}
+
+	@Override
+	public String getDescription() {
+		return "a struct literal";
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/expression/BoxUnaryOperation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/expression/BoxUnaryOperation.java
@@ -14,13 +14,13 @@
  */
 package ortus.boxlang.compiler.ast.expression;
 
-import java.util.Map;
-
 import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+import java.util.Map;
 
 /**
  * AST Node representing a unary operator
@@ -76,6 +76,11 @@ public class BoxUnaryOperation extends BoxExpression {
 
 	public BoxNode accept( ReplacingBoxVisitor v ) {
 		return v.visit( this );
+	}
+
+	@Override
+	public String getDescription() {
+		return "an unary operation";
 	}
 
 }

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/expression/BoxComparisonOperationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/expression/BoxComparisonOperationTransformer.java
@@ -82,7 +82,7 @@ public class BoxComparisonOperationTransformer extends AbstractTransformer {
 			template = "GreaterThanEqual.invoke(${left},${right})";
 		} else if ( operation.getOperator() == BoxComparisonOperator.LessThan ) {
 			template = "LessThan.invoke(${left},${right})";
-		} else if ( operation.getOperator() == BoxComparisonOperator.LesslThanEqual ) {
+		} else if ( operation.getOperator() == BoxComparisonOperator.LessThanEquals ) {
 			template = "LessThanEqual.invoke(${left},${right})";
 		} else {
 			throw new ExpressionException( "not implemented", operation );

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxScriptParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxScriptParser.java
@@ -1,145 +1,53 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 package ortus.boxlang.compiler.parser;
 
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import ortus.boxlang.compiler.ast.*;
+import ortus.boxlang.compiler.ast.comment.BoxDocComment;
+import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
+import ortus.boxlang.compiler.ast.comment.BoxSingleLineComment;
+import ortus.boxlang.compiler.ast.expression.*;
+import ortus.boxlang.compiler.toolchain.BoxExpressionVisitor;
+import ortus.boxlang.compiler.toolchain.BoxVisitor;
+import ortus.boxlang.parser.antlr.BoxScriptGrammar;
+import ortus.boxlang.parser.antlr.BoxScriptLexer;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.services.ComponentService;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BOMInputStream;
-
-import ortus.boxlang.compiler.ast.BoxClass;
-import ortus.boxlang.compiler.ast.BoxExpression;
-import ortus.boxlang.compiler.ast.BoxInterface;
-import ortus.boxlang.compiler.ast.BoxNode;
-import ortus.boxlang.compiler.ast.BoxScript;
-import ortus.boxlang.compiler.ast.BoxStatement;
-import ortus.boxlang.compiler.ast.BoxStaticInitializer;
-import ortus.boxlang.compiler.ast.BoxTemplate;
-import ortus.boxlang.compiler.ast.Issue;
-import ortus.boxlang.compiler.ast.Point;
-import ortus.boxlang.compiler.ast.Position;
-import ortus.boxlang.compiler.ast.Source;
-import ortus.boxlang.compiler.ast.SourceCode;
-import ortus.boxlang.compiler.ast.SourceFile;
-import ortus.boxlang.compiler.ast.comment.BoxDocComment;
-import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
-import ortus.boxlang.compiler.ast.comment.BoxSingleLineComment;
-import ortus.boxlang.compiler.ast.expression.BoxAccess;
-import ortus.boxlang.compiler.ast.expression.BoxArgument;
-import ortus.boxlang.compiler.ast.expression.BoxArrayAccess;
-import ortus.boxlang.compiler.ast.expression.BoxArrayLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxAssignment;
-import ortus.boxlang.compiler.ast.expression.BoxAssignmentModifier;
-import ortus.boxlang.compiler.ast.expression.BoxAssignmentOperator;
-import ortus.boxlang.compiler.ast.expression.BoxBinaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxBinaryOperator;
-import ortus.boxlang.compiler.ast.expression.BoxBooleanLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxClosure;
-import ortus.boxlang.compiler.ast.expression.BoxComparisonOperation;
-import ortus.boxlang.compiler.ast.expression.BoxComparisonOperator;
-import ortus.boxlang.compiler.ast.expression.BoxDecimalLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxDotAccess;
-import ortus.boxlang.compiler.ast.expression.BoxExpressionInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxFQN;
-import ortus.boxlang.compiler.ast.expression.BoxFunctionInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxFunctionalBIFAccess;
-import ortus.boxlang.compiler.ast.expression.BoxFunctionalMemberAccess;
-import ortus.boxlang.compiler.ast.expression.BoxIdentifier;
-import ortus.boxlang.compiler.ast.expression.BoxIntegerLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxLambda;
-import ortus.boxlang.compiler.ast.expression.BoxMethodInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxNew;
-import ortus.boxlang.compiler.ast.expression.BoxNull;
-import ortus.boxlang.compiler.ast.expression.BoxParenthesis;
-import ortus.boxlang.compiler.ast.expression.BoxScope;
-import ortus.boxlang.compiler.ast.expression.BoxStaticAccess;
-import ortus.boxlang.compiler.ast.expression.BoxStaticMethodInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxStringConcat;
-import ortus.boxlang.compiler.ast.expression.BoxStringInterpolation;
-import ortus.boxlang.compiler.ast.expression.BoxStringLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxStructLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxStructType;
-import ortus.boxlang.compiler.ast.expression.BoxTernaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxUnaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxUnaryOperator;
-import ortus.boxlang.compiler.ast.statement.BoxAccessModifier;
-import ortus.boxlang.compiler.ast.statement.BoxAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxArgumentDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxAssert;
-import ortus.boxlang.compiler.ast.statement.BoxBreak;
-import ortus.boxlang.compiler.ast.statement.BoxContinue;
-import ortus.boxlang.compiler.ast.statement.BoxDo;
-import ortus.boxlang.compiler.ast.statement.BoxDocumentationAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxExpressionStatement;
-import ortus.boxlang.compiler.ast.statement.BoxForIn;
-import ortus.boxlang.compiler.ast.statement.BoxForIndex;
-import ortus.boxlang.compiler.ast.statement.BoxFunctionDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxIfElse;
-import ortus.boxlang.compiler.ast.statement.BoxImport;
-import ortus.boxlang.compiler.ast.statement.BoxMethodDeclarationModifier;
-import ortus.boxlang.compiler.ast.statement.BoxParam;
-import ortus.boxlang.compiler.ast.statement.BoxProperty;
-import ortus.boxlang.compiler.ast.statement.BoxRethrow;
-import ortus.boxlang.compiler.ast.statement.BoxReturn;
-import ortus.boxlang.compiler.ast.statement.BoxReturnType;
-import ortus.boxlang.compiler.ast.statement.BoxStatementBlock;
-import ortus.boxlang.compiler.ast.statement.BoxSwitch;
-import ortus.boxlang.compiler.ast.statement.BoxSwitchCase;
-import ortus.boxlang.compiler.ast.statement.BoxThrow;
-import ortus.boxlang.compiler.ast.statement.BoxTry;
-import ortus.boxlang.compiler.ast.statement.BoxTryCatch;
-import ortus.boxlang.compiler.ast.statement.BoxType;
-import ortus.boxlang.compiler.ast.statement.BoxWhile;
-import ortus.boxlang.compiler.ast.statement.component.BoxComponent;
-import ortus.boxlang.compiler.ast.statement.component.BoxTemplateIsland;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.AbstractFunctionContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.AssignmentContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.BoxClassContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.ComponentContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.ComponentIslandContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.NewContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.NotTernaryExpressionContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.ParamContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.PreannotationContext;
-import ortus.boxlang.parser.antlr.BoxScriptGrammar.VariableDeclarationContext;
-import ortus.boxlang.parser.antlr.BoxScriptLexer;
-import ortus.boxlang.runtime.BoxRuntime;
-import ortus.boxlang.runtime.components.ComponentDescriptor;
-import ortus.boxlang.runtime.services.ComponentService;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 /**
  * Parser for Box scripts
  */
+@SuppressWarnings( "DuplicatedCode" )
 public class BoxScriptParser extends AbstractParser {
 
-	private boolean			inOutputBlock		= false;
 	public ComponentService	componentService	= BoxRuntime.getInstance().getComponentService();
+	private boolean			inOutputBlock		= false;
+	private Token			firstToken			= null;
 
 	/**
 	 * Constructor
@@ -157,12 +65,14 @@ public class BoxScriptParser extends AbstractParser {
 		this.inOutputBlock = inOutputBlock;
 	}
 
-	public void setInOutputBlock( boolean inOutputBlock ) {
-		this.inOutputBlock = inOutputBlock;
-	}
-
+	@SuppressWarnings( "unused" )
 	public boolean getInOutputBlock() {
 		return inOutputBlock;
+	}
+
+	@SuppressWarnings( "unused" )
+	public void setInOutputBlock( boolean inOutputBlock ) {
+		this.inOutputBlock = inOutputBlock;
 	}
 
 	/**
@@ -172,7 +82,7 @@ public class BoxScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -198,7 +108,7 @@ public class BoxScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -214,7 +124,7 @@ public class BoxScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -235,7 +145,7 @@ public class BoxScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxExpr as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see ParsingResult
 	 * @see BoxExpression
@@ -247,16 +157,19 @@ public class BoxScriptParser extends AbstractParser {
 		BoxScriptLexerCustom	lexer		= new BoxScriptLexerCustom( CharStreams.fromStream( inputStream, StandardCharsets.UTF_8 ) );
 		BoxScriptGrammar		parser		= new BoxScriptGrammar( new CommonTokenStream( lexer ) );
 		addErrorListeners( lexer, parser );
+		parser.setErrorHandler( new BoxParserErrorStrategy() );
 
-		BoxScriptGrammar.ExpressionContext parseTree = parser.expression();
+		BoxScriptGrammar.TestExpressionContext parseTree = parser.testExpression();
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
 
+		var expressionVisitor = new BoxExpressionVisitor( this, new BoxVisitor( this ) );
 		try {
-			BoxExpression ast = toAst( null, parseTree );
+			var ast = parseTree.accept( expressionVisitor );
 			return new ParsingResult( ast, issues, comments );
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -274,7 +187,7 @@ public class BoxScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxStatement as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see ParsingResult
 	 * @see BoxStatement
@@ -286,14 +199,19 @@ public class BoxScriptParser extends AbstractParser {
 		BoxScriptLexerCustom	lexer		= new BoxScriptLexerCustom( CharStreams.fromStream( inputStream, StandardCharsets.UTF_8 ) );
 		BoxScriptGrammar		parser		= new BoxScriptGrammar( new CommonTokenStream( lexer ) );
 		addErrorListeners( lexer, parser );
+		parser.setErrorHandler( new BoxParserErrorStrategy() );
+
 		BoxScriptGrammar.FunctionOrStatementContext parseTree = parser.functionOrStatement();
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
+
+		var visitor = new BoxVisitor( this );
 		try {
-			BoxStatement ast = toAst( null, parseTree );
+			var ast = parseTree.accept( visitor );
 			return new ParsingResult( ast, issues, comments );
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -302,6 +220,15 @@ public class BoxScriptParser extends AbstractParser {
 			}
 			return new ParsingResult( null, issues, comments );
 		}
+	}
+
+	public BoxScriptParser setSource( Source source ) {
+		if ( this.sourceToParse != null ) {
+			return this;
+		}
+		this.sourceToParse = source;
+		this.errorListener.setSource( this.sourceToParse );
+		return this;
 	}
 
 	/**
@@ -317,7 +244,12 @@ public class BoxScriptParser extends AbstractParser {
 	protected BoxNode parserFirstStage( InputStream stream, Boolean classOrInterface ) throws IOException {
 		BoxScriptLexerCustom	lexer	= new BoxScriptLexerCustom( CharStreams.fromStream( stream, StandardCharsets.UTF_8 ) );
 		BoxScriptGrammar		parser	= new BoxScriptGrammar( new CommonTokenStream( lexer ) );
+
+		// DEBUG: Will print a trace of all parser rules visited:
+		// boxParser.setTrace( true );
 		addErrorListeners( lexer, parser );
+		parser.setErrorHandler( new BoxParserErrorStrategy() );
+
 		BoxScriptGrammar.ClassOrInterfaceContext	classOrInterfaceContext	= null;
 		BoxScriptGrammar.ScriptContext				scriptContext			= null;
 		if ( classOrInterface ) {
@@ -328,17 +260,22 @@ public class BoxScriptParser extends AbstractParser {
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
 
 		lexer.reset();
-		Token	firstToken	= lexer.nextToken();
+		firstToken = lexer.nextToken();
 		BoxNode	rootNode;
+
+		// Create the visitor we will use to build the AST
+		var		visitor	= new BoxVisitor( this );
+
 		try {
 			if ( classOrInterface ) {
-				rootNode = toAst( null, classOrInterfaceContext );
+				rootNode = classOrInterfaceContext.accept( visitor );
 			} else {
-				rootNode = toAst( null, scriptContext, firstToken );
+				rootNode = scriptContext.accept( visitor );
 			}
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -356,14 +293,55 @@ public class BoxScriptParser extends AbstractParser {
 		}
 		// associate all comments in the source with the appropriate AST nodes
 		return rootNode.associateComments( this.comments );
-
 	}
 
-	/**
-	 * Validate the parsing by interrogating the lexer for several error scenarios
-	 * 
-	 * @param lexer the lexer to validate
-	 */
+	public List<BoxStatement> parseBoxTemplateStatements( String code, Position position ) {
+		try {
+			if ( inOutputBlock ) {
+				code = "<bx:output>" + code + "</bx:output>";
+			}
+			ParsingResult result = new BoxTemplateParser( position.getStart().getLine(), position.getStart().getColumn() ).setSource( sourceToParse )
+			    .setSubParser( true ).parse( code );
+			this.comments.addAll( result.getComments() );
+			if ( result.getIssues().isEmpty() ) {
+				BoxNode root = result.getRoot();
+				if ( root instanceof BoxTemplate template ) {
+					return template.getStatements();
+				} else if ( root instanceof BoxStatement statement ) {
+					return List.of( statement );
+				} else {
+					// Could be a BoxClass, which we may actually need to support
+					errorListener.semanticError( "Unexpected root node type [" + root.getClass().getName() + "] in component island.", root.getPosition() );
+					return null;
+				}
+			} else {
+				// Add these issues to the main parser
+				issues.addAll( result.getIssues() );
+				return List.of();
+			}
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error parsing component island: " + code, e );
+		}
+	}
+
+	public BoxExpression parseBoxExpression( String code, Position position ) {
+		try {
+			ParsingResult result = new BoxScriptParser( position.getStart().getLine(), position.getStart().getColumn() ).setSource( sourceToParse )
+			    .setSubParser( true ).parseExpression( code );
+			this.comments.addAll( result.getComments() );
+			if ( result.getIssues().isEmpty() ) {
+				return ( BoxExpression ) result.getRoot();
+			} else {
+				// Add these issues to the main parser
+				issues.addAll( result.getIssues() );
+				return new BoxNull( null, null );
+			}
+		} catch ( IOException e ) {
+			errorListener.semanticError( "Error parsing expression " + e.getMessage(), position );
+			return new BoxNull( null, null );
+		}
+	}
+
 	private void validateParse( BoxScriptLexerCustom lexer ) {
 
 		if ( lexer.hasUnpoppedModes() ) {
@@ -371,24 +349,19 @@ public class BoxScriptParser extends AbstractParser {
 
 			if ( modes.contains( "hashMode" ) ) {
 				Token lastHash = lexer.findPreviousToken( BoxScriptLexerCustom.ICHAR );
-				issues.add( new Issue( "Untermimated hash expression inside of string literal.", getPosition( lastHash ) ) );
+				errorListener.semanticError( "Unterminated hash expression inside of string literal.", getPosition( lastHash ) );
 			} else if ( modes.contains( "quotesMode" ) ) {
 				Token lastQuote = lexer.findPreviousToken( BoxScriptLexerCustom.OPEN_QUOTE );
-				issues.add( new Issue( "Untermimated double quote expression.", getPosition( lastQuote ) ) );
+				errorListener.semanticError( "Unterminated double quote expression.", getPosition( lastQuote ) );
 			} else if ( modes.contains( "squotesMode" ) ) {
 				Token lastQuote = lexer.findPreviousToken( BoxScriptLexerCustom.OPEN_QUOTE );
-				issues.add( new Issue( "Untermimated single quote expression.", getPosition( lastQuote ) ) );
+				errorListener.semanticError( "Unterminated single quote expression.", getPosition( lastQuote ) );
 			} else {
-				// Catch-all. If this error is encontered, look at what modes were still on the stack, find what token was never ended, and
+				// Catch-all. If this error is encountered, look at what modes were still on the stack, find what token was never ended, and
 				// add logic like the above to handle it. Eventually, this catch-all should never be used.
-				Position position = new Position(
-				    new Point( 0, 0 ),
-				    new Point( 0, 0 ),
-				    sourceToParse
-				);
-				issues.add( new Issue(
-				    "Unpopped Lexer modes. [" + modes.stream().collect( Collectors.joining( ", " ) ) + "] Please report this to get a better error message.",
-				    position ) );
+				Position position = new Position( new Point( 1, 0 ), new Point( 1, 1 ), sourceToParse );
+				errorListener.semanticError(
+				    "Internal error(42): Un-popped Lexer modes. [" + String.join( ", ", modes ) + "] Please report this to the developers.", position );
 			}
 			// I'm only returning here because we have to reset the lexer above to get the position of the unmatched token, so we no longer have
 			// the ability to check for unconsumed tokens.
@@ -396,12 +369,12 @@ public class BoxScriptParser extends AbstractParser {
 		}
 
 		// Check if there are unconsumed tokens
-		Token token = lexer._token;
+		Token token = lexer.nextToken();
 		while ( token.getType() != Token.EOF && ( token.getChannel() == BoxScriptLexerCustom.HIDDEN ) ) {
 			token = lexer.nextToken();
 		}
 		if ( token.getType() != Token.EOF ) {
-			StringBuffer	extraText	= new StringBuffer();
+			StringBuilder	extraText	= new StringBuilder();
 			int				startLine	= token.getLine();
 			int				startColumn	= token.getCharPositionInLine();
 			int				endColumn	= startColumn + token.getText().length();
@@ -410,7 +383,7 @@ public class BoxScriptParser extends AbstractParser {
 				extraText.append( token.getText() );
 				token = lexer.nextToken();
 			}
-			issues.add( new Issue( "Extra char(s) [" + extraText.toString() + "] at the end of parsing.", position ) );
+			errorListener.semanticError( "Extra char(s) [" + extraText + "] at the end of parsing.", position );
 		}
 
 		// If there is already a parsing issue, try to get a more specific error
@@ -419,26 +392,24 @@ public class BoxScriptParser extends AbstractParser {
 			Token unclosedBrace = lexer.findUnclosedToken( BoxScriptLexerCustom.LBRACE, BoxScriptLexerCustom.RBRACE );
 			if ( unclosedBrace != null ) {
 				issues.clear();
-				issues.add(
-				    new Issue( "Unclosed curly brace [{] on line " + ( unclosedBrace.getLine() + this.startLine ),
-				        createOffsetPosition( unclosedBrace.getLine(),
-				            unclosedBrace.getCharPositionInLine(), unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine() + 1 ) ) );
+				errorListener.reset();
+				errorListener.semanticError( "Unclosed curly brace [{] on line " + ( unclosedBrace.getLine() + this.startLine ), createOffsetPosition(
+				    unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine(), unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine() + 1 ) );
 			}
 
 			Token unclosedParen = lexer.findUnclosedToken( BoxScriptLexerCustom.LPAREN, BoxScriptLexerCustom.RPAREN );
 			if ( unclosedParen != null ) {
 				issues.clear();
-				issues
-				    .add( new Issue( "Unclosed parenthesis [(] on line " + ( unclosedParen.getLine() + this.startLine ),
-				        createOffsetPosition( unclosedParen.getLine(),
-				            unclosedParen.getCharPositionInLine(), unclosedParen.getLine(), unclosedParen.getCharPositionInLine() + 1 ) ) );
+				errorListener.reset();
+				errorListener.semanticError( "Unclosed parenthesis [(] on line " + ( unclosedParen.getLine() + this.startLine ), createOffsetPosition(
+				    unclosedParen.getLine(), unclosedParen.getCharPositionInLine(), unclosedParen.getLine(), unclosedParen.getCharPositionInLine() + 1 ) );
 			}
 		}
 	}
 
 	/**
 	 * Extract comments from the lexer's hidden channel and parse the java doc comments
-	 * 
+	 *
 	 * @param lexer the lexer to extract comments from
 	 */
 	private void extractComments( BoxScriptLexerCustom lexer ) throws IOException {
@@ -466,1963 +437,8 @@ public class BoxScriptParser extends AbstractParser {
 		}
 	}
 
-	protected BoxNode toAst( File file, BoxScriptGrammar.ClassOrInterfaceContext classOrInterface ) {
-
-		if ( classOrInterface.boxClass() != null ) {
-			return toAst( file, classOrInterface.boxClass() );
-		} else if ( classOrInterface.interface_() != null ) {
-			return toAst( file, classOrInterface.interface_() );
-		} else {
-			issues.add( new Issue( "Unexpected classOrInterface type", getPosition( classOrInterface ) ) );
-			return null;
-		}
-
-	}
-
-	private BoxNode toAst( File file, BoxScriptGrammar.InterfaceContext interface_ ) {
-		List<BoxStatement>					body			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxAnnotation>					postAnnotations	= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxImport>						imports			= new ArrayList<>();
-
-		interface_.importStatement().forEach( stmt -> {
-			imports.add( toAst( file, stmt ) );
-		} );
-
-		for ( BoxScriptGrammar.PostannotationContext annotation : interface_.postannotation() ) {
-			postAnnotations.add( toAst( file, annotation ) );
-		}
-		interface_.abstractFunction().forEach( stmt -> {
-			body.add( toAst( file, stmt ) );
-		} );
-		interface_.function().forEach( stmt -> {
-			BoxFunctionDeclaration funDec = toAst( file, stmt );
-			body.add( funDec );
-			// ensure last function added has default modifier
-			if ( funDec.getModifiers().stream()
-			    .noneMatch( m -> m.equals( BoxMethodDeclarationModifier.DEFAULT ) || m.equals( BoxMethodDeclarationModifier.STATIC ) ) ) {
-				issues.add( new Issue( "Interface methods must have the default or static modifier", funDec.getPosition() ) );
-			}
-		} );
-		interface_.staticInitializer().forEach( stmt -> {
-			body.add( toAst( file, stmt ) );
-		} );
-
-		return new BoxInterface( imports, body, annotations, postAnnotations, documentation, getPosition( interface_ ), getSourceText( interface_ ) );
-	}
-
-	/**
-	 * Converts the interface Function declaration parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionContext rule
-	 *
-	 * @return corresponding AST AbstractFunctionContext
-	 *
-	 * @see AbstractFunctionContext
-	 */
-	private BoxFunctionDeclaration toAst( File file, BoxScriptGrammar.AbstractFunctionContext node ) {
-		return processFunction(
-		    node.functionSignature().preannotation(),
-		    node.postannotation(),
-		    node.functionSignature().identifier().getText(),
-		    node.functionSignature(),
-		    null,
-		    node );
-	}
-
-	/**
-	 * Converts the Function declaration parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionContext rule
-	 *
-	 * @return corresponding AST BoxFunctionDeclaration
-	 *
-	 * @see BoxFunctionDeclaration
-	 */
-	private BoxFunctionDeclaration toAst( File file, BoxScriptGrammar.FunctionContext node ) {
-		return processFunction(
-		    node.functionSignature().preannotation(),
-		    node.postannotation(),
-		    node.functionSignature().identifier().getText(),
-		    node.functionSignature(),
-		    node.statementBlock(),
-		    node );
-	}
-
-	private BoxFunctionDeclaration processFunction(
-	    List<BoxScriptGrammar.PreannotationContext> preannotations,
-	    List<BoxScriptGrammar.PostannotationContext> postannotations,
-	    String name,
-	    BoxScriptGrammar.FunctionSignatureContext functionSignature,
-	    BoxScriptGrammar.StatementBlockContext statementBlock,
-	    ParserRuleContext node ) {
-
-		BoxReturnType						returnType		= null;
-		// Is null for interface function
-		List<BoxStatement>					body			= null;
-		List<BoxArgumentDeclaration>		args			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxAnnotation>					annToRemove		= new ArrayList<>();
-		BoxAccessModifier					accessModifier	= null;
-		List<BoxMethodDeclarationModifier>	modifiers		= new ArrayList<>();
-
-		if ( functionSignature.modifiers() != null ) {
-			if ( !functionSignature.modifiers().STATIC().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.STATIC );
-			}
-			if ( !functionSignature.modifiers().FINAL().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.FINAL );
-			}
-			if ( !functionSignature.modifiers().ABSTRACT().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.ABSTRACT );
-			}
-			if ( !functionSignature.modifiers().DEFAULT().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.DEFAULT );
-			}
-			if ( functionSignature.modifiers().accessModifier() != null && !functionSignature.modifiers().accessModifier().isEmpty() ) {
-				var accessModifierNode = functionSignature.modifiers().accessModifier( 0 );
-				if ( accessModifierNode.PUBLIC() != null ) {
-					accessModifier = BoxAccessModifier.Public;
-				} else if ( accessModifierNode.PRIVATE() != null ) {
-					accessModifier = BoxAccessModifier.Private;
-				} else if ( accessModifierNode.REMOTE() != null ) {
-					accessModifier = BoxAccessModifier.Remote;
-				} else if ( accessModifierNode.PACKAGE() != null ) {
-					accessModifier = BoxAccessModifier.Package;
-				}
-			}
-		}
-
-		for ( BoxScriptGrammar.PreannotationContext annotation : preannotations ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-		for ( BoxScriptGrammar.PostannotationContext annotation : postannotations ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-
-		if ( functionSignature.functionParamList() != null ) {
-			for ( BoxScriptGrammar.FunctionParamContext arg : functionSignature.functionParamList().functionParam() ) {
-				BoxArgumentDeclaration argDeclaration = toAst( file, arg );
-				/* Resolve annotations @name.key "value" */
-				for ( BoxAnnotation pre : annotations ) {
-					String prename = pre.getKey().getValue();
-					if ( prename.toLowerCase().startsWith( argDeclaration.getName().toLowerCase() ) ) {
-						if ( prename.indexOf( '.' ) > -1 ) {
-							prename = pre.getKey().getValue().substring( 0, pre.getKey().getValue().indexOf( "." ) );
-
-						} else {
-							prename = "hint";
-						}
-						BoxFQN key = new BoxFQN(
-						    pre.getKey().getValue().substring( pre.getKey().getValue().indexOf( "." ) + 1 ), pre.getPosition(),
-						    pre.getSourceText()
-						);
-						argDeclaration.getAnnotations().add(
-						    new BoxAnnotation( key, pre.getValue(), pre.getPosition(), pre.getSourceText() )
-						);
-						annToRemove.add( pre );
-					}
-				}
-				args.add( argDeclaration );
-			}
-		}
-
-		if ( functionSignature.returnType() != null ) {
-			String	targetType	= functionSignature.returnType().getText();
-			BoxType	boxType		= BoxType.fromString( targetType );
-			String	fqn			= boxType.equals( BoxType.Fqn ) ? targetType : null;
-			returnType = new BoxReturnType( boxType, fqn, getPosition( functionSignature.returnType() ), getSourceText( functionSignature.returnType() ) );
-		}
-		if ( statementBlock != null ) {
-			body = new ArrayList<>();
-			body.addAll( toAstStatementBlockAsList( file, statementBlock ) );
-		}
-		annotations.removeAll( annToRemove );
-
-		return new BoxFunctionDeclaration( accessModifier, modifiers, name, returnType, args, annotations, documentation, body, getPosition( node ),
-		    getSourceText( node ) );
-	}
-
-	protected BoxScript toAst( File file, BoxScriptGrammar.ScriptContext rule, Token firstToken ) {
-		List<BoxStatement> statements = new ArrayList<>();
-
-		rule.functionOrStatement().forEach( stmt -> {
-			statements.add( toAst( file, stmt ) );
-		} );
-		// Force the script to start at the top of the file so doc comments associate with functions correctly
-		return new BoxScript( statements, getPositionStartingAt( rule, firstToken ), getSourceText( rule ) );
-	}
-
-	private BoxNode toAst( File file, BoxClassContext component ) {
-		List<BoxStatement>					body			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxProperty>					property		= new ArrayList<>();
-		List<BoxImport>						imports			= new ArrayList<>();
-		// Used for validating existence of abstract methods
-		boolean								isAbstract;
-
-		component.importStatement().forEach( stmt -> {
-			imports.add( toAst( file, stmt ) );
-		} );
-
-		for ( BoxScriptGrammar.PreannotationContext annotation : component.preannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-		for ( BoxScriptGrammar.PostannotationContext annotation : component.postannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-		if ( component.ABSTRACT() != null ) {
-			annotations.add(
-			    new BoxAnnotation(
-			        new BoxFQN( "abstract", getPosition( component.ABSTRACT() ), component.ABSTRACT().getText() ),
-			        null,
-			        getPosition( component.ABSTRACT() ),
-			        component.ABSTRACT().getText() ) );
-		}
-		isAbstract = annotations.stream().anyMatch( a -> a.getKey().getValue().equalsIgnoreCase( "abstract" ) );
-
-		if ( component.classBody() != null && component.classBody().children != null ) {
-			for ( var child : component.classBody().children ) {
-				if ( child instanceof BoxScriptGrammar.FunctionOrStatementContext funOrStmt ) {
-					if ( funOrStmt.abstractFunction() != null ) {
-						BoxScriptGrammar.AbstractFunctionContext abstractFunc = funOrStmt.abstractFunction();
-						if ( !isAbstract ) {
-							issues.add( new Issue( "Unexpected abstract function in non-abstract class", getPosition( child ) ) );
-							return null;
-						}
-						if ( abstractFunc.functionSignature().modifiers() != null && abstractFunc.functionSignature().modifiers().ABSTRACT().isEmpty() ) {
-							issues.add(
-							    new Issue(
-							        "Function [" + abstractFunc.functionSignature().identifier().getText() + "] with no body must have abstract modifier",
-							        getPosition( child ) ) );
-							return null;
-						}
-						body.add( toAst( file, abstractFunc ) );
-						continue;
-					}
-					body.add( toAst( file, funOrStmt ) );
-				} else if ( child instanceof BoxScriptGrammar.StaticInitializerContext staticInit ) {
-					body.add( toAst( file, staticInit ) );
-				} else {
-					issues.add( new Issue( "Unexpected class body type: " + child.getClass().getSimpleName(), getPosition( child ) ) );
-					return null;
-				}
-			}
-		}
-		for ( BoxScriptGrammar.PropertyContext annotation : component.property() ) {
-			property.add( toAst( file, annotation ) );
-		}
-
-		return new BoxClass( imports, body, annotations, documentation, property, getPositionStartingAt( component, component.boxClassName() ),
-		    getSourceText( component ) );
-	}
-
-	private BoxStaticInitializer toAst( File file, BoxScriptGrammar.StaticInitializerContext staticInitializer ) {
-		List<BoxStatement> body = toAstStatementBlockAsList( file, staticInitializer.statementBlock() );
-		return new BoxStaticInitializer( body, getPosition( staticInitializer ), getSourceText( staticInitializer ) );
-	}
-
-	/**
-	 * Converts the ImportStatementContext parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param rule ANTLR ImportStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxImport
-	 */
-	private BoxImport toAst( File file, BoxScriptGrammar.ImportStatementContext rule ) {
-		BoxExpression	expr	= null;
-		BoxIdentifier	alias	= null;
-		if ( rule.importFQN() != null ) {
-			String prefix = "";
-			if ( rule.prefix != null ) {
-				prefix = rule.prefix.getText() + ":";
-			}
-			expr = new BoxFQN( prefix + rule.importFQN().getText(), getPosition( rule.importFQN() ), getSourceText( rule.importFQN() ) );
-		}
-		if ( rule.alias != null ) {
-			BoxExpression tmp = toAst( file, rule.alias );
-			if ( tmp instanceof BoxScope ) {
-				issues.add( new Issue( "Cannot use a scope as an alias", getPosition( rule ) ) );
-				return null;
-			} else {
-				alias = ( BoxIdentifier ) tmp;
-			}
-
-		}
-		return new BoxImport( expr, alias, getPosition( rule ), getSourceText( rule ) );
-	}
-
-	/**
-	 * Converts the FunctionOrStatement parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionOrStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.FunctionOrStatementContext node ) {
-		if ( node.function() != null ) {
-			return toAst( file, node.function() );
-		} else if ( node.statement() != null ) {
-			return toAst( file, node.statement() );
-		} else {
-			issues.add( new Issue( "Function or statement not implemented", getPosition( node ) ) );
-			return null;
-		}
-	}
-
-	/**
-	 * Converts the Statement parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR StatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.StatementContext node ) {
-		if ( node.simpleStatement() != null ) {
-			return toAst( file, node.simpleStatement() );
-		} else if ( node.if_() != null ) {
-			return toAst( file, node.if_() );
-		} else if ( node.while_() != null ) {
-			return toAst( file, node.while_() );
-		} else if ( node.do_() != null ) {
-			return toAst( file, node.do_() );
-		} else if ( node.switch_() != null ) {
-			return toAst( file, node.switch_() );
-		} else if ( node.for_() != null ) {
-			return toAst( file, node.for_() );
-		} else if ( node.try_() != null ) {
-			return toAst( file, node.try_() );
-		} else if ( node.componentIsland() != null ) {
-			return toAst( file, node.componentIsland() );
-		} else if ( node.component() != null ) {
-			return toAst( file, node.component() );
-		} else if ( node.include() != null ) {
-			return toAst( file, node.include() );
-		} else if ( node.statementBlock() != null ) {
-			return toAst( file, node.statementBlock() );
-		} else if ( node.importStatement() != null ) {
-			return toAst( file, node.importStatement() );
-		} else if ( node.throw_() != null ) {
-			return toAst( file, node.throw_() );
-		} else {
-			issues.add( new Issue( "Statement not implemented", getPosition( node ) ) );
-			return null;
-		}
-	}
-
-	/**
-	 * Converts the StatementFavorBlockContext parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR StatementFavorBlockContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.StatementFavorBlockContext node ) {
-		if ( node.simpleStatement() != null ) {
-			return toAst( file, node.simpleStatement() );
-		} else if ( node.if_() != null ) {
-			return toAst( file, node.if_() );
-		} else if ( node.while_() != null ) {
-			return toAst( file, node.while_() );
-		} else if ( node.do_() != null ) {
-			return toAst( file, node.do_() );
-		} else if ( node.switch_() != null ) {
-			return toAst( file, node.switch_() );
-		} else if ( node.for_() != null ) {
-			return toAst( file, node.for_() );
-		} else if ( node.try_() != null ) {
-			return toAst( file, node.try_() );
-		} else if ( node.componentIsland() != null ) {
-			return toAst( file, node.componentIsland() );
-		} else if ( node.component() != null ) {
-			return toAst( file, node.component() );
-		} else if ( node.include() != null ) {
-			return toAst( file, node.include() );
-		} else if ( node.statementBlock() != null ) {
-			return toAst( file, node.statementBlock() );
-		} else if ( node.importStatement() != null ) {
-			return toAst( file, node.importStatement() );
-		} else if ( node.throw_() != null ) {
-			return toAst( file, node.throw_() );
-		} else {
-			issues.add( new Issue( "Statement not implemented", getPosition( node ) ) );
-			return null;
-		}
-	}
-
-	private BoxStatement toAst( File file, ComponentContext node ) {
-		List<BoxStatement>	body			= null;
-		String				componentName	= node.componentName().getText();
-		List<BoxAnnotation>	attributes		= new ArrayList<>();
-
-		if ( node.componentAttributes() != null && node.componentAttributes().componentAttribute() != null ) {
-			for ( var attr : node.componentAttributes().componentAttribute() ) {
-				attributes.add( toAstAnnotation( file, attr ) );
-			}
-		}
-
-		// Special check for param's script shortcut
-		if ( componentName.equalsIgnoreCase( "param" ) ) {
-			// If there is only one attribute and it is not name= and has a value, then we need to convert it to a name/value pair
-			// Ex: param foo="bar";
-			// Becomes: param name="foo" default="bar";
-			if ( attributes.size() == 1 && !attributes.get( 0 ).getKey().getValue().equalsIgnoreCase( "name" ) && attributes.get( 0 ).getValue() != null ) {
-				List<BoxAnnotation> newAttributes = new ArrayList<>();
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "name", getPosition( node ), "name" ),
-				        new BoxStringLiteral( attributes.get( 0 ).getKey().getValue(), attributes.get( 0 ).getKey().getPosition(),
-				            attributes.get( 0 ).getKey().getSourceText() ),
-				        attributes.get( 0 ).getKey().getPosition(),
-				        "name=\"" + attributes.get( 0 ).getKey().getSourceText() + "\""
-				    )
-				);
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "default", attributes.get( 0 ).getValue().getPosition(), "default" ),
-				        attributes.get( 0 ).getValue(),
-				        attributes.get( 0 ).getValue().getPosition(),
-				        "default=" + attributes.get( 0 ).getValue().getSourceText()
-				    )
-				);
-				attributes = newAttributes;
-				// If there are two attributes, the first one has a null value, and none of them are named "name"
-				// Ex: param String foo="bar";
-				// Becomes: param type="String" name="foo" default="bar";
-				// Ex: param String foo;
-				// Becomes: param type="String" name="foo";
-			} else if ( attributes.size() == 2 && attributes.get( 0 ).getValue() == null && !attributes.get( 0 ).getKey().getValue().equalsIgnoreCase( "name" )
-			    && !attributes.get( 1 ).getKey().getValue().equalsIgnoreCase( "name" ) ) {
-				List<BoxAnnotation> newAttributes = new ArrayList<>();
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "type", getPosition( node ), "type" ),
-				        new BoxStringLiteral( attributes.get( 0 ).getKey().getValue(), attributes.get( 0 ).getKey().getPosition(),
-				            attributes.get( 0 ).getKey().getSourceText() ),
-				        attributes.get( 0 ).getKey().getPosition(),
-				        "type=\"" + attributes.get( 0 ).getKey().getSourceText() + "\""
-				    )
-				);
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "name", getPosition( node ), "name" ),
-				        new BoxStringLiteral( attributes.get( 1 ).getKey().getValue(), attributes.get( 1 ).getKey().getPosition(),
-				            attributes.get( 1 ).getKey().getSourceText() ),
-				        attributes.get( 1 ).getKey().getPosition(),
-				        "name=" + attributes.get( 1 ).getKey().getSourceText()
-				    )
-				);
-				// Only if there is a default
-				if ( attributes.get( 1 ).getValue() != null ) {
-					newAttributes.add(
-					    new BoxAnnotation(
-					        new BoxFQN( "default", attributes.get( 1 ).getValue().getPosition(), "default" ),
-					        attributes.get( 1 ).getValue(),
-					        attributes.get( 1 ).getValue().getPosition(),
-					        "default=" + attributes.get( 1 ).getValue().getSourceText()
-					    )
-					);
-				}
-				attributes = newAttributes;
-			}
-		}
-
-		ComponentDescriptor descriptor = componentService.getComponent( componentName );
-		if ( node.statementBlock() != null ) {
-			if ( descriptor != null && !descriptor.allowsBody() ) {
-				issues.add( new Issue( "The [" + componentName + "] component does not allow a body", getPosition( node ) ) );
-			}
-			body = new ArrayList<>();
-			body.addAll( toAstStatementBlockAsList( file, node.statementBlock() ) );
-		} else if ( descriptor != null && descriptor.requiresBody() ) {
-			issues.add( new Issue( "The [" + componentName + "] component requires a body", getPosition( node ) ) );
-		}
-
-		// Special check for loop condition to avoid runtime eval
-		if ( componentName.equalsIgnoreCase( "loop" ) ) {
-			for ( var attr : attributes ) {
-				if ( attr.getKey().getValue().equalsIgnoreCase( "condition" ) ) {
-					BoxExpression condition = attr.getValue();
-					if ( condition instanceof BoxStringLiteral str ) {
-						// parse as script expression and update value
-						condition = parseBoxExpression( str.getValue(), condition.getPosition() );
-					}
-					BoxExpression newCondition = new BoxClosure(
-					    List.of(),
-					    List.of(),
-					    new BoxReturn( condition, condition.getPosition(), condition.getSourceText() ),
-					    condition.getPosition(),
-					    condition.getSourceText() );
-					attr.setValue( newCondition );
-				}
-			}
-		}
-		return new BoxComponent( componentName, attributes, body, 0, getPosition( node ), getSourceText( node ) );
-	}
-
-	private BoxAnnotation toAstAnnotation( File file, BoxScriptGrammar.ComponentAttributeContext node ) {
-		BoxFQN			name	= new BoxFQN( node.identifier().getText(), getPosition( node.identifier() ), getSourceText( node.identifier() ) );
-		BoxExpression	value	= null;
-		if ( node.expression() != null ) {
-			value = toAst( file, node.expression() );
-		}
-		return new BoxAnnotation( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ComponentIslandContext parser rule to the corresponding AST node
-	 *
-	 * @param file            source file, if any
-	 * @param componentIsland ANTLR ComponentIslandContext rule
-	 *
-	 * @return the corresponding AST BoxComponentIsland
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxTemplateIsland toAst( File file, ComponentIslandContext componentIsland ) {
-		return new BoxTemplateIsland(
-		    parseBoxTemplateStatements(
-		        componentIsland.componentIslandBody().getText(),
-		        getPosition( componentIsland.componentIslandBody() )
-		    ),
-		    getPosition( componentIsland.componentIslandBody() ),
-		    getSourceText( componentIsland.componentIslandBody() )
-		);
-
-	}
-
-	public List<BoxStatement> parseBoxTemplateStatements( String code, Position position ) {
-		try {
-			if ( inOutputBlock ) {
-				code = "<bx:output>" + code + "</bx:output>";
-			}
-			ParsingResult result = new BoxTemplateParser( position.getStart().getLine(), position.getStart().getColumn() )
-			    .setSource( sourceToParse )
-			    .setSubParser( true )
-			    .parse( code );
-			this.comments.addAll( result.getComments() );
-			if ( result.getIssues().isEmpty() ) {
-				BoxNode root = result.getRoot();
-				if ( root instanceof BoxTemplate template ) {
-					return template.getStatements();
-				} else if ( root instanceof BoxStatement statement ) {
-					return List.of( statement );
-				} else {
-					// Could be a BoxClass, which we may actually need to support
-					issues.add( new Issue( "Unexpected root node type [" + root.getClass().getName() + "] in component island.", root.getPosition() ) );
-					return null;
-				}
-			} else {
-				// Add these issues to the main parser
-				issues.addAll( result.getIssues() );
-				return List.of();
-			}
-		} catch ( IOException e ) {
-			throw new BoxRuntimeException( "Error parsing component island: " + code, e );
-		}
-	}
-
-	/**
-	 * Converts the include parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IncludeContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.IncludeContext node ) {
-		return new BoxComponent(
-		    "include",
-		    List.of(
-		        new BoxAnnotation(
-		            new BoxFQN( "template",
-		                getPosition( node.expression() ),
-		                getSourceText( node.expression() ) ),
-		            toAst( file, node.expression() ),
-		            getPosition( node.expression() ),
-		            getSourceText( node.expression() )
-		        )
-		    ),
-		    getPosition( node ),
-		    getSourceText( node )
-		);
-	}
-
-	/**
-	 * Converts the rethrow parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR RethrowContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.RethrowContext node ) {
-		return new BoxRethrow( getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the throw parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ThrowContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.ThrowContext node ) {
-		BoxExpression expression = toAst( file, node.expression() );
-		return new BoxThrow( expression, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the do parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxDo
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.DoContext node ) {
-		BoxExpression	condition	= toAst( file, node.expression() );
-		BoxStatement	body		= null;
-		String			label		= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statementFavorBlock() );
-		return new BoxDo( label, condition, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the try parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxTry
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.TryContext node ) {
-		List<BoxStatement>	tryBody		= toAstStatementBlockAsList( file, node.statementBlock() );
-		List<BoxTryCatch>	catches		= node.catch_().stream().map( it -> toAst( file, it ) ).collect( Collectors.toList() );
-		List<BoxStatement>	finallyBody	= new ArrayList<>();
-		if ( node.finally_() != null ) {
-			finallyBody.addAll( toAstStatementBlockAsList( file, node.finally_().statementBlock() ) );
-		}
-		return new BoxTry( tryBody, catches, finallyBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the catch parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxTryCatch
-	 */
-	private BoxTryCatch toAst( File file, BoxScriptGrammar.Catch_Context node ) {
-		BoxExpression		exception	= toAst( file, node.expression() );
-		List<BoxStatement>	catchBody	= toAstStatementBlockAsList( file, node.statementBlock() );
-
-		List<BoxExpression>	catchTypes	= node.catchType().stream().map( ctNode -> {
-											if ( ctNode.fqn() != null ) {
-												return new BoxFQN( ctNode.fqn().getText(), getPosition( ctNode ),
-												    getSourceText( ctNode ) );
-											}
-
-											return toAst( file, ctNode.stringLiteral() );
-										} )
-		    .collect( Collectors.toList() );
-
-		return new BoxTryCatch( catchTypes, exception, catchBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the assert parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR AssertContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxAssert
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.AssertContext node ) {
-		BoxExpression expression = toAst( file, node.expression() );
-		return new BoxAssert( expression, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the For parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ForContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxForIn
-	 * @see BoxForIndex
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.ForContext node ) {
-		BoxStatement	body;
-		String			label	= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statementFavorBlock() );
-
-		if ( node.IN() != null ) {
-			BoxExpression	variable	= toAst( file, node.accessExpression() );
-			Boolean			hasVar		= node.VAR() != null;
-			BoxExpression	collection	= toAst( file, node.expression() );
-
-			return new BoxForIn( label, variable, collection, body, hasVar, getPosition( node ), getSourceText( node ) );
-		}
-		BoxExpression	initializer	= null;
-		BoxExpression	condition	= null;
-		BoxExpression	step		= null;
-		if ( node.forAssignment() != null ) {
-			initializer = toAst( file, node.forAssignment().expression() );
-		}
-		if ( node.forCondition() != null ) {
-			condition = toAst( file, node.forCondition().expression() );
-		}
-		if ( node.forIncrement() != null ) {
-			step = toAst( file, node.forIncrement().expression() );
-		}
-
-		return new BoxForIndex( label, initializer, condition, step, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Switch parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR SwitchContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxSwitch
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.SwitchContext node ) {
-		BoxExpression		condition	= toAst( file, node.expression() );
-		List<BoxSwitchCase>	cases		= new ArrayList<>();
-		for ( BoxScriptGrammar.CaseContext c : node.case_() ) {
-			cases.add( toAst( file, c ) );
-		}
-		return new BoxSwitch( condition, cases, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Case parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR CaseContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxSwitchCase
-	 */
-	private BoxSwitchCase toAst( File file, BoxScriptGrammar.CaseContext node ) {
-		BoxExpression expr = null;
-		if ( node.expression() != null ) {
-			expr = toAst( file, node.expression() );
-		}
-
-		List<BoxStatement> statements = new ArrayList<>();
-		if ( node.statementFavorBlock() != null ) {
-			for ( var statement : node.statementFavorBlock() ) {
-				statements.add( toAst( file, statement ) );
-			}
-		}
-		return new BoxSwitchCase( expr, null, statements, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Continue parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ContinueContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxContinue
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.ContinueContext node ) {
-		String label = null;
-		if ( node.identifier() != null ) {
-			label = node.identifier().getText();
-		}
-		return new BoxContinue( label, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Break parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR BreakContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxBreak
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.BreakContext node ) {
-		String label = null;
-		if ( node.identifier() != null ) {
-			label = node.identifier().getText();
-		}
-		return new BoxBreak( label, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the While parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR WhileContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxWhile
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.WhileContext node ) {
-		BoxExpression	condition	= toAst( file, node.condition );
-		BoxStatement	body;
-
-		String			label		= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statementFavorBlock() );
-		return new BoxWhile( label, condition, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the IfContext parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 *
-	 * @return the corresponding AST BoxIfElse
-	 *
-	 * @see BoxIfElse
-	 */
-	private BoxIfElse toAst( File file, BoxScriptGrammar.IfContext node ) {
-		BoxExpression	condition	= toAst( file, node.expression() );
-		BoxStatement	thenBody;
-		BoxStatement	elseBody	= null;
-
-		thenBody = toAst( file, node.ifStmt );
-		if ( node.elseStmt != null ) {
-			elseBody = toAst( file, node.elseStmt );
-		}
-		return new BoxIfElse( condition, thenBody, elseBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the StatementBlock parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR BreakContext rule
-	 *
-	 * @return the list of the corresponding AST BoxStatement subclasses in the block
-	 *
-	 * @see BoxStatement
-	 */
-	private List<BoxStatement> toAstStatementBlockAsList( File file, BoxScriptGrammar.StatementBlockContext node ) {
-		return node.statement().stream().map( stmt -> toAst( file, stmt ) ).collect( Collectors.toList() );
-	}
-
-	private BoxStatement toAst( File file, BoxScriptGrammar.StatementBlockContext node ) {
-		return new BoxStatementBlock( toAstStatementBlockAsList( file, node ), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the SimpleStatement parser rule to the corresponding AST node.
-	 * The SimpleStatement contains rules of an Expression statement
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR SimpleStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement subclass
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.SimpleStatementContext node ) {
-
-		if ( node.assert_() != null ) {
-			return toAst( file, node.assert_() );
-		} else if ( node.return_() != null ) {
-			BoxExpression expr = null;
-			if ( node.return_().expression() != null ) {
-				expr = toAst( file, node.return_().expression() );
-			}
-			return new BoxReturn( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.incrementDecrementStatement() != null ) {
-			return toAst( file, node.incrementDecrementStatement() );
-		} else if ( node.expression() != null ) {
-			BoxExpression expr = toAst( file, node.expression() );
-			return new BoxExpressionStatement( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.break_() != null ) {
-			return toAst( file, node.break_() );
-		} else if ( node.continue_() != null ) {
-			return toAst( file, node.continue_() );
-		} else if ( node.rethrow() != null ) {
-			return toAst( file, node.rethrow() );
-		} else if ( node.param() != null ) {
-			return toAst( file, node.param() );
-		} else if ( node.variableDeclaration() != null ) {
-			return toAst( file, node.variableDeclaration() );
-		}
-
-		issues.add( new Issue( "Simple statement not implemented", getPosition( node ) ) );
-		return null;
-
-	}
-
-	private BoxStatement toAst( File file, VariableDeclarationContext variableDeclaration ) {
-		return new BoxExpressionStatement(
-		    new BoxAssignment(
-		        toAst( file, variableDeclaration.identifier() ),
-		        null,
-		        null,
-		        List.of( BoxAssignmentModifier.VAR ),
-		        getPosition( variableDeclaration ),
-		        getSourceText( variableDeclaration )
-		    ),
-		    getPosition( variableDeclaration ),
-		    getSourceText( variableDeclaration )
-		);
-	}
-
-	private BoxStatement toAst( File file, ParamContext node ) {
-		BoxExpression	type			= null;
-		BoxExpression	defaultValue	= null;
-		if ( node.type() != null ) {
-			type = new BoxStringLiteral( node.type().getText(), getPosition( node.type() ), getSourceText( node.type() ) );
-		}
-		if ( node.expression() != null ) {
-			defaultValue = toAst( file, node.expression() );
-		}
-		return new BoxParam(
-		    new BoxStringLiteral( node.accessExpression().getText(), getPosition( node.accessExpression() ), getSourceText( node.accessExpression() ) ),
-		    type,
-		    defaultValue,
-		    getPosition( node ),
-		    getSourceText( node )
-		);
-	}
-
-	/**
-	 * Converts the IncrementDecrementStatement parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IncrementDecrementStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement subclass
-	 *
-	 * @see
-	 */
-	private BoxStatement toAst( File file, BoxScriptGrammar.IncrementDecrementStatementContext node ) {
-		if ( node instanceof BoxScriptGrammar.PostIncrementContext ) {
-			BoxScriptGrammar.PostIncrementContext	ctx		= ( BoxScriptGrammar.PostIncrementContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PostPlusPlus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof BoxScriptGrammar.PostDecrementContext ) {
-			BoxScriptGrammar.PostDecrementContext	ctx		= ( BoxScriptGrammar.PostDecrementContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PostMinusMinus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof BoxScriptGrammar.PreIncrementContext ) {
-			BoxScriptGrammar.PreIncrementContext	ctx		= ( BoxScriptGrammar.PreIncrementContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PrePlusPlus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof BoxScriptGrammar.PreDecremenentContext ) {
-			BoxScriptGrammar.PreDecremenentContext	ctx		= ( BoxScriptGrammar.PreDecremenentContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PreMinusMinus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		issues.add( new Issue( "Increment/Decrement not implemented", getPosition( node ) ) );
-		return null;
-	}
-
-	/**
-	 * Converts the AccessExpression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR AccessExpressionContext rule
-	 *
-	 * @return the corresponding AST BoxExpression subclass
-	 *
-	 * @see BoxIdentifier
-	 * @see BoxArrayAccess
-	 * @see BoxDotAccess
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.AccessExpressionContext node ) {
-		BoxExpression expr = toAst( file, node.objectExpression() );
-		// loop over children
-		for ( int i = 0; i < node.getChildCount(); i++ ) {
-			ParseTree child = node.getChild( i );
-			if ( child instanceof BoxScriptGrammar.DotAccessContext dotAccess ) {
-				BoxExpression access;
-				// Any reserved keywords like scopes on the accessed after a dot is just a keyword.
-				if ( dotAccess.identifier() != null && dotAccess.identifier().reservedKeyword() != null ) {
-					BoxScriptGrammar.ReservedKeywordContext keyword = dotAccess.identifier().reservedKeyword();
-					access = new BoxIdentifier( keyword.getText(), getPosition( keyword ), getSourceText( keyword ) );
-				} else if ( dotAccess.identifier() != null ) {
-					access = toAst( file, dotAccess.identifier() );
-				} else {
-					// turn .123 into 123 as an integer literal
-					access = new BoxIntegerLiteral( dotAccess.floatLiteralDecimalOnly().getText().substring( 1 ),
-					    getPosition( dotAccess.floatLiteralDecimalOnly() ), getSourceText( dotAccess.floatLiteralDecimalOnly() ) );
-				}
-				expr = new BoxDotAccess( expr, dotAccess.QM() != null, access, getPosition( dotAccess ),
-				    getSourceText( dotAccess ) );
-			} else if ( child instanceof BoxScriptGrammar.ArrayAccessContext arrayAccess ) {
-				expr = new BoxArrayAccess( expr, false, toAst( file, arrayAccess.expression() ), getPosition( arrayAccess ), getSourceText( arrayAccess ) );
-			} else if ( child instanceof BoxScriptGrammar.MethodInvokationContext methodInvokation ) {
-				if ( methodInvokation.functionInvokation() != null ) {
-					List<BoxArgument>					args	= toAst( file, methodInvokation.functionInvokation().invokationExpression().argumentList() );
-					BoxScriptGrammar.IdentifierContext	id		= methodInvokation.functionInvokation().identifier();
-					BoxExpression						name	= new BoxIdentifier( id.getText(), getPosition( id ), getSourceText( id ) );
-
-					expr = new BoxMethodInvocation( name, expr, args, methodInvokation.QM() != null, true, getPosition( methodInvokation ),
-					    getSourceText( methodInvokation ) );
-				} else if ( methodInvokation.arrayAccess() != null ) {
-					List<BoxArgument>	args	= toAst( file, methodInvokation.invokationExpression().argumentList() );
-					BoxExpression		name	= toAst( file, methodInvokation.arrayAccess().expression() );
-					expr = new BoxMethodInvocation( name, expr, args, false, false, getPosition( methodInvokation ), getSourceText( methodInvokation ) );
-				} else {
-					issues.add( new Issue( "Unimplemented method invocation does not use function invocation or array access rules", getPosition( node ) ) );
-					return null;
-				}
-			} else if ( child instanceof BoxScriptGrammar.InvokationExpressionContext invokationExpression ) {
-				expr = new BoxExpressionInvocation( expr, toAst( file, invokationExpression.argumentList() ), getPosition( invokationExpression ),
-				    getSourceText( invokationExpression ) );
-			}
-		}
-		return expr;
-	}
-
-	/**
-	 * Converts the IdentifierContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IdentifierContext rule
-	 *
-	 * @return the corresponding AST BoxIdentifier or a BoxScope if it is a reserved keyword
-	 *
-	 * @see BoxScope
-	 * @see BoxIdentifier
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.IdentifierContext node ) {
-		BoxScriptGrammar.ReservedKeywordContext keyword = node.reservedKeyword();
-		if ( keyword != null && keyword.scope() != null ) {
-			return toAst( file, keyword.scope() );
-		}
-		String name = "";
-		if ( node.IDENTIFIER() != null ) {
-			name = node.IDENTIFIER().getText();
-		} else if ( node.reservedKeyword() != null ) {
-			name = node.reservedKeyword().getText();
-		}
-		return new BoxIdentifier( name, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Scope parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ScopeContext rule
-	 *
-	 * @return corresponding AST BoxScope
-	 *
-	 * @see BoxScope for the reserved keywords used to identify a scope
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.ScopeContext node ) {
-		return new BoxScope( node.getText(), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the string literal into a BoxStringLiteral or BoxStringInterpolation
-	 *
-	 * @param file       source file, if any
-	 * @param expression ANTLR StringLiteralContext rule
-	 *
-	 * @return corresponding AST BoxExpr subclass
-	 *
-	 * @see BoxExpression subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.StringLiteralContext expression ) {
-		String quoteChar = expression.getText().substring( 0, 1 );
-		if ( expression.expression().isEmpty() ) {
-			String s = expression.getText();
-			// trim leading and trailing quote
-			s = s.substring( 1, s.length() - 1 );
-			return new BoxStringLiteral(
-			    escapeStringLiteral( quoteChar, s ),
-			    getPosition( expression ),
-			    getSourceText( expression )
-			);
-
-		} else {
-			List<BoxExpression> parts = new ArrayList<>();
-			expression.children.forEach( it -> {
-				if ( it != null && it instanceof BoxScriptGrammar.StringLiteralPartContext ) {
-					parts.add( new BoxStringLiteral( escapeStringLiteral( quoteChar, getSourceText( ( ParserRuleContext ) it ) ),
-					    getPosition( ( ParserRuleContext ) it ),
-					    getSourceText( ( ParserRuleContext ) it ) ) );
-				}
-				if ( it != null && it instanceof BoxScriptGrammar.ExpressionContext ) {
-					parts.add( toAst( file, ( BoxScriptGrammar.ExpressionContext ) it ) );
-				}
-			} );
-			return new BoxStringInterpolation( parts, getPosition( expression ), getSourceText( expression ) );
-		}
-	}
-
-	/**
-	 * Escape double up quotes and pounds in a string literal
-	 *
-	 * @param quoteChar the quote character used to surround the string
-	 * @param string    the string to escape
-	 *
-	 * @return the escaped string
-	 */
-	private String escapeStringLiteral( String quoteChar, String string ) {
-		String escaped = string.replace( "##", "#" );
-		return escaped.replace( quoteChar + quoteChar, quoteChar );
-	}
-
-	/**
-	 * Converts the Expression parser rule to the corresponding AST node.
-	 * The operator precedence resolved in the ANTLR grammar
-	 *
-	 * @param file       source file, if any
-	 * @param expression ANTLR ExpressionContext rule
-	 *
-	 * @return corresponding AST BoxExpr subclass
-	 *
-	 * @see BoxExpression subclasses
-	 * @see BoxBinaryOperator
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.ExpressionContext expression ) {
-		if ( expression.ternary() != null ) {
-			BoxExpression	condition	= toAst( file, expression.ternary().notTernaryExpression() );
-			BoxExpression	whenTrue	= toAst( file, expression.ternary().expression( 0 ) );
-			BoxExpression	whenFalse	= toAst( file, expression.ternary().expression( 1 ) );
-			return new BoxTernaryOperation( condition, whenTrue, whenFalse, getPosition( expression ), getSourceText( expression ) );
-		}
-		if ( expression.assignment() != null ) {
-			return toAst( file, expression.assignment() );
-		} else if ( expression.notTernaryExpression() != null ) {
-			return toAst( file, expression.notTernaryExpression() );
-		}
-
-		issues.add( new Issue( "Expression not implemented", getPosition( expression ) ) );
-		return null;
-	}
-
-	private BoxExpression toAst( File file, NotTernaryExpressionContext expression ) {
-		if ( expression.accessExpression() != null ) {
-			return toAst( file, expression.accessExpression() );
-		} else if ( expression.and() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.And, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.or() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Or, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.PLUS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Plus, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.MINUS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Minus, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.STAR() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Star, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.SLASH() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Slash, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.BACKSLASH() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Backslash, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.unary() != null ) {
-			return toAst( file, expression.unary() );
-		} else if ( expression.POWER() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Power, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.XOR() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Xor, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.PERCENT() != null || expression.MOD() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Mod, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.instanceOf() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.InstanceOf, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.TEQ() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.TEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.neq() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.NotEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.gt() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.GreaterThan, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.gte() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.GreaterThanEquals, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.lt() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.LessThan, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.lte() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.LesslThanEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.eq() != null || expression.IS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.Equal, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.AMPERSAND() != null ) {
-			List<BoxExpression>								parts	= new ArrayList<>();
-			BoxScriptGrammar.NotTernaryExpressionContext	current	= expression;
-			// unwrap nested foo & bar & baz & bum into a single concat node
-			do {
-				parts.add( 0, toAst( file, current.right ) );
-				current = current.left;
-			} while ( current.AMPERSAND() != null );
-			parts.add( 0, toAst( file, current ) );
-
-			return new BoxStringConcat( parts, getPosition( expression ), getSourceText( expression ) );
-
-		} else if ( expression.EQV() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Equivalence, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.IMP() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Implies, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.ELVIS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Elvis, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.notOrBang() != null && expression.CONTAIN() == null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			return new BoxUnaryOperation( expr, BoxUnaryOperator.Not, getPosition( expression ), getSourceText( expression ) );
-			// return new BoxNegateOperation( expr, BoxNegateOperator.Not, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.CONTAINS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Contains, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.CONTAIN() != null && expression.DOES() != null && expression.NOT() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.NotContains, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.pre != null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			if ( expression.PLUSPLUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PrePlusPlus, getPosition( expression ), getSourceText( expression ) );
-			}
-			if ( expression.MINUSMINUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PreMinusMinus, getPosition( expression ), getSourceText( expression ) );
-			}
-		} else if ( expression.post != null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			if ( expression.PLUSPLUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PostPlusPlus, getPosition( expression ), getSourceText( expression ) );
-			}
-			if ( expression.MINUSMINUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PostMinusMinus, getPosition( expression ), getSourceText( expression ) );
-			}
-		} else if ( expression.castAs() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.CastAs, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( !expression.ICHAR().isEmpty() ) {
-			return toAst( file, expression.notTernaryExpression( 0 ) );
-		} else if ( expression.assignment() != null ) {
-			return toAst( file, expression.assignment() );
-		} else if ( expression.NULL() != null ) {
-			return new BoxNull( getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.bitwiseSignedLeftShift() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseSignedLeftShift, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.bitwiseSignedRightShift() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseSignedRightShift, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.bitwiseUnsignedRightShift() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseUnsignedRightShift, right, getPosition( expression ),
-			    getSourceText( expression ) );
-		} else if ( expression.bitwiseAnd() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseAnd, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.bitwiseOr() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseOr, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.bitwiseXOR() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.BitwiseXor, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.anonymousFunction() != null ) {
-			/* Lambda declaration */
-			if ( expression.anonymousFunction().lambda() != null ) {
-				BoxScriptGrammar.LambdaContext	lambda		= expression.anonymousFunction().lambda();
-				List<BoxArgumentDeclaration>	args		= new ArrayList<>();
-				List<BoxAnnotation>				annotations	= new ArrayList<>();
-				BoxStatement					body;
-				/* Process the arguments */
-				if ( lambda.functionParamList() != null ) {
-					for ( BoxScriptGrammar.FunctionParamContext arg : lambda.functionParamList().functionParam() ) {
-						BoxArgumentDeclaration argDeclaration = toAst( file, arg );
-						args.add( argDeclaration );
-					}
-				}
-				if ( lambda.identifier() != null ) {
-					BoxArgumentDeclaration argDeclaration = new BoxArgumentDeclaration( false, "Any", lambda.identifier().getText(), null, new ArrayList<>(),
-					    new ArrayList<>(), getPosition( lambda.identifier() ), getSourceText( lambda.identifier() ) );
-					args.add( argDeclaration );
-				}
-				/* Process the annotations */
-				for ( BoxScriptGrammar.PostannotationContext annotation : lambda.postannotation() ) {
-					annotations.add( toAst( file, annotation ) );
-				}
-				/* Process the body */
-				body = toAst( file, lambda.statementFavorBlock() );
-				return new BoxLambda( args, annotations, body, getPosition( expression ), getSourceText( expression ) );
-			} else if ( expression.anonymousFunction().closure() != null ) {
-				/* Closure declaration */
-				BoxScriptGrammar.ClosureContext	closure		= expression.anonymousFunction().closure();
-				List<BoxArgumentDeclaration>	args		= new ArrayList<>();
-				List<BoxAnnotation>				annotations	= new ArrayList<>();
-				BoxStatement					body;
-
-				if ( closure.functionParamList() != null ) {
-					for ( BoxScriptGrammar.FunctionParamContext arg : closure.functionParamList().functionParam() ) {
-						BoxArgumentDeclaration argDeclaration = toAst( file, arg );
-						args.add( argDeclaration );
-					}
-				}
-				if ( closure.identifier() != null ) {
-					BoxArgumentDeclaration argDeclaration = new BoxArgumentDeclaration( false, "Any", closure.identifier().getText(), null, new ArrayList<>(),
-					    new ArrayList<>(), getPosition( closure.identifier() ), getSourceText( closure.identifier() ) );
-					args.add( argDeclaration );
-				}
-				/* Process the annotations */
-				for ( BoxScriptGrammar.PostannotationContext annotation : closure.postannotation() ) {
-					annotations.add( toAst( file, annotation ) );
-				}
-				/* Process the body */
-				// ()=> and ()->{} funnel through anonymousFunctionBody and have statementblock or simplestatement
-				if ( closure.statementFavorBlock() != null ) {
-					body = toAst( file, closure.statementFavorBlock() );
-					// function() {} syntax always uses statement block
-				} else {
-					body = toAst( file, closure.statementBlock() );
-				}
-
-				return new BoxClosure( args, annotations, body, getPosition( expression ), getSourceText( expression ) );
-			}
-		} else if ( expression.staticAccessExpression() != null ) {
-			return toAst( file, expression.staticAccessExpression() );
-		} else if ( expression.COLONCOLON() != null ) {
-			return new BoxFunctionalBIFAccess( expression.identifier().getText(), getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.DOT() != null ) {
-			List<BoxArgument> arguments = null;
-			if ( expression.invokationExpression() != null ) {
-				arguments = toAst( file, expression.invokationExpression().argumentList() );
-			}
-			return new BoxFunctionalMemberAccess( expression.identifier().getText(), arguments, getPosition( expression ), getSourceText( expression ) );
-		}
-		issues.add( new Issue( "Expression not implemented", getPosition( expression ) ) );
-		return null;
-	}
-
-	private BoxExpression toAst( File file, BoxScriptGrammar.StaticAccessExpressionContext staticAccessExpression ) {
-		BoxExpression expr = toAst( file, staticAccessExpression.staticObjectExpression() );
-
-		if ( staticAccessExpression.staticMethodInvokation() != null ) {
-			List<BoxArgument>					args	= toAst( file,
-			    staticAccessExpression.staticMethodInvokation().functionInvokation().invokationExpression().argumentList() );
-			BoxScriptGrammar.IdentifierContext	id		= staticAccessExpression.staticMethodInvokation().functionInvokation().identifier();
-			BoxIdentifier						name	= new BoxIdentifier( id.getText(), getPosition( id ), getSourceText( id ) );
-
-			return new BoxStaticMethodInvocation( name, expr, args, getPosition( staticAccessExpression.staticMethodInvokation() ),
-			    getSourceText( staticAccessExpression.staticMethodInvokation() ) );
-
-		} else if ( staticAccessExpression.staticAccess() != null ) {
-			BoxExpression access;
-			// Any reserved keywords like scopes on the accessed after a dot is just a keyword.
-			if ( staticAccessExpression.staticAccess().identifier() != null ) {
-				access = new BoxIdentifier( staticAccessExpression.staticAccess().identifier().getText(),
-				    getPosition( staticAccessExpression.staticAccess().identifier() ), getSourceText( staticAccessExpression.staticAccess().identifier() ) );
-			} else {
-				// turn 123 into an integer literal
-				access = new BoxIntegerLiteral( staticAccessExpression.staticAccess().integerLiteral().getText(),
-				    getPosition( staticAccessExpression.staticAccess().integerLiteral() ),
-				    getSourceText( staticAccessExpression.staticAccess().integerLiteral() ) );
-			}
-			return new BoxStaticAccess( expr, false, access, getPosition( staticAccessExpression.staticAccess() ),
-			    getSourceText( staticAccessExpression.staticAccess() ) );
-		} else {
-			issues.add( new Issue( "Unimplemented static method invocation does not use function invocation or array access rules",
-			    getPosition( staticAccessExpression ) ) );
-			return null;
-		}
-	}
-
-	private BoxExpression toAst( File file, BoxScriptGrammar.StaticObjectExpressionContext staticObjectExpression ) {
-		if ( staticObjectExpression.fqn() != null ) {
-			return toAst( file, staticObjectExpression.fqn() );
-		} else if ( staticObjectExpression.identifier() != null ) {
-			return new BoxIdentifier( staticObjectExpression.identifier().getText(), getPosition( staticObjectExpression.identifier() ),
-			    getSourceText( staticObjectExpression.identifier() ) );
-		} else {
-			issues.add( new Issue( "Unimplemented static object expression", getPosition( staticObjectExpression ) ) );
-			return null;
-		}
-	}
-
-	private BoxExpression toAst( File file, AssignmentContext node ) {
-		BoxExpression			left	= toAst( file, node.assignmentLeft().accessExpression() );
-		BoxExpression			right	= toAst( file, node.assignmentRight().expression() );
-		BoxAssignmentOperator	op		= BoxAssignmentOperator.Equal;
-		if ( node.PLUSEQUAL() != null ) {
-			op = BoxAssignmentOperator.PlusEqual;
-		} else if ( node.MINUSEQUAL() != null ) {
-			op = BoxAssignmentOperator.MinusEqual;
-		} else if ( node.STAREQUAL() != null ) {
-			op = BoxAssignmentOperator.StarEqual;
-		} else if ( node.SLASHEQUAL() != null ) {
-			op = BoxAssignmentOperator.SlashEqual;
-		} else if ( node.MODEQUAL() != null ) {
-			op = BoxAssignmentOperator.ModEqual;
-		} else if ( node.CONCATEQUAL() != null ) {
-			op = BoxAssignmentOperator.ConcatEqual;
-		}
-		// In the future, we expect there to be more than just var here, thus the list.
-		List<BoxAssignmentModifier> modifiers = new ArrayList<BoxAssignmentModifier>();
-		if ( node.VAR() != null ) {
-			modifiers.add( BoxAssignmentModifier.VAR );
-		}
-
-		return new BoxAssignment( left, op, right, modifiers, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the UnaryContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FqnContext rule
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.FqnContext node ) {
-		return new BoxFQN( node.getText(), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the UnaryContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR UnaryContext rule
-	 *
-	 * @return corresponding AST BoxUnaryOperation
-	 *
-	 * @see BoxUnaryOperation
-	 * @see BoxUnaryOperator
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.UnaryContext node ) {
-
-		BoxExpression		expr	= toAst( file, node.expression() );
-		BoxUnaryOperator	op		= node.MINUS() != null ? BoxUnaryOperator.Minus
-		    : ( node.PLUS() != null ? BoxUnaryOperator.Plus : BoxUnaryOperator.BitwiseComplement );
-		if ( expr instanceof BoxBinaryOperation bop ) {
-			return new BoxBinaryOperation(
-			    new BoxUnaryOperation( bop.getLeft(), op, getPosition( node ), getSourceText( node ) ),
-			    bop.getOperator(),
-			    bop.getRight(),
-			    bop.getPosition(),
-			    bop.getSourceText()
-			);
-		}
-		return new BoxUnaryOperation( expr, op, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ObjectExpression parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ObjectExpressionContext rule
-	 *
-	 * @return corresponding AST
-	 *
-	 * @see BoxAccess subclasses
-	 * @see BoxIdentifier subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.ObjectExpressionContext node ) {
-		if ( node.LPAREN() != null ) {
-			BoxExpression expr = toAst( file, node.expression() );
-			return new BoxParenthesis( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.functionInvokation() != null )
-			return toAst( file, node.functionInvokation() );
-		else if ( node.identifier() != null )
-			return toAst( file, node.identifier() );
-		else if ( node.literalExpression() != null ) {
-			return toAst( file, node.literalExpression() );
-		} else if ( node.new_() != null ) {
-			return toAst( file, node.new_() );
-		}
-
-		issues.add( new Issue( "Object expression not implemented", getPosition( node ) ) );
-		return null;
-
-	}
-
-	/**
-	 * Converts the NewContext parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR NewContext rule
-	 *
-	 * @return corresponding AST
-	 */
-	private BoxExpression toAst( File file, NewContext node ) {
-		BoxExpression		expr	= null;
-		BoxIdentifier		prefix	= null;
-		List<BoxArgument>	args	= toAst( file, node.argumentList() );
-		if ( node.fqn() != null ) {
-			expr = toAst( file, node.fqn() );
-		}
-		if ( node.stringLiteral() != null ) {
-			expr = toAst( file, node.stringLiteral() );
-		}
-		if ( node.identifier() != null ) {
-			var tmp = toAst( file, node.identifier() );
-			if ( tmp instanceof BoxIdentifier bi ) {
-				prefix = bi;
-			} else {
-				prefix = new BoxIdentifier( ( ( BoxScope ) tmp ).getName(), getPosition( node.identifier() ), getSourceText( node.identifier() ) );
-			}
-
-		}
-		return new BoxNew( prefix, expr, args, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ObjectExpression parser rule to the corresponding AST node. * @param file
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR LiteralExpressionContext rule
-	 *
-	 * @return corresponding AST BoxAccess or an LiteralExpressionContext
-	 *
-	 * @see BoxAccess subclasses
-	 * @see BoxIdentifier subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.LiteralExpressionContext node ) {
-		if ( node.stringLiteral() != null ) {
-			return toAst( file, node.stringLiteral() );
-		}
-		if ( node.integerLiteral() != null ) {
-			return toAst( file, node.integerLiteral() );
-		}
-		if ( node.floatLiteral() != null ) {
-			BoxScriptGrammar.FloatLiteralContext fnode = node.floatLiteral();
-			return new BoxDecimalLiteral(
-			    fnode.getText(),
-			    getPosition( fnode ),
-			    getSourceText( fnode )
-			);
-		}
-		if ( node.booleanLiteral() != null ) {
-			BoxScriptGrammar.BooleanLiteralContext bnode = node.booleanLiteral();
-			return new BoxBooleanLiteral(
-			    bnode.getText(),
-			    getPosition( bnode ),
-			    getSourceText( bnode ) );
-		}
-		if ( node.arrayExpression() != null ) {
-			return toAst( file, node.arrayExpression() );
-		}
-
-		if ( node.structExpression() != null ) {
-			return toAst( file, node.structExpression() );
-		}
-
-		issues.add( new Issue( "Literal expression not implemented", getPosition( node ) ) );
-		return null;
-
-	}
-
-	/**
-	 * Converts the IntegerLiteral parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 *
-	 * @return corresponding AST BoxAccess or an IntegerLiteralContext
-	 *
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.IntegerLiteralContext integerLiteral ) {
-		return new BoxIntegerLiteral(
-		    integerLiteral.getText(),
-		    getPosition( integerLiteral ),
-		    getSourceText( integerLiteral )
-		);
-	}
-
-	/**
-	 * Converts the Struct Expression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArrayExpressionContext rule
-	 *
-	 * @return corresponding AST BoxArray
-	 *
-	 * @see BoxArrayLiteral subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.StructExpressionContext node ) {
-		List<BoxExpression>	values	= new ArrayList<>();
-		BoxStructType		type	= node.RBRACKET() != null ? BoxStructType.Ordered : BoxStructType.Unordered;
-		if ( node.structMembers() != null ) {
-			for ( BoxScriptGrammar.StructMemberContext pair : node.structMembers().structMember() ) {
-				if ( pair.stringLiteral() != null ) {
-					values.add( toAst( file, pair.stringLiteral() ) );
-				} else if ( pair.identifier() != null ) {
-					values.add( toAst( file, pair.identifier() ) );
-				} else if ( pair.integerLiteral() != null ) {
-					values.add( toAst( file, pair.integerLiteral() ) );
-				}
-				values.add( toAst( file, pair.expression() ) );
-			}
-		}
-		return new BoxStructLiteral( type, values, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Array Expression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArrayExpressionContext rule
-	 *
-	 * @return corresponding AST BoxArray
-	 *
-	 * @see BoxArrayLiteral subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.ArrayExpressionContext node ) {
-		List<BoxExpression> values = new ArrayList<>();
-		if ( node.arrayValues() != null ) {
-			for ( BoxScriptGrammar.ExpressionContext value : node.arrayValues().expression() ) {
-				values.add( toAst( file, value ) );
-			}
-		}
-		return new BoxArrayLiteral( values, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Function Invocation parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionInvokationContext rule
-	 *
-	 * @return corresponding AST BoxFunctionInvocation
-	 *
-	 * @see BoxFunctionInvocation subclasses
-	 * @see BoxArgument subclasses
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.FunctionInvokationContext node ) {
-		List<BoxArgument> args = toAst( file, node.invokationExpression().argumentList() );
-		return new BoxFunctionInvocation( node.identifier().getText(),
-		    args,
-		    getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the argument list to the corresponding List of AST nodes
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArgumentListContext rule
-	 *
-	 * @return corresponding List of AST nodes
-	 *
-	 */
-	private List<BoxArgument> toAst( File file, BoxScriptGrammar.ArgumentListContext node ) {
-		List<BoxArgument>	args	= new ArrayList<>();
-		Boolean				isNamed	= false;
-		if ( node != null ) {
-			for ( BoxScriptGrammar.NamedArgumentContext arg : node.namedArgument() ) {
-				isNamed = true;
-				args.add( toAst( file, arg ) );
-			}
-			for ( BoxScriptGrammar.PositionalArgumentContext arg : node.positionalArgument() ) {
-				if ( isNamed ) {
-					issues.add( new Issue( "You cannot mix named and positional arguments", getPosition( arg ) ) );
-				}
-				args.add( toAst( file, arg ) );
-			}
-		}
-		return args;
-	}
-
-	/**
-	 * Converts the PositionalArgumentContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PositionalArgumentContext rule
-	 *
-	 * @return corresponding AST PositionalArgumentContext
-	 *
-	 * @see BoxArgument
-	 */
-	private BoxArgument toAst( File file, BoxScriptGrammar.PositionalArgumentContext node ) {
-		BoxExpression value = toAst( file, node.expression() );
-		return new BoxArgument( null, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the NamedArgumentContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR NamedArgumentContext rule
-	 *
-	 * @return corresponding AST NamedArgumentContext
-	 *
-	 * @see BoxArgument
-	 */
-	private BoxArgument toAst( File file, BoxScriptGrammar.NamedArgumentContext node ) {
-		BoxExpression name;
-		if ( node.identifier() != null ) {
-			name = new BoxStringLiteral( node.identifier().getText(), getPosition( node ), getSourceText( node ) );
-		} else {
-			name = toAst( file, node.stringLiteral() );
-		}
-		BoxExpression value = toAst( file, node.expression() );
-		return new BoxArgument( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the AttributeSimple parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR AttributeSimpleContext rule
-	 *
-	 * @return corresponding AST AttributeSimpleContext
-	 *
-	 */
-	private BoxExpression toAst( File file, BoxScriptGrammar.AttributeSimpleContext node ) {
-		if ( node.literalExpression() != null ) {
-			return toAst( file, node.literalExpression() );
-		} else if ( node.identifier() != null ) {
-			// Converting an identifer to a string literal here in the AST removes ambiguity, but also loses the
-			// lexical context of the original source code.
-			return new BoxStringLiteral( node.identifier().getText(), getPosition( node ), getSourceText( node ) );
-		} else if ( node.fqn() != null ) {
-			// Converting an fqn to a string literal here in the AST removes ambiguity, but also loses the
-			// lexical context of the original source code.
-			return new BoxStringLiteral( node.fqn().getText(), getPosition( node ), getSourceText( node ) );
-		}
-		issues.add( new Issue( "Attribute simple not implemented", getPosition( node ) ) );
-		return null;
-	}
-
-	/**
-	 * Converts the pre annotation parser rule to the corresponding AST node.
-	 *
-	 * @param file       source file, if any
-	 * @param annotation ANTLR PreannotationContext rule
-	 *
-	 * @return corresponding AST PreannotationContext
-	 *
-	 * @see PreannotationContext
-	 */
-	private BoxAnnotation toAst( File file, BoxScriptGrammar.PreannotationContext annotation ) {
-		BoxExpression	avalue	= null;
-		BoxExpression	aname	= toAst( file, annotation.fqn() );
-		if ( annotation.literalExpression().size() == 1 ) {
-			avalue = toAst( file, annotation.literalExpression( 0 ) );
-		} else if ( annotation.literalExpression().size() > 1 ) {
-			List<BoxExpression> values = new ArrayList<>();
-			for ( BoxScriptGrammar.LiteralExpressionContext value : annotation.literalExpression() ) {
-				values.add( toAst( file, value ) );
-			}
-			avalue = new BoxArrayLiteral( values, getPosition( annotation ), getSourceText( annotation ) );
-		} else {
-			avalue = null;
-		}
-		return new BoxAnnotation( ( BoxFQN ) aname, avalue, getPosition( annotation ), getSourceText( annotation ) );
-	}
-
-	/**
-	 * Converts the Function argument parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ParamContext rule
-	 *
-	 * @return corresponding AST BoxArgumentDeclaration
-	 *
-	 * @see BoxArgumentDeclaration
-	 */
-	private BoxArgumentDeclaration toAst( File file, BoxScriptGrammar.FunctionParamContext node ) {
-		Boolean								required		= false;
-		String								type			= null;
-		String								name			= "undefined";
-		BoxExpression						expr			= null;
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-
-		name = node.identifier().getText();
-		if ( node.REQUIRED() != null ) {
-			required = true;
-		}
-
-		if ( node.expression() != null ) {
-			expr = toAst( file, node.expression() );
-		}
-		if ( node.type() != null ) {
-			type = node.type().getText();
-		}
-		for ( BoxScriptGrammar.PostannotationContext annotation : node.postannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-
-		return new BoxArgumentDeclaration( required, type, name, expr, annotations, documentation, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts a post annotation into the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PostannotationContext rule
-	 *
-	 * @return corresponding AST PostannotationContext
-	 *
-	 * @see BoxAnnotation
-	 */
-	private BoxAnnotation toAst( File file, BoxScriptGrammar.PostannotationContext node ) {
-
-		BoxFQN			name	= new BoxFQN( node.key.getText(), getPosition( node.key ), getSourceText( node.key ) );
-		BoxExpression	value;
-		if ( node.value != null ) {
-			value = toAst( file, node.value );
-		} else {
-			value = null;
-		}
-		return new BoxAnnotation( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts a Property into the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PropertyContext rule
-	 *
-	 * @return corresponding AST PropertyContext
-	 *
-	 */
-	private BoxProperty toAst( File file, BoxScriptGrammar.PropertyContext node ) {
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxAnnotation>					postAnnotations	= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-
-		for ( BoxScriptGrammar.PreannotationContext annotation : node.preannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-		for ( BoxScriptGrammar.PostannotationContext annotation : node.postannotation() ) {
-			postAnnotations.add( toAst( file, annotation ) );
-		}
-
-		return new BoxProperty( annotations, postAnnotations, documentation, getPosition( node ), getSourceText( node ) );
-	}
-
-	public BoxExpression parseBoxExpression( String code, Position position ) {
-		try {
-			ParsingResult result = new BoxScriptParser( position.getStart().getLine(), position.getStart().getColumn() )
-			    .setSource( sourceToParse )
-			    .setSubParser( true )
-			    .parseExpression( code );
-			this.comments.addAll( result.getComments() );
-			if ( result.getIssues().isEmpty() ) {
-				return ( BoxExpression ) result.getRoot();
-			} else {
-				// Add these issues to the main parser
-				issues.addAll( result.getIssues() );
-				return new BoxNull( null, null );
-			}
-		} catch ( IOException e ) {
-			issues.add( new Issue( "Error parsing expression " + e.getMessage(), position ) );
-			return new BoxNull( null, null );
-		}
-	}
-
-	@Override
-	public BoxScriptParser setSource( Source source ) {
-		if ( this.sourceToParse != null ) {
-			return this;
-		}
-		this.sourceToParse = source;
-		return this;
+	public Token getFirstToken() {
+		return firstToken;
 	}
 
 	@Override
@@ -2431,4 +447,163 @@ public class BoxScriptParser extends AbstractParser {
 		return this;
 	}
 
+	/**
+	 * Checks DOT access methods to ensure that nonsensical access methods are rejected at AST build time
+	 * and not left to the runtime, when it is not so useful!
+	 * <p>
+	 * This is necessarily quite an involved check as there are many combinations of left and right
+	 * </p>
+	 *
+	 * @param left  the left side of the dot access left.right
+	 * @param right the right side of the dot access left.right
+	 */
+	public void checkDotAccess( BoxExpression left, BoxExpression right ) {
+
+		// Check the right hand side to see if it is a valid access method
+		checkRight( right );
+
+		// Check to see if the left hand side is something that is valid to be accessed via a dot access
+		checkLeft( left );
+
+		// Now we know the LHS is valid for access by a dot method and the RHS is a valid access method, so
+		// we can check the combinations here if needed.
+		// TODO: @Brad - Add more checks here if needed
+	}
+
+	/**
+	 * Check the right hand side of a dot access to ensure it is a valid access method
+	 *
+	 * @param right the right side of the dot access left.right
+	 */
+	private void checkRight( BoxExpression right ) {
+		// Check the right hand side is a valid access method and fall through if it is not
+		switch ( right ) {
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxIdentifier ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxIntegerLiteral ignored -> {
+			}
+			case BoxMethodInvocation ignored -> {
+			}
+			case BoxNull ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxExpressionInvocation ignored -> {
+			}
+			default ->
+			    errorListener.semanticError( "dot access via " + right.getDescription() + " is not a valid access method", right.getPosition() );
+		}
+	}
+
+	/**
+	 * Check the left hand side of a dot access to ensure it is a valid construct for dot access
+	 *
+	 * @param left the left side of the dot access left.right
+	 */
+	private void checkLeft( BoxExpression left ) {
+		// Check the left hand side is a valid construct for dot access and fall through if it is not
+		switch ( left ) {
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxArrayAccess ignored -> {
+			}
+			case BoxIdentifier ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxStringLiteral ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxArrayLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxMethodInvocation ignored -> {
+			}
+			case BoxStructLiteral ignored -> {
+			}
+			case BoxNew ignored -> {
+			}
+			case BoxDecimalLiteral ignored -> {
+			}
+			case BoxParenthesis ignored -> {
+				// TODO: Brad - Should we allow this always, or check what is inside the parenthesis?
+			}
+			default ->
+			    errorListener.semanticError( left.getDescription() + " is not a valid construct for dot access", left.getPosition() );
+		}
+	}
+
+	/**
+	 * Check array access to ensure that nonsensical access methods are rejected at AST build time
+	 *
+	 * @param ctx    the Parsers ExprArrayAccessContext for source reference etc
+	 * @param object the object node that is being accessed as if it were an array
+	 * @param access the access node that is being used to access the object
+	 */
+	public void checkArrayAccess( BoxScriptGrammar.ExprArrayAccessContext ctx, BoxExpression object, BoxExpression access ) {
+
+		// Semantic errors are always nicer than runtime errors, so we check here as it is a quick easy check
+		if ( access instanceof BoxIntegerLiteral literal ) {
+
+			if ( Integer.parseInt( literal.getValue() ) < 1 ) {
+				errorListener.semanticError( "Array cannot be indexed by a number smaller than 1", literal.getPosition() );
+			}
+		}
+
+		switch ( object ) {
+			case BoxIdentifier ignored -> {
+			}
+			case BoxArrayAccess ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxStringLiteral ignored -> {
+			}
+			case BoxArrayLiteral ignored -> {
+			}
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxNew ignored -> {
+			}
+			case BoxDecimalLiteral ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxNull ignored -> {
+			}
+			case BoxStructLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxIntegerLiteral ignored -> {
+			}
+			case BoxMethodInvocation ignored -> {
+			}
+			case BoxParenthesis ignored -> {
+				// TODO: Brad - Should we allow this always, or check what is inside the parenthesis?
+			}
+			default ->
+			    errorListener.semanticError( object.getDescription() + " is not a valid construct for array access ", getPosition( ctx ) );
+		}
+	}
+
+	public void reportExpressionError( BoxExpression expression ) {
+		errorListener.semanticError( "Invalid expression error: " + expression.getSourceText(), expression.getPosition() );
+	}
+
+	public void reportStatementError( BoxStatement statement ) {
+		errorListener.semanticError( "Invalid statement error: " + statement.getSourceText(), statement.getPosition() );
+	}
+
+	public void reportError( String message, Position position ) {
+		errorListener.semanticError( message, position );
+	}
 }

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxTemplateParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxTemplateParser.java
@@ -834,19 +834,19 @@ public class BoxTemplateParser extends AbstractParser {
 		}
 	}
 
-	private BoxExpression toAst( File file, InterpolatedExpressionContext interp ) {
+	public BoxExpression toAst( File file, InterpolatedExpressionContext interp ) {
 		return parseBoxExpression( interp.expression().getText(), getPosition( interp.expression() ) );
 	}
 
 	/**
 	 * Escape double up quotes and pounds in a string literal
-	 * 
+	 *
 	 * @param quoteChar the quote character used to surround the string
 	 * @param string    the string to escape
-	 * 
+	 *
 	 * @return the escaped string
 	 */
-	private String escapeStringLiteral( String quoteChar, String string ) {
+	public String escapeStringLiteral( String quoteChar, String string ) {
 		String escaped = string.replace( "##", "#" );
 		return escaped.replace( quoteChar + quoteChar, quoteChar );
 	}
@@ -924,16 +924,16 @@ public class BoxTemplateParser extends AbstractParser {
 
 	/**
 	 * A helper function to find a specific annotation by name and return the value expression
-	 * 
+	 *
 	 * @param annotations             the list of annotations to search
 	 * @param name                    the name of the annotation to find
 	 * @param required                whether the annotation is required. If required, and not present a parsing Issue is created.
 	 * @param defaultValue            the default value to return if the annotation is not found. Ignored if requried is false.
 	 * @param containingComponentName the name of the component that contains the annotation, used in error handling
 	 * @param position                the position of the component, used in error handling
-	 * 
+	 *
 	 * @return the value expression of the annotation, or the default value if the annotation is not found
-	 * 
+	 *
 	 */
 	private BoxExpression findExprInAnnotations( List<BoxAnnotation> annotations, String name, boolean required, BoxExpression defaultValue,
 	    String containingComponentName,
@@ -953,11 +953,11 @@ public class BoxTemplateParser extends AbstractParser {
 	/**
 	 * A helper function to take a BoxExpr and return the value expression as a string.
 	 * If the expression is not a string literal, an Issue is created.
-	 * 
+	 *
 	 * @param expr       the expression to get the value from
 	 * @param name       the name of the attribute, used in error handling
 	 * @param allowEmpty whether an empty string is allowed. If not allowed, an Issue is created.
-	 * 
+	 *
 	 * @return the value of the expression as a string, or null if the expression is null
 	 */
 	private String getBoxExprAsString( BoxExpression expr, String name, boolean allowEmpty ) {
@@ -1092,6 +1092,7 @@ public class BoxTemplateParser extends AbstractParser {
 			return this;
 		}
 		this.sourceToParse = source;
+		this.errorListener.setSource( this.sourceToParse );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/parser/CFScriptLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFScriptLexerCustom.java
@@ -1,29 +1,28 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 package ortus.boxlang.compiler.parser;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenSource;
 import org.antlr.v4.runtime.misc.Pair;
-
 import ortus.boxlang.parser.antlr.CFScriptLexer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * I extend the generated ANTLR lexer to add some custom methods for getting unpopped modes
@@ -36,7 +35,7 @@ public class CFScriptLexerCustom extends CFScriptLexer {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param input input stream
 	 */
 	public CFScriptLexerCustom( CharStream input ) {
@@ -45,7 +44,7 @@ public class CFScriptLexerCustom extends CFScriptLexer {
 
 	/**
 	 * Check if there are unpopped modes on the Lexer's mode stack
-	 * 
+	 *
 	 * @return true if there are unpopped modes
 	 */
 	public boolean hasUnpoppedModes() {
@@ -91,9 +90,9 @@ public class CFScriptLexerCustom extends CFScriptLexer {
 
 	/**
 	 * Get the last token of a specific type
-	 * 
+	 *
 	 * @param type type of token to find
-	 * 
+	 *
 	 * @return the last token of the specified type
 	 */
 	public Token findPreviousToken( int type ) {
@@ -113,7 +112,7 @@ public class CFScriptLexerCustom extends CFScriptLexer {
 	 * if( condition ) {
 	 * } elseif( condition ) {
 	 * }
-	 * but it totally messed with the grammer to return a single elseif token
+	 * but it totally messed with the grammar to return a single elseif token
 	 * so we're changing any elseif tokens to be two tokens.
 	 */
 	public Token nextToken() {
@@ -143,7 +142,7 @@ public class CFScriptLexerCustom extends CFScriptLexer {
 	 * Back up to the closest unclosed brace
 	 * Return null if none found
 	 * *
-	 * 
+	 *
 	 * @return the unmatched opening brace
 	 */
 	public Token findUnclosedToken( int start, int end ) {

--- a/src/main/java/ortus/boxlang/compiler/parser/CFScriptParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFScriptParser.java
@@ -1,145 +1,54 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 package ortus.boxlang.compiler.parser;
 
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import ortus.boxlang.compiler.ast.*;
+import ortus.boxlang.compiler.ast.comment.BoxDocComment;
+import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
+import ortus.boxlang.compiler.ast.comment.BoxSingleLineComment;
+import ortus.boxlang.compiler.ast.expression.*;
+import ortus.boxlang.compiler.ast.visitor.CFTranspilerVisitor;
+import ortus.boxlang.compiler.toolchain.CFExpressionVisitor;
+import ortus.boxlang.compiler.toolchain.CFVisitor;
+import ortus.boxlang.parser.antlr.CFScriptGrammar;
+import ortus.boxlang.parser.antlr.CFScriptLexer;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.services.ComponentService;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BOMInputStream;
-
-import ortus.boxlang.compiler.ast.BoxClass;
-import ortus.boxlang.compiler.ast.BoxExpression;
-import ortus.boxlang.compiler.ast.BoxInterface;
-import ortus.boxlang.compiler.ast.BoxNode;
-import ortus.boxlang.compiler.ast.BoxScript;
-import ortus.boxlang.compiler.ast.BoxStatement;
-import ortus.boxlang.compiler.ast.BoxStaticInitializer;
-import ortus.boxlang.compiler.ast.BoxTemplate;
-import ortus.boxlang.compiler.ast.Issue;
-import ortus.boxlang.compiler.ast.Point;
-import ortus.boxlang.compiler.ast.Position;
-import ortus.boxlang.compiler.ast.Source;
-import ortus.boxlang.compiler.ast.SourceCode;
-import ortus.boxlang.compiler.ast.SourceFile;
-import ortus.boxlang.compiler.ast.comment.BoxDocComment;
-import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
-import ortus.boxlang.compiler.ast.comment.BoxSingleLineComment;
-import ortus.boxlang.compiler.ast.expression.BoxAccess;
-import ortus.boxlang.compiler.ast.expression.BoxArgument;
-import ortus.boxlang.compiler.ast.expression.BoxArrayAccess;
-import ortus.boxlang.compiler.ast.expression.BoxArrayLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxAssignment;
-import ortus.boxlang.compiler.ast.expression.BoxAssignmentModifier;
-import ortus.boxlang.compiler.ast.expression.BoxAssignmentOperator;
-import ortus.boxlang.compiler.ast.expression.BoxBinaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxBinaryOperator;
-import ortus.boxlang.compiler.ast.expression.BoxBooleanLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxClosure;
-import ortus.boxlang.compiler.ast.expression.BoxComparisonOperation;
-import ortus.boxlang.compiler.ast.expression.BoxComparisonOperator;
-import ortus.boxlang.compiler.ast.expression.BoxDecimalLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxDotAccess;
-import ortus.boxlang.compiler.ast.expression.BoxExpressionInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxFQN;
-import ortus.boxlang.compiler.ast.expression.BoxFunctionInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxIdentifier;
-import ortus.boxlang.compiler.ast.expression.BoxIntegerLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxMethodInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxNew;
-import ortus.boxlang.compiler.ast.expression.BoxNull;
-import ortus.boxlang.compiler.ast.expression.BoxParenthesis;
-import ortus.boxlang.compiler.ast.expression.BoxScope;
-import ortus.boxlang.compiler.ast.expression.BoxStaticAccess;
-import ortus.boxlang.compiler.ast.expression.BoxStaticMethodInvocation;
-import ortus.boxlang.compiler.ast.expression.BoxStringConcat;
-import ortus.boxlang.compiler.ast.expression.BoxStringInterpolation;
-import ortus.boxlang.compiler.ast.expression.BoxStringLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxStructLiteral;
-import ortus.boxlang.compiler.ast.expression.BoxStructType;
-import ortus.boxlang.compiler.ast.expression.BoxTernaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxUnaryOperation;
-import ortus.boxlang.compiler.ast.expression.BoxUnaryOperator;
-import ortus.boxlang.compiler.ast.statement.BoxAccessModifier;
-import ortus.boxlang.compiler.ast.statement.BoxAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxArgumentDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxBreak;
-import ortus.boxlang.compiler.ast.statement.BoxContinue;
-import ortus.boxlang.compiler.ast.statement.BoxDo;
-import ortus.boxlang.compiler.ast.statement.BoxDocumentationAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxExpressionStatement;
-import ortus.boxlang.compiler.ast.statement.BoxForIn;
-import ortus.boxlang.compiler.ast.statement.BoxForIndex;
-import ortus.boxlang.compiler.ast.statement.BoxFunctionDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxIfElse;
-import ortus.boxlang.compiler.ast.statement.BoxImport;
-import ortus.boxlang.compiler.ast.statement.BoxMethodDeclarationModifier;
-import ortus.boxlang.compiler.ast.statement.BoxParam;
-import ortus.boxlang.compiler.ast.statement.BoxProperty;
-import ortus.boxlang.compiler.ast.statement.BoxRethrow;
-import ortus.boxlang.compiler.ast.statement.BoxReturn;
-import ortus.boxlang.compiler.ast.statement.BoxReturnType;
-import ortus.boxlang.compiler.ast.statement.BoxStatementBlock;
-import ortus.boxlang.compiler.ast.statement.BoxSwitch;
-import ortus.boxlang.compiler.ast.statement.BoxSwitchCase;
-import ortus.boxlang.compiler.ast.statement.BoxThrow;
-import ortus.boxlang.compiler.ast.statement.BoxTry;
-import ortus.boxlang.compiler.ast.statement.BoxTryCatch;
-import ortus.boxlang.compiler.ast.statement.BoxType;
-import ortus.boxlang.compiler.ast.statement.BoxWhile;
-import ortus.boxlang.compiler.ast.statement.component.BoxComponent;
-import ortus.boxlang.compiler.ast.statement.component.BoxTemplateIsland;
-import ortus.boxlang.compiler.ast.visitor.CFTranspilerVisitor;
-import ortus.boxlang.parser.antlr.CFScriptGrammar;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.AbstractFunctionContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.AssignmentContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.BoxClassContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.ComponentContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.ComponentIslandContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.IntegerLiteralContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.InterfaceContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.NewContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.NotTernaryExpressionContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.ParamContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.StaticAccessExpressionContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.StaticObjectExpressionContext;
-import ortus.boxlang.parser.antlr.CFScriptGrammar.VariableDeclarationContext;
-import ortus.boxlang.parser.antlr.CFScriptLexer;
-import ortus.boxlang.runtime.BoxRuntime;
-import ortus.boxlang.runtime.components.ComponentDescriptor;
-import ortus.boxlang.runtime.services.ComponentService;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 /**
  * Parser for CF scripts
  */
+@SuppressWarnings( "DuplicatedCode" )
 public class CFScriptParser extends AbstractParser {
 
-	private boolean			inOutputBlock		= false;
+	private Token			firstToken			= null;
 	public ComponentService	componentService	= BoxRuntime.getInstance().getComponentService();
+	private boolean			inOutputBlock		= false;
 
 	/**
 	 * Constructor
@@ -157,12 +66,14 @@ public class CFScriptParser extends AbstractParser {
 		this.inOutputBlock = inOutputBlock;
 	}
 
-	public void setInOutputBlock( boolean inOutputBlock ) {
-		this.inOutputBlock = inOutputBlock;
-	}
-
+	@SuppressWarnings( "unused" )
 	public boolean getInOutputBlock() {
 		return inOutputBlock;
+	}
+
+	@SuppressWarnings( "unused" )
+	public void setInOutputBlock( boolean inOutputBlock ) {
+		this.inOutputBlock = inOutputBlock;
 	}
 
 	/**
@@ -172,7 +83,7 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -195,7 +106,7 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -211,7 +122,7 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see BoxScript
 	 * @see ParsingResult
@@ -232,7 +143,7 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxExpr as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see ParsingResult
 	 * @see BoxExpression
@@ -249,10 +160,14 @@ public class CFScriptParser extends AbstractParser {
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
+
+		var expressionVisitor = new CFExpressionVisitor( this, new CFVisitor( this ) );
+
 		try {
-			BoxExpression ast = toAst( null, parseTree );
+			var ast = parseTree.accept( expressionVisitor );
 			return new ParsingResult( ast, issues, comments );
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -271,7 +186,7 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxStatement as root and the list of errors (if any)
 	 *
-	 * @throws IOException
+	 * @throws IOException if the input stream is in error
 	 *
 	 * @see ParsingResult
 	 * @see BoxStatement
@@ -287,10 +202,14 @@ public class CFScriptParser extends AbstractParser {
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
+
+		var visitor = new CFVisitor( this );
 		try {
-			BoxStatement ast = toAst( null, parseTree );
+			var ast = parseTree.accept( visitor );
+
 			return new ParsingResult( ast, issues, comments );
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -314,7 +233,11 @@ public class CFScriptParser extends AbstractParser {
 	protected BoxNode parserFirstStage( InputStream stream, Boolean classOrInterface ) throws IOException {
 		CFScriptLexerCustom	lexer	= new CFScriptLexerCustom( CharStreams.fromStream( stream, StandardCharsets.UTF_8 ) );
 		CFScriptGrammar		parser	= new CFScriptGrammar( new CommonTokenStream( lexer ) );
+
+		// DEBUG: Will print a trace of all parser rules visited:
+		// boxParser.setTrace( true );
 		addErrorListeners( lexer, parser );
+
 		CFScriptGrammar.ClassOrInterfaceContext	classOrInterfaceContext	= null;
 		CFScriptGrammar.ScriptContext			scriptContext			= null;
 		if ( classOrInterface ) {
@@ -325,17 +248,22 @@ public class CFScriptParser extends AbstractParser {
 
 		// This must run FIRST before resetting the lexer
 		validateParse( lexer );
+
 		// This can add issues to an otherwise successful parse
 		extractComments( lexer );
 
 		lexer.reset();
-		Token	firstToken	= lexer.nextToken();
+		firstToken = lexer.nextToken();
 		BoxNode	rootNode;
+
+		// Create the visitor we will use to build the AST
+		var		visitor	= new CFVisitor( this );
+
 		try {
 			if ( classOrInterface ) {
-				rootNode = toAst( null, classOrInterfaceContext );
+				rootNode = classOrInterfaceContext.accept( visitor );
 			} else {
-				rootNode = toAst( null, scriptContext, firstToken );
+				rootNode = scriptContext.accept( visitor );
 			}
 		} catch ( Exception e ) {
 			// Ignore issues creating AST if the parsing already had failures
@@ -348,7 +276,6 @@ public class CFScriptParser extends AbstractParser {
 		if ( isSubParser() ) {
 			return rootNode;
 		}
-
 		if ( rootNode == null ) {
 			return null;
 		}
@@ -367,24 +294,20 @@ public class CFScriptParser extends AbstractParser {
 
 			if ( modes.contains( "hashMode" ) ) {
 				Token lastHash = lexer.findPreviousToken( CFScriptLexer.ICHAR );
-				issues.add( new Issue( "Untermimated hash expression inside of string literal.", getPosition( lastHash ) ) );
+				errorListener.semanticError( "Unterminated hash expression inside of string literal.", getPosition( lastHash ) );
 			} else if ( modes.contains( "quotesMode" ) ) {
 				Token lastQuote = lexer.findPreviousToken( CFScriptLexer.OPEN_QUOTE );
-				issues.add( new Issue( "Untermimated quote expression.", getPosition( lastQuote ) ) );
+				errorListener.semanticError( "Unterminated quote expression.", getPosition( lastQuote ) );
 			} else if ( modes.contains( "squotesMode" ) ) {
 				Token lastQuote = lexer.findPreviousToken( CFScriptLexer.OPEN_QUOTE );
-				issues.add( new Issue( "Untermimated single quote expression.", getPosition( lastQuote ) ) );
+				errorListener.semanticError( "Unterminated single quote expression.", getPosition( lastQuote ) );
 			} else {
-				// Catch-all. If this error is encontered, look at what modes were still on the stack, find what token was never ended, and
+				// Catch-all. If this error is encountered, look at what modes were still on the stack, find what token was never ended, and
 				// add logic like the above to handle it. Eventually, this catch-all should never be used.
-				Position position = new Position(
-				    new Point( 0, 0 ),
-				    new Point( 0, 0 ),
-				    sourceToParse
-				);
-				issues.add( new Issue(
-				    "Unpopped Lexer modes. [" + modes.stream().collect( Collectors.joining( ", " ) ) + "] Please report this to get a better error message.",
-				    position ) );
+				Position position = new Position( new Point( 0, 0 ), new Point( 0, 0 ), sourceToParse );
+				errorListener.semanticError(
+				    "Internal error(42): Un-popped Lexer modes. [" + String.join( ", ", modes ) + "] Please report this to the developers.", position );
+
 			}
 			// I'm only returning here because we have to reset the lexer above to get the position of the unmatched token, so we no longer have
 			// the ability to check for unconsumed tokens.
@@ -397,7 +320,7 @@ public class CFScriptParser extends AbstractParser {
 			token = lexer.nextToken();
 		}
 		if ( token.getType() != Token.EOF ) {
-			StringBuffer	extraText	= new StringBuffer();
+			StringBuilder	extraText	= new StringBuilder();
 			int				startLine	= token.getLine();
 			int				startColumn	= token.getCharPositionInLine();
 			int				endColumn	= startColumn + token.getText().length();
@@ -406,7 +329,7 @@ public class CFScriptParser extends AbstractParser {
 				extraText.append( token.getText() );
 				token = lexer.nextToken();
 			}
-			issues.add( new Issue( "Extra char(s) [" + extraText.toString() + "] at the end of parsing.", position ) );
+			errorListener.semanticError( "Extra char(s) [" + extraText + "] at the end of parsing.", position );
 		}
 
 		// If there is already a parsing issue, try to get a more specific error
@@ -415,19 +338,17 @@ public class CFScriptParser extends AbstractParser {
 			Token unclosedBrace = lexer.findUnclosedToken( CFScriptLexer.LBRACE, CFScriptLexer.RBRACE );
 			if ( unclosedBrace != null ) {
 				issues.clear();
-				issues.add(
-				    new Issue( "Unclosed curly brace [{] on line " + ( unclosedBrace.getLine() + this.startLine ),
-				        createOffsetPosition( unclosedBrace.getLine(),
-				            unclosedBrace.getCharPositionInLine(), unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine() + 1 ) ) );
+				errorListener.reset();
+				errorListener.semanticError( "Unclosed curly brace [{] on line " + ( unclosedBrace.getLine() + this.startLine ), createOffsetPosition(
+				    unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine(), unclosedBrace.getLine(), unclosedBrace.getCharPositionInLine() + 1 ) );
 			}
 
 			Token unclosedParen = lexer.findUnclosedToken( CFScriptLexer.LPAREN, CFScriptLexer.RPAREN );
 			if ( unclosedParen != null ) {
 				issues.clear();
-				issues
-				    .add( new Issue( "Unclosed parenthesis [(] on line " + ( unclosedParen.getLine() + this.startLine ),
-				        createOffsetPosition( unclosedParen.getLine(),
-				            unclosedParen.getCharPositionInLine(), unclosedParen.getLine(), unclosedParen.getCharPositionInLine() + 1 ) ) );
+				errorListener.reset();
+				errorListener.semanticError( "Unclosed parenthesis [(] on line " + ( unclosedParen.getLine() + this.startLine ), createOffsetPosition(
+				    unclosedParen.getLine(), unclosedParen.getCharPositionInLine(), unclosedParen.getLine(), unclosedParen.getCharPositionInLine() + 1 ) );
 			}
 		}
 	}
@@ -449,19 +370,18 @@ public class CFScriptParser extends AbstractParser {
 				String commentText = token.getText().trim().substring( 2 ).trim();
 				comments.add( new BoxSingleLineComment( commentText, getPosition( token ), token.getText() ) );
 			} else if ( token.getType() == CFScriptLexer.COMMENT ) {
-				comments.add(
-				    new BoxMultiLineComment( extractMultiLineCommentText( token.getText(), false ), getPosition( token ), token.getText() ) );
+				comments.add( new BoxMultiLineComment( extractMultiLineCommentText( token.getText(), false ), getPosition( token ), token.getText() ) );
 				// Lucee allows <!--- tag comments ---> in script. Yuck.
 			} else if ( token.getType() == CFScriptLexer.TAG_COMMENT_START ) {
 				Token			startToken			= token;
 				int				commentStartLine	= token.getLine() + this.startLine;
 				int				commentStartColumn	= token.getCharPositionInLine() + this.startColumn;
-				StringBuffer	tagComment			= new StringBuffer();
+				StringBuilder	tagComment			= new StringBuilder();
 				token = lexer.nextToken();
 				while ( token.getType() != CFScriptLexer.TAG_COMMENT_END && token.getType() != Token.EOF ) {
 					// validate all tokens MUST be TAG_COMMENT_START, or TAG_COMMENT_TEXT
 					if ( token.getType() != CFScriptLexer.TAG_COMMENT_START && token.getType() != CFScriptLexer.TAG_COMMENT_TEXT ) {
-						issues.add( new Issue( "Invalid tag comment", getPosition( token ) ) );
+						errorListener.semanticError( "Invalid tag comment", getPosition( token ) );
 						break;
 					}
 					tagComment.append( token.getText() );
@@ -472,13 +392,8 @@ public class CFScriptParser extends AbstractParser {
 				int		commentEndColumn	= token.getCharPositionInLine() + ( newLineCount > 0 ? this.startColumn : 0 );
 				String	finalCommentText	= tagComment.toString();
 				// Convert to a proper /* script comment */
-				comments.add(
-				    new BoxMultiLineComment(
-				        finalCommentText.trim(),
-				        createPosition( commentStartLine, commentStartColumn, commentEndLine, commentEndColumn ),
-				        getSourceText( startToken, token )
-				    )
-				);
+				comments.add( new BoxMultiLineComment( finalCommentText.trim(),
+				    createPosition( commentStartLine, commentStartColumn, commentEndLine, commentEndColumn ), getSourceText( startToken, token ) ) );
 			}
 			token = lexer.nextToken();
 			docParser.setStartLine( token.getLine() );
@@ -486,390 +401,14 @@ public class CFScriptParser extends AbstractParser {
 		}
 	}
 
-	/**
-	 *
-	 * @param file             source file, if any
-	 * @param classOrInterface ANTLR parser rule to transform
-	 *
-	 * @return a Node
-	 *
-	 */
-	protected BoxNode toAst( File file, CFScriptGrammar.ClassOrInterfaceContext classOrInterface ) {
-
-		if ( classOrInterface.boxClass() != null ) {
-			return toAst( file, classOrInterface.boxClass() );
-		} else if ( classOrInterface.interface_() != null ) {
-			return toAst( file, classOrInterface.interface_() );
-		} else {
-			issues.add( new Issue( "Unexpected classOrInterface type", getPosition( classOrInterface ) ) );
-			return null;
-		}
-
-	}
-
-	private BoxNode toAst( File file, InterfaceContext interface_ ) {
-		List<BoxStatement>					body			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxAnnotation>					postAnnotations	= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxImport>						imports			= new ArrayList<>();
-
-		interface_.importStatement().forEach( stmt -> {
-			imports.add( toAst( file, stmt ) );
-		} );
-
-		for ( CFScriptGrammar.PostannotationContext annotation : interface_.postannotation() ) {
-			postAnnotations.add( toAst( file, annotation ) );
-		}
-		interface_.abstractFunction().forEach( stmt -> {
-			body.add( toAst( file, stmt ) );
-		} );
-		interface_.function().forEach( stmt -> {
-			BoxFunctionDeclaration funDec = toAst( file, stmt );
-			body.add( funDec );
-			// ensure last function added has default modifier
-			if ( funDec.getModifiers().stream().noneMatch( m -> m.equals( BoxMethodDeclarationModifier.DEFAULT ) ) ) {
-				issues.add( new Issue( "Interface methods must have the default modifier", funDec.getPosition() ) );
-			}
-		} );
-
-		return new BoxInterface( imports, body, annotations, postAnnotations, documentation, getPosition( interface_ ), getSourceText( interface_ ) );
-	}
-
-	protected BoxScript toAst( File file, CFScriptGrammar.ScriptContext rule, Token firstToken ) {
-		List<BoxStatement> statements = new ArrayList<>();
-
-		rule.functionOrStatement().forEach( stmt -> {
-			statements.add( toAst( file, stmt ) );
-		} );
-		// Force the script to start at the top of the file so doc comments associate with functions correctly
-		return new BoxScript( statements, getPositionStartingAt( rule, firstToken ), getSourceText( rule ) );
-	}
-
-	private BoxNode toAst( File file, BoxClassContext component ) {
-		List<BoxStatement>					body			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxProperty>					property		= new ArrayList<>();
-		List<BoxImport>						imports			= new ArrayList<>();
-		// Used for validating existence of abstract methods
-		boolean								isAbstract;
-
-		component.importStatement().forEach( stmt -> {
-			imports.add( toAst( file, stmt ) );
-		} );
-
-		for ( CFScriptGrammar.PostannotationContext annotation : component.postannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-		for ( CFScriptGrammar.PropertyContext annotation : component.property() ) {
-			property.add( toAst( file, annotation ) );
-		}
-		if ( component.ABSTRACT() != null ) {
-			annotations.add(
-			    new BoxAnnotation(
-			        new BoxFQN( "abstract", getPosition( component.ABSTRACT() ), component.ABSTRACT().getText() ),
-			        null,
-			        getPosition( component.ABSTRACT() ),
-			        component.ABSTRACT().getText() ) );
-		}
-		isAbstract = annotations.stream().anyMatch( a -> a.getKey().getValue().equalsIgnoreCase( "abstract" ) );
-
-		if ( component.classBody() != null && component.classBody().children != null ) {
-			for ( var child : component.classBody().children ) {
-				if ( child instanceof CFScriptGrammar.FunctionOrStatementContext funOrStmt ) {
-					if ( funOrStmt.abstractFunction() != null ) {
-						CFScriptGrammar.AbstractFunctionContext abstractFunc = funOrStmt.abstractFunction();
-						if ( !isAbstract ) {
-							issues.add( new Issue( "Unexpected abstract function in non-abstract class", getPosition( child ) ) );
-							return null;
-						}
-						if ( abstractFunc.functionSignature().modifiers() != null && abstractFunc.functionSignature().modifiers().ABSTRACT().isEmpty() ) {
-							issues.add(
-							    new Issue(
-							        "Function [" + abstractFunc.functionSignature().identifier().getText() + "] with no body must have abstract modifier",
-							        getPosition( child ) ) );
-							return null;
-						}
-						body.add( toAst( file, abstractFunc ) );
-						continue;
-					}
-					body.add( toAst( file, funOrStmt ) );
-				} else if ( child instanceof CFScriptGrammar.StaticInitializerContext staticInit ) {
-					body.add( toAst( file, staticInit ) );
-				} else {
-					issues.add( new Issue( "Unexpected class body type: " + child.getClass().getSimpleName(), getPosition( child ) ) );
-					return null;
-				}
-			}
-		}
-
-		return new BoxClass( imports, body, annotations, documentation, property,
-		    getPositionStartingAt( component, component.boxClassName() ),
-		    getSourceText( component ) );
-	}
-
-	private BoxStaticInitializer toAst( File file, CFScriptGrammar.StaticInitializerContext staticInitializer ) {
-		List<BoxStatement> body = toAstStatementBlockAsList( file, staticInitializer.statementBlock() );
-		return new BoxStaticInitializer( body, getPosition( staticInitializer ), getSourceText( staticInitializer ) );
-	}
-
-	/**
-	 * Converts the ImportStatementContext parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param rule ANTLR ImportStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxImport
-	 */
-	private BoxImport toAst( File file, CFScriptGrammar.ImportStatementContext rule ) {
-		BoxExpression	expr	= null;
-		String			className;
-		BoxIdentifier	alias	= null;
-		String			prefix	= "bx:";
-
-		// If it's a string literal, unwrap the quotes
-		if ( rule.importFQN().stringLiteral() != null ) {
-			className	= rule.importFQN().getText();
-			className	= className.substring( 1, className.length() - 1 );
-		} else {
-			className = rule.importFQN().getText();
-		}
-		expr = new BoxFQN( prefix + className, getPosition( rule.importFQN() ), getSourceText( rule.importFQN() ) );
-		return new BoxImport( expr, alias, getPosition( rule ), getSourceText( rule ) );
-	}
-
-	/**
-	 * Converts the FunctionOrStatement parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionOrStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.FunctionOrStatementContext node ) {
-		if ( node.function() != null ) {
-			return toAst( file, node.function() );
-		} else if ( node.statement() != null ) {
-			return toAst( file, node.statement() );
-		} else {
-			issues.add( new Issue( "Function or statement not implemented", getPosition( node ) ) );
-			return null;
-		}
-	}
-
-	/**
-	 * Converts the Statement parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR StatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.StatementContext node ) {
-		if ( node.function() != null ) {
-			return toAst( file, node.function() );
-		} else if ( node.simpleStatement() != null ) {
-			return toAst( file, node.simpleStatement() );
-		} else if ( node.if_() != null ) {
-			return toAst( file, node.if_() );
-		} else if ( node.while_() != null ) {
-			return toAst( file, node.while_() );
-		} else if ( node.do_() != null ) {
-			return toAst( file, node.do_() );
-		} else if ( node.switch_() != null ) {
-			return toAst( file, node.switch_() );
-		} else if ( node.for_() != null ) {
-			return toAst( file, node.for_() );
-		} else if ( node.try_() != null ) {
-			return toAst( file, node.try_() );
-		} else if ( node.componentIsland() != null ) {
-			return toAst( file, node.componentIsland() );
-		} else if ( node.component() != null ) {
-			return toAst( file, node.component() );
-		} else if ( node.include() != null ) {
-			return toAst( file, node.include() );
-		} else if ( node.statementBlock() != null ) {
-			return toAst( file, node.statementBlock() );
-		} else if ( node.importStatement() != null ) {
-			return toAst( file, node.importStatement() );
-		} else if ( node.throw_() != null ) {
-			return toAst( file, node.throw_() );
-		} else {
-			issues.add( new Issue( "Statement not implemented", getPosition( node ) ) );
-			return null;
-		}
-	}
-
-	private BoxStatement toAst( File file, ComponentContext node ) {
-		List<BoxStatement>	body			= null;
-		String				componentName	= null;
-		List<BoxAnnotation>	attributes		= new ArrayList<>();
-
-		if ( node.componentAttributes() != null && node.componentAttributes().componentAttribute() != null ) {
-			for ( var attr : node.componentAttributes().componentAttribute() ) {
-				attributes.add( toAstAnnotation( file, attr ) );
-			}
-			// ACF specific tag-in-script syntax
-		} else if ( node.delimitedComponentAttributes() != null && node.delimitedComponentAttributes().componentAttribute() != null ) {
-			for ( var attr : node.delimitedComponentAttributes().componentAttribute() ) {
-				attributes.add( toAstAnnotation( file, attr ) );
-			}
-		}
-
-		if ( node.componentName() != null ) {
-			componentName = node.componentName().getText();
-		} else {
-			// strip prefix from name so "cfbrad" becomes "brad". ACF specific tag-in-script syntax
-			componentName = node.prefixedIdentifier().getText().substring( 2 );
-		}
-
-		// Special check for param's script shortcut
-		if ( componentName.equalsIgnoreCase( "param" ) ) {
-			// If there is only one attribute and it is not name= and has a value, then we need to convert it to a name/value pair
-			// Ex: param foo="bar";
-			// Becomes: param name="foo" default="bar";
-			if ( attributes.size() == 1 && !attributes.get( 0 ).getKey().getValue().equalsIgnoreCase( "name" ) && attributes.get( 0 ).getValue() != null ) {
-				List<BoxAnnotation> newAttributes = new ArrayList<>();
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "name", getPosition( node ), "name" ),
-				        new BoxStringLiteral( attributes.get( 0 ).getKey().getValue(), attributes.get( 0 ).getKey().getPosition(),
-				            attributes.get( 0 ).getKey().getSourceText() ),
-				        attributes.get( 0 ).getKey().getPosition(),
-				        "name=\"" + attributes.get( 0 ).getKey().getSourceText() + "\""
-				    )
-				);
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "default", attributes.get( 0 ).getValue().getPosition(), "default" ),
-				        attributes.get( 0 ).getValue(),
-				        attributes.get( 0 ).getValue().getPosition(),
-				        "default=" + attributes.get( 0 ).getValue().getSourceText()
-				    )
-				);
-				attributes = newAttributes;
-				// If there are two attributes, the first one has a null value, and none of them are named "name"
-				// Ex: param String foo="bar";
-				// Becomes: param type="String" name="foo" default="bar";
-				// Ex: param String foo;
-				// Becomes: param type="String" name="foo";
-			} else if ( attributes.size() == 2 && attributes.get( 0 ).getValue() == null && !attributes.get( 0 ).getKey().getValue().equalsIgnoreCase( "name" )
-			    && !attributes.get( 1 ).getKey().getValue().equalsIgnoreCase( "name" ) ) {
-				List<BoxAnnotation> newAttributes = new ArrayList<>();
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "type", getPosition( node ), "type" ),
-				        new BoxStringLiteral( attributes.get( 0 ).getKey().getValue(), attributes.get( 0 ).getKey().getPosition(),
-				            attributes.get( 0 ).getKey().getSourceText() ),
-				        attributes.get( 0 ).getKey().getPosition(),
-				        "type=\"" + attributes.get( 0 ).getKey().getSourceText() + "\""
-				    )
-				);
-				newAttributes.add(
-				    new BoxAnnotation(
-				        new BoxFQN( "name", getPosition( node ), "name" ),
-				        new BoxStringLiteral( attributes.get( 1 ).getKey().getValue(), attributes.get( 1 ).getKey().getPosition(),
-				            attributes.get( 1 ).getKey().getSourceText() ),
-				        attributes.get( 1 ).getKey().getPosition(),
-				        "name=" + attributes.get( 1 ).getKey().getSourceText()
-				    )
-				);
-				// Only if there is a default
-				if ( attributes.get( 1 ).getValue() != null ) {
-					newAttributes.add(
-					    new BoxAnnotation(
-					        new BoxFQN( "default", attributes.get( 1 ).getValue().getPosition(), "default" ),
-					        attributes.get( 1 ).getValue(),
-					        attributes.get( 1 ).getValue().getPosition(),
-					        "default=" + attributes.get( 1 ).getValue().getSourceText()
-					    )
-					);
-				}
-				attributes = newAttributes;
-			}
-		}
-
-		ComponentDescriptor descriptor = componentService.getComponent( componentName );
-		if ( node.statementBlock() != null ) {
-			if ( descriptor != null && !descriptor.allowsBody() ) {
-				issues.add( new Issue( "The [" + componentName + "] component does not allow a body", getPosition( node ) ) );
-			}
-			body = new ArrayList<>();
-			body.addAll( toAstStatementBlockAsList( file, node.statementBlock() ) );
-		} else if ( descriptor != null && descriptor.requiresBody() ) {
-			issues.add( new Issue( "The [" + componentName + "] component requires a body", getPosition( node ) ) );
-		}
-
-		// Special check for cfloop condition to avoid runtime eval
-		if ( componentName.equalsIgnoreCase( "loop" ) ) {
-			for ( var attr : attributes ) {
-				if ( attr.getKey().getValue().equalsIgnoreCase( "condition" ) ) {
-					BoxExpression condition = attr.getValue();
-					if ( condition instanceof BoxStringLiteral str ) {
-						// parse as CF script expression and update value
-						condition = parseCFExpression( str.getValue(), condition.getPosition() );
-					}
-					BoxExpression newCondition = new BoxClosure(
-					    List.of(),
-					    List.of(),
-					    new BoxReturn( condition, condition.getPosition(), condition.getSourceText() ),
-					    condition.getPosition(),
-					    condition.getSourceText() );
-					attr.setValue( newCondition );
-				}
-			}
-		}
-
-		return new BoxComponent( componentName, attributes, body, 0, getPosition( node ), getSourceText( node ) );
-	}
-
-	private BoxAnnotation toAstAnnotation( File file, CFScriptGrammar.ComponentAttributeContext node ) {
-		BoxFQN			name	= new BoxFQN( node.identifier().getText(), getPosition( node.identifier() ), getSourceText( node.identifier() ) );
-		BoxExpression	value	= null;
-		if ( node.expression() != null ) {
-			value = toAst( file, node.expression() );
-		}
-		return new BoxAnnotation( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ComponentIslandContext parser rule to the corresponding AST node
-	 *
-	 * @param file            source file, if any
-	 * @param componentIsland ANTLR ComponentIslandContext rule
-	 *
-	 * @return the corresponding AST BoxComponentIsland
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxTemplateIsland toAst( File file, ComponentIslandContext componentIsland ) {
-		return new BoxTemplateIsland(
-		    parseCFMLStatements(
-		        componentIsland.componentIslandBody().getText(),
-		        getPosition( componentIsland.componentIslandBody() )
-		    ),
-		    getPosition( componentIsland.componentIslandBody() ),
-		    getSourceText( componentIsland.componentIslandBody() )
-		);
-
-	}
-
+	@SuppressWarnings( "unused" )
 	public List<BoxStatement> parseCFMLStatements( String code, Position position ) {
 		try {
 			if ( inOutputBlock ) {
 				code = "<cfoutput>" + code + "</cfoutput>";
 			}
-			ParsingResult result = new CFTemplateParser( position.getStart().getLine(), position.getStart().getColumn() )
-			    .setSource( sourceToParse )
-			    .setSubParser( true )
-			    .parse( code );
+			ParsingResult result = new CFTemplateParser( position.getStart().getLine(), position.getStart().getColumn() ).setSource( sourceToParse )
+			    .setSubParser( true ).parse( code );
 			this.comments.addAll( result.getComments() );
 			if ( result.getIssues().isEmpty() ) {
 				BoxNode root = result.getRoot();
@@ -879,7 +418,7 @@ public class CFScriptParser extends AbstractParser {
 					return List.of( statement );
 				} else {
 					// Could be a BoxClass, which we may actually need to support
-					issues.add( new Issue( "Unexpected root node type [" + root.getClass().getName() + "] in component island.", root.getPosition() ) );
+					errorListener.semanticError( "Unexpected root node type [" + root.getClass().getName() + "] in component island.", root.getPosition() );
 					return null;
 				}
 			} else {
@@ -893,580 +432,6 @@ public class CFScriptParser extends AbstractParser {
 	}
 
 	/**
-	 * Converts the include parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IncludeContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.IncludeContext node ) {
-		return new BoxComponent(
-		    "include",
-		    List.of(
-		        new BoxAnnotation(
-		            new BoxFQN( "template",
-		                getPosition( node.expression() ),
-		                getSourceText( node.expression() ) ),
-		            toAst( file, node.expression() ),
-		            getPosition( node.expression() ),
-		            getSourceText( node.expression() )
-		        )
-		    ),
-		    getPosition( node ),
-		    getSourceText( node )
-		);
-	}
-
-	/**
-	 * Converts the rethrow parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR RethrowContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.RethrowContext node ) {
-		return new BoxRethrow( getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the throw parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ThrowContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxThrow
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.ThrowContext node ) {
-		BoxExpression expression = toAst( file, node.expression() );
-		return new BoxThrow( expression, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the do parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxDo
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.DoContext node ) {
-		BoxExpression	condition	= toAst( file, node.expression() );
-		BoxStatement	body		= null;
-		String			label		= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statement() );
-		return new BoxDo( label, condition, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the try parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxTry
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.TryContext node ) {
-		List<BoxStatement>	tryBody		= toAstStatementBlockAsList( file, node.statementBlock() );
-		List<BoxTryCatch>	catches		= node.catch_().stream().map( it -> toAst( file, it ) ).collect( Collectors.toList() );
-		List<BoxStatement>	finallyBody	= new ArrayList<>();
-		if ( node.finally_() != null ) {
-			finallyBody.addAll( toAstStatementBlockAsList( file, node.finally_().statementBlock() ) );
-		}
-		return new BoxTry( tryBody, catches, finallyBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the catch parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR TryContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxTryCatch
-	 */
-	private BoxTryCatch toAst( File file, CFScriptGrammar.Catch_Context node ) {
-		BoxExpression		exception	= toAst( file, node.expression() );
-		List<BoxStatement>	catchBody	= toAstStatementBlockAsList( file, node.statementBlock() );
-
-		List<BoxExpression>	catchTypes	= node.catchType().stream().map( ctNode -> {
-											if ( ctNode.fqn() != null ) {
-												return new BoxFQN( ctNode.fqn().getText(), getPosition( ctNode ),
-												    getSourceText( ctNode ) );
-											}
-
-											return toAst( file, ctNode.stringLiteral() );
-										} )
-		    .collect( Collectors.toList() );
-
-		return new BoxTryCatch( catchTypes, exception, catchBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the For parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ForContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxForIn
-	 * @see BoxForIndex
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.ForContext node ) {
-		BoxStatement	body;
-		String			label	= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statement() );
-
-		if ( node.IN() != null ) {
-			BoxExpression	variable	= toAst( file, node.accessExpression() );
-			Boolean			hasVar		= node.VAR() != null;
-			BoxExpression	collection	= toAst( file, node.expression() );
-
-			return new BoxForIn( label, variable, collection, body, hasVar, getPosition( node ), getSourceText( node ) );
-		}
-		BoxExpression	initializer	= null;
-		BoxExpression	condition	= null;
-		BoxExpression	step		= null;
-		if ( node.forAssignment() != null ) {
-			initializer = toAst( file, node.forAssignment().expression() );
-		}
-		if ( node.forCondition() != null ) {
-			condition = toAst( file, node.forCondition().expression() );
-		}
-		if ( node.forIncrement() != null ) {
-			step = toAst( file, node.forIncrement().expression() );
-		}
-
-		return new BoxForIndex( label, initializer, condition, step, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Switch parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR SwitchContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxSwitch
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.SwitchContext node ) {
-		BoxExpression		condition	= toAst( file, node.expression() );
-		List<BoxSwitchCase>	cases		= new ArrayList<>();
-		for ( CFScriptGrammar.CaseContext c : node.case_() ) {
-			cases.add( toAst( file, c ) );
-		}
-		return new BoxSwitch( condition, cases, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Case parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR CaseContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxSwitchCase
-	 */
-	private BoxSwitchCase toAst( File file, CFScriptGrammar.CaseContext node ) {
-		BoxExpression expr = null;
-		if ( node.expression() != null ) {
-			expr = toAst( file, node.expression() );
-		}
-
-		List<BoxStatement> statements = new ArrayList<>();
-		if ( node.statement() != null ) {
-			for ( var statement : node.statement() ) {
-				statements.add( toAst( file, statement ) );
-			}
-		}
-		return new BoxSwitchCase( expr, null, statements, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Continue parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ContinueContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxContinue
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.ContinueContext node ) {
-		String label = null;
-		if ( node.identifier() != null ) {
-			label = node.identifier().getText();
-		}
-		return new BoxContinue( label, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Break parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR BreakContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxBreak
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.BreakContext node ) {
-		String label = null;
-		if ( node.identifier() != null ) {
-			label = node.identifier().getText();
-		}
-		return new BoxBreak( label, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the While parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR WhileContext rule
-	 *
-	 * @return the corresponding AST BoxStatement
-	 *
-	 * @see BoxWhile
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.WhileContext node ) {
-		BoxExpression	condition	= toAst( file, node.condition );
-		BoxStatement	body;
-
-		String			label		= null;
-		if ( node.label != null ) {
-			label = node.label.getText();
-		}
-
-		body = toAst( file, node.statement() );
-		return new BoxWhile( label, condition, body, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the IfContext parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 *
-	 * @return the corresponding AST BoxIfElse
-	 *
-	 * @see BoxIfElse
-	 */
-	private BoxIfElse toAst( File file, CFScriptGrammar.IfContext node ) {
-		BoxExpression	condition	= toAst( file, node.expression() );
-		BoxStatement	thenBody;
-		BoxStatement	elseBody	= null;
-
-		thenBody = toAst( file, node.ifStmt );
-		if ( node.elseStmt != null ) {
-			elseBody = toAst( file, node.elseStmt );
-		}
-		return new BoxIfElse( condition, thenBody, elseBody, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the StatementBlock parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR BreakContext rule
-	 *
-	 * @return the list of the corresponding AST BoxStatement subclasses in the block
-	 *
-	 * @see BoxStatement
-	 */
-
-	private BoxStatement toAst( File file, CFScriptGrammar.StatementBlockContext node ) {
-		return new BoxStatementBlock( toAstStatementBlockAsList( file, node ), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the StatementBlock parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR BreakContext rule
-	 *
-	 * @return the list of the corresponding AST BoxStatement subclasses in the block
-	 *
-	 * @see BoxStatement
-	 */
-	private List<BoxStatement> toAstStatementBlockAsList( File file, CFScriptGrammar.StatementBlockContext node ) {
-		return node.statement().stream().map( stmt -> toAst( file, stmt ) ).collect( Collectors.toList() );
-	}
-
-	/**
-	 * Converts the SimpleStatement parser rule to the corresponding AST node.
-	 * The SimpleStatement contains rules of an Expression statement
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR SimpleStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement subclass
-	 *
-	 * @see BoxStatement
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.SimpleStatementContext node ) {
-
-		if ( node.return_() != null ) {
-			BoxExpression expr = null;
-			if ( node.return_().expression() != null ) {
-				expr = toAst( file, node.return_().expression() );
-			}
-			return new BoxReturn( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.incrementDecrementStatement() != null ) {
-			return toAst( file, node.incrementDecrementStatement() );
-		} else if ( node.expression() != null ) {
-			BoxExpression expr = toAst( file, node.expression() );
-			return new BoxExpressionStatement( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.break_() != null ) {
-			return toAst( file, node.break_() );
-		} else if ( node.continue_() != null ) {
-			return toAst( file, node.continue_() );
-		} else if ( node.rethrow() != null ) {
-			return toAst( file, node.rethrow() );
-		} else if ( node.param() != null ) {
-			return toAst( file, node.param() );
-		} else if ( node.variableDeclaration() != null ) {
-			return toAst( file, node.variableDeclaration() );
-		}
-
-		issues.add( new Issue( "Simple statement not implemented", getPosition( node ) ) );
-		return null;
-	}
-
-	private BoxStatement toAst( File file, VariableDeclarationContext variableDeclaration ) {
-		return new BoxExpressionStatement(
-		    new BoxAssignment(
-		        toAst( file, variableDeclaration.identifier() ),
-		        null,
-		        null,
-		        List.of( BoxAssignmentModifier.VAR ),
-		        getPosition( variableDeclaration ),
-		        getSourceText( variableDeclaration )
-		    ),
-		    getPosition( variableDeclaration ),
-		    getSourceText( variableDeclaration )
-		);
-	}
-
-	private BoxStatement toAst( File file, ParamContext node ) {
-		BoxExpression	type			= null;
-		BoxExpression	defaultValue	= null;
-		if ( node.type() != null ) {
-			type = new BoxStringLiteral( node.type().getText(), getPosition( node.type() ), getSourceText( node.type() ) );
-		}
-		if ( node.expression() != null ) {
-			defaultValue = toAst( file, node.expression() );
-		}
-		return new BoxParam(
-		    new BoxStringLiteral( node.accessExpression().getText(), getPosition( node.accessExpression() ), getSourceText( node.accessExpression() ) ),
-		    type,
-		    defaultValue,
-		    getPosition( node ),
-		    getSourceText( node )
-		);
-	}
-
-	/**
-	 * Converts the IncrementDecrementStatement parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IncrementDecrementStatementContext rule
-	 *
-	 * @return the corresponding AST BoxStatement subclass
-	 *
-	 * @see
-	 */
-	private BoxStatement toAst( File file, CFScriptGrammar.IncrementDecrementStatementContext node ) {
-		if ( node instanceof CFScriptGrammar.PostIncrementContext ) {
-			CFScriptGrammar.PostIncrementContext	ctx		= ( CFScriptGrammar.PostIncrementContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PostPlusPlus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof CFScriptGrammar.PostDecrementContext ) {
-			CFScriptGrammar.PostDecrementContext	ctx		= ( CFScriptGrammar.PostDecrementContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PostMinusMinus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof CFScriptGrammar.PreIncrementContext ) {
-			CFScriptGrammar.PreIncrementContext	ctx		= ( CFScriptGrammar.PreIncrementContext ) node;
-			BoxExpression						expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation					post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PrePlusPlus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		if ( node instanceof CFScriptGrammar.PreDecremenentContext ) {
-			CFScriptGrammar.PreDecremenentContext	ctx		= ( CFScriptGrammar.PreDecremenentContext ) node;
-			BoxExpression							expr	= toAst( file, ctx.accessExpression() );
-			BoxUnaryOperation						post	= new BoxUnaryOperation( expr, BoxUnaryOperator.PreMinusMinus, getPosition( node ),
-			    getSourceText( node ) );
-			return new BoxExpressionStatement( post, getPosition( node ), getSourceText( node ) );
-		}
-		issues.add( new Issue( "Increment/Decrement not implemented", getPosition( node ) ) );
-		return null;
-	}
-
-	/**
-	 * Converts the AccessExpression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR AccessExpressionContext rule
-	 *
-	 * @return the corresponding AST BoxExpression subclass
-	 *
-	 * @see BoxIdentifier
-	 * @see BoxArrayAccess
-	 * @see BoxDotAccess
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.AccessExpressionContext node ) {
-		BoxExpression expr = toAst( file, node.objectExpression() );
-		// loop over children
-		for ( int i = 0; i < node.getChildCount(); i++ ) {
-			ParseTree child = node.getChild( i );
-			if ( child instanceof CFScriptGrammar.DotAccessContext dotAccess ) {
-				BoxExpression access;
-				// Any reserved keywords like scopes on the accessed after a dot is just a keyword.
-				if ( dotAccess.identifier() != null && dotAccess.identifier().reservedKeyword() != null ) {
-					CFScriptGrammar.ReservedKeywordContext keyword = dotAccess.identifier().reservedKeyword();
-					access = new BoxIdentifier( keyword.getText(), getPosition( keyword ), getSourceText( keyword ) );
-				} else if ( dotAccess.identifier() != null ) {
-					access = toAst( file, dotAccess.identifier() );
-				} else {
-					// turn .123 into 123 as an integer literal
-					access = new BoxIntegerLiteral( dotAccess.floatLiteralDecimalOnly().getText().substring( 1 ),
-					    getPosition( dotAccess.floatLiteralDecimalOnly() ), getSourceText( dotAccess.floatLiteralDecimalOnly() ) );
-				}
-				expr = new BoxDotAccess( expr, dotAccess.QM() != null, access, getPosition( dotAccess ),
-				    getSourceText( dotAccess ) );
-			} else if ( child instanceof CFScriptGrammar.ArrayAccessContext arrayAccess ) {
-				expr = new BoxArrayAccess( expr, false, toAst( file, arrayAccess.expression() ), getPosition( arrayAccess ), getSourceText( arrayAccess ) );
-			} else if ( child instanceof CFScriptGrammar.MethodInvokationContext methodInvokation ) {
-				if ( methodInvokation.functionInvokation() != null ) {
-					List<BoxArgument>					args	= toAst( file, methodInvokation.functionInvokation().invokationExpression().argumentList() );
-					CFScriptGrammar.IdentifierContext	id		= methodInvokation.functionInvokation().identifier();
-					BoxExpression						name	= new BoxIdentifier( id.getText(), getPosition( id ), getSourceText( id ) );
-
-					expr = new BoxMethodInvocation( name, expr, args, methodInvokation.QM() != null, true, getPosition( methodInvokation ),
-					    getSourceText( methodInvokation ) );
-				} else if ( methodInvokation.arrayAccess() != null ) {
-					List<BoxArgument>	args	= toAst( file, methodInvokation.invokationExpression().argumentList() );
-					BoxExpression		name	= toAst( file, methodInvokation.arrayAccess().expression() );
-					expr = new BoxMethodInvocation( name, expr, args, false, false, getPosition( methodInvokation ), getSourceText( methodInvokation ) );
-				} else {
-					issues.add( new Issue( "Unimplemented method invocation does not use function invocation or array access rules",
-					    getPosition( methodInvokation ) ) );
-					return null;
-				}
-			} else if ( child instanceof CFScriptGrammar.InvokationExpressionContext invokationExpression ) {
-				expr = new BoxExpressionInvocation( expr, toAst( file, invokationExpression.argumentList() ), getPosition( invokationExpression ),
-				    getSourceText( invokationExpression ) );
-			}
-		}
-		return expr;
-	}
-
-	/**
-	 * Converts the IdentifierContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IdentifierContext rule
-	 *
-	 * @return the corresponding AST BoxIdentifier or a BoxScope if it is a reserved keyword
-	 *
-	 * @see BoxScope
-	 * @see BoxIdentifier
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.IdentifierContext node ) {
-		CFScriptGrammar.ReservedKeywordContext keyword = node.reservedKeyword();
-		if ( keyword != null && keyword.scope() != null ) {
-			return toAst( file, keyword.scope() );
-		}
-		String name = "";
-		if ( node.IDENTIFIER() != null ) {
-			name = node.IDENTIFIER().getText();
-		} else if ( node.reservedKeyword() != null ) {
-			name = node.reservedKeyword().getText();
-		}
-		return new BoxIdentifier( name, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Scope parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ScopeContext rule
-	 *
-	 * @return corresponding AST BoxScope
-	 *
-	 * @see BoxScope for the reserved keywords used to identify a scope
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.ScopeContext node ) {
-		return new BoxScope( node.getText(), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the string literal into a BoxStringLiteral or BoxStringInterpolation
-	 *
-	 * @param file       source file, if any
-	 * @param expression ANTLR StringLiteralContext rule
-	 *
-	 * @return corresponding AST BoxExpr subclass
-	 *
-	 * @see BoxExpression subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.StringLiteralContext expression ) {
-		String quoteChar = expression.getText().substring( 0, 1 );
-		if ( expression.expression().isEmpty() ) {
-			String s = expression.getText();
-			// trim leading and trailing quote
-			s = s.substring( 1, s.length() - 1 );
-			return new BoxStringLiteral(
-			    escapeStringLiteral( quoteChar, s ),
-			    getPosition( expression ),
-			    getSourceText( expression )
-			);
-
-		} else {
-			List<BoxExpression> parts = new ArrayList<>();
-			expression.children.forEach( it -> {
-				if ( it != null && it instanceof CFScriptGrammar.StringLiteralPartContext ) {
-					parts.add( new BoxStringLiteral( escapeStringLiteral( quoteChar, getSourceText( ( ParserRuleContext ) it ) ),
-					    getPosition( ( ParserRuleContext ) it ),
-					    getSourceText( ( ParserRuleContext ) it ) ) );
-				}
-				if ( it != null && it instanceof CFScriptGrammar.ExpressionContext ) {
-					parts.add( toAst( file, ( CFScriptGrammar.ExpressionContext ) it ) );
-				}
-			} );
-			return new BoxStringInterpolation( parts, getPosition( expression ), getSourceText( expression ) );
-		}
-	}
-
-	/**
 	 * Escape double up quotes and pounds in a string literal
 	 *
 	 * @param quoteChar the quote character used to surround the string
@@ -1474,818 +439,15 @@ public class CFScriptParser extends AbstractParser {
 	 *
 	 * @return the escaped string
 	 */
-	private String escapeStringLiteral( String quoteChar, String string ) {
+	public String escapeStringLiteral( String quoteChar, String string ) {
 		String escaped = string.replace( "##", "#" );
 		return escaped.replace( quoteChar + quoteChar, quoteChar );
 	}
 
-	/**
-	 * Converts the Expression parser rule to the corresponding AST node.
-	 * The operator precedence resolved in the ANTLR grammar
-	 *
-	 * @param file       source file, if any
-	 * @param expression ANTLR ExpressionContext rule
-	 *
-	 * @return corresponding AST BoxExpr subclass
-	 *
-	 * @see BoxExpression subclasses
-	 * @see BoxBinaryOperator
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.ExpressionContext expression ) {
-		if ( expression.ternary() != null ) {
-			BoxExpression	condition	= toAst( file, expression.ternary().notTernaryExpression() );
-			BoxExpression	whenTrue	= toAst( file, expression.ternary().expression( 0 ) );
-			BoxExpression	whenFalse	= toAst( file, expression.ternary().expression( 1 ) );
-			return new BoxTernaryOperation( condition, whenTrue, whenFalse, getPosition( expression ), getSourceText( expression ) );
-		}
-		if ( expression.assignment() != null ) {
-			return toAst( file, expression.assignment() );
-		} else if ( expression.notTernaryExpression() != null ) {
-			return toAst( file, expression.notTernaryExpression() );
-		}
-
-		issues.add( new Issue( "Expression not implemented", getPosition( expression ) ) );
-		return null;
-	}
-
-	private BoxExpression toAst( File file, NotTernaryExpressionContext expression ) {
-		if ( expression.accessExpression() != null ) {
-			return toAst( file, expression.accessExpression() );
-		} else if ( expression.and() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.And, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.or() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Or, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.PLUS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Plus, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.MINUS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Minus, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.STAR() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Star, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.SLASH() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Slash, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.BACKSLASH() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Backslash, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.unary() != null ) {
-			return toAst( file, expression.unary() );
-		} else if ( expression.POWER() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Power, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.XOR() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Xor, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.PERCENT() != null || expression.MOD() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Mod, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.TEQ() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.TEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.neq() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.NotEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.gt() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.GreaterThan, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.gte() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.GreaterThanEquals, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.lt() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.LessThan, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.lte() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.LesslThanEqual, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.eq() != null || expression.IS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxComparisonOperation( left, BoxComparisonOperator.Equal, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.AMPERSAND() != null ) {
-			List<BoxExpression>							parts	= new ArrayList<>();
-			CFScriptGrammar.NotTernaryExpressionContext	current	= expression;
-			// unwrap nested foo & bar & baz & bum into a single concat node
-			do {
-				parts.add( 0, toAst( file, current.right ) );
-				current = current.left;
-			} while ( current.AMPERSAND() != null );
-			parts.add( 0, toAst( file, current ) );
-
-			return new BoxStringConcat( parts, getPosition( expression ), getSourceText( expression ) );
-
-		} else if ( expression.EQV() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Equivalence, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.IMP() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Implies, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.ELVIS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Elvis, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.notOrBang() != null && expression.CONTAIN() == null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			return new BoxUnaryOperation( expr, BoxUnaryOperator.Not, getPosition( expression ), getSourceText( expression ) );
-			// return new BoxNegateOperation( expr, BoxNegateOperator.Not, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.CONTAINS() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.Contains, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.CONTAIN() != null && expression.DOES() != null && expression.NOT() != null ) {
-			BoxExpression	left	= toAst( file, expression.notTernaryExpression( 0 ) );
-			BoxExpression	right	= toAst( file, expression.notTernaryExpression( 1 ) );
-			return new BoxBinaryOperation( left, BoxBinaryOperator.NotContains, right, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.pre != null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			if ( expression.PLUSPLUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PrePlusPlus, getPosition( expression ), getSourceText( expression ) );
-			}
-			if ( expression.MINUSMINUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PreMinusMinus, getPosition( expression ), getSourceText( expression ) );
-			}
-		} else if ( expression.post != null ) {
-			BoxExpression expr = toAst( file, expression.notTernaryExpression( 0 ) );
-			if ( expression.PLUSPLUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PostPlusPlus, getPosition( expression ), getSourceText( expression ) );
-			}
-			if ( expression.MINUSMINUS() != null ) {
-				return new BoxUnaryOperation( expr, BoxUnaryOperator.PostMinusMinus, getPosition( expression ), getSourceText( expression ) );
-			}
-		} else if ( !expression.ICHAR().isEmpty() ) {
-			return toAst( file, expression.notTernaryExpression( 0 ) );
-		} else if ( expression.assignment() != null ) {
-			return toAst( file, expression.assignment() );
-		} else if ( expression.NULL() != null ) {
-			return new BoxNull( getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.anonymousFunction() != null ) {
-			/* Closure declaration */
-			CFScriptGrammar.ClosureContext	closure		= expression.anonymousFunction().closure();
-			List<BoxArgumentDeclaration>	args		= new ArrayList<>();
-			List<BoxAnnotation>				annotations	= new ArrayList<>();
-			BoxStatement					body;
-
-			if ( closure.functionParamList() != null ) {
-				for ( CFScriptGrammar.FunctionParamContext arg : closure.functionParamList().functionParam() ) {
-					BoxArgumentDeclaration argDeclaration = toAst( file, arg );
-					args.add( argDeclaration );
-				}
-			}
-			if ( closure.identifier() != null ) {
-				BoxArgumentDeclaration argDeclaration = new BoxArgumentDeclaration( false, "Any", closure.identifier().getText(), null, new ArrayList<>(),
-				    new ArrayList<>(), getPosition( closure.identifier() ), getSourceText( closure.identifier() ) );
-				args.add( argDeclaration );
-			}
-			/* Process the annotations */
-			for ( CFScriptGrammar.PostannotationContext annotation : closure.postannotation() ) {
-				annotations.add( toAst( file, annotation ) );
-			}
-			/* Process the body */
-			// ()=> and ()->{} funnel through anonymousFunctionBody and have a simplestatement (which could be a statement block)
-			if ( closure.statement() != null ) {
-				body = toAst( file, closure.statement() );
-				// function() {} syntax always uses statement block
-			} else {
-				body = toAst( file, closure.statementBlock() );
-			}
-
-			return new BoxClosure( args, annotations, body, getPosition( expression ), getSourceText( expression ) );
-		} else if ( expression.staticAccessExpression() != null ) {
-			return toAst( file, expression.staticAccessExpression() );
-		}
-		issues.add( new Issue( "Expression not implemented", getPosition( expression ) ) );
-		return null;
-	}
-
-	private BoxExpression toAst( File file, StaticAccessExpressionContext staticAccessExpression ) {
-		BoxExpression expr = toAst( file, staticAccessExpression.staticObjectExpression() );
-
-		if ( staticAccessExpression.staticMethodInvokation() != null ) {
-			List<BoxArgument>					args	= toAst( file,
-			    staticAccessExpression.staticMethodInvokation().functionInvokation().invokationExpression().argumentList() );
-			CFScriptGrammar.IdentifierContext	id		= staticAccessExpression.staticMethodInvokation().functionInvokation().identifier();
-			BoxIdentifier						name	= new BoxIdentifier( id.getText(), getPosition( id ), getSourceText( id ) );
-
-			return new BoxStaticMethodInvocation( name, expr, args, getPosition( staticAccessExpression.staticMethodInvokation() ),
-			    getSourceText( staticAccessExpression.staticMethodInvokation() ) );
-
-		} else if ( staticAccessExpression.staticAccess() != null ) {
-			BoxExpression access;
-			// Any reserved keywords like scopes on the accessed after a dot is just a keyword.
-			if ( staticAccessExpression.staticAccess().identifier() != null ) {
-				access = new BoxIdentifier( staticAccessExpression.staticAccess().identifier().getText(),
-				    getPosition( staticAccessExpression.staticAccess().identifier() ), getSourceText( staticAccessExpression.staticAccess().identifier() ) );
-			} else {
-				// turn 123 into an integer literal
-				access = new BoxIntegerLiteral( staticAccessExpression.staticAccess().integerLiteral().getText(),
-				    getPosition( staticAccessExpression.staticAccess().integerLiteral() ),
-				    getSourceText( staticAccessExpression.staticAccess().integerLiteral() ) );
-			}
-			return new BoxStaticAccess( expr, false, access, getPosition( staticAccessExpression.staticAccess() ),
-			    getSourceText( staticAccessExpression.staticAccess() ) );
-		} else {
-			issues.add(
-			    new Issue( "Unimplemented method invocation does not use function invocation or array access rules", getPosition( staticAccessExpression ) ) );
-			return null;
-		}
-	}
-
-	private BoxExpression toAst( File file, StaticObjectExpressionContext staticObjectExpression ) {
-		if ( staticObjectExpression.fqn() != null ) {
-			return toAst( file, staticObjectExpression.fqn() );
-		} else if ( staticObjectExpression.identifier() != null ) {
-			return new BoxIdentifier( staticObjectExpression.identifier().getText(), getPosition( staticObjectExpression.identifier() ),
-			    getSourceText( staticObjectExpression.identifier() ) );
-		} else {
-			issues.add( new Issue( "Unimplemented static object expression", getPosition( staticObjectExpression ) ) );
-			return null;
-		}
-	}
-
-	private BoxExpression toAst( File file, AssignmentContext node ) {
-		BoxExpression			left	= toAst( file, node.assignmentLeft().accessExpression() );
-		BoxExpression			right	= toAst( file, node.assignmentRight().expression() );
-		BoxAssignmentOperator	op		= BoxAssignmentOperator.Equal;
-		if ( node.PLUSEQUAL() != null ) {
-			op = BoxAssignmentOperator.PlusEqual;
-		} else if ( node.MINUSEQUAL() != null ) {
-			op = BoxAssignmentOperator.MinusEqual;
-		} else if ( node.STAREQUAL() != null ) {
-			op = BoxAssignmentOperator.StarEqual;
-		} else if ( node.SLASHEQUAL() != null ) {
-			op = BoxAssignmentOperator.SlashEqual;
-		} else if ( node.MODEQUAL() != null ) {
-			op = BoxAssignmentOperator.ModEqual;
-		} else if ( node.CONCATEQUAL() != null ) {
-			op = BoxAssignmentOperator.ConcatEqual;
-		}
-		// In the future, we expect there to be more than just var here, thus the list.
-		List<BoxAssignmentModifier> modifiers = new ArrayList<BoxAssignmentModifier>();
-		if ( node.VAR() != null ) {
-			modifiers.add( BoxAssignmentModifier.VAR );
-		}
-
-		return new BoxAssignment( left, op, right, modifiers, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the UnaryContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FqnContext rule
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.FqnContext node ) {
-		return new BoxFQN( node.getText(), getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the UnaryContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR UnaryContext rule
-	 *
-	 * @return corresponding AST BoxUnaryOperation
-	 *
-	 * @see BoxUnaryOperation
-	 * @see BoxUnaryOperator
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.UnaryContext node ) {
-
-		BoxExpression		expr	= toAst( file, node.expression() );
-		BoxUnaryOperator	op		= node.MINUS() != null ? BoxUnaryOperator.Minus
-		    : ( node.PLUS() != null ? BoxUnaryOperator.Plus : BoxUnaryOperator.BitwiseComplement );
-		if ( expr instanceof BoxBinaryOperation bop ) {
-			return new BoxBinaryOperation(
-			    new BoxUnaryOperation( bop.getLeft(), op, getPosition( node ), getSourceText( node ) ),
-			    bop.getOperator(),
-			    bop.getRight(),
-			    bop.getPosition(),
-			    bop.getSourceText()
-			);
-		}
-		return new BoxUnaryOperation( expr, op, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ObjectExpression parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ObjectExpressionContext rule
-	 *
-	 * @return corresponding AST
-	 *
-	 * @see BoxAccess subclasses
-	 * @see BoxIdentifier subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.ObjectExpressionContext node ) {
-		if ( node.LPAREN() != null ) {
-			BoxExpression expr = toAst( file, node.expression() );
-			return new BoxParenthesis( expr, getPosition( node ), getSourceText( node ) );
-		} else if ( node.functionInvokation() != null )
-			return toAst( file, node.functionInvokation() );
-		else if ( node.identifier() != null )
-			return toAst( file, node.identifier() );
-		else if ( node.literalExpression() != null ) {
-			return toAst( file, node.literalExpression() );
-		} else if ( node.new_() != null ) {
-			return toAst( file, node.new_() );
-		}
-
-		issues.add( new Issue( "Object expression not implemented", getPosition( node ) ) );
-		return null;
-
-	}
-
-	/**
-	 * Converts the NewContext parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR NewContext rule
-	 *
-	 * @return corresponding AST
-	 */
-	private BoxExpression toAst( File file, NewContext node ) {
-		BoxExpression		expr	= null;
-		BoxIdentifier		prefix	= null;
-		List<BoxArgument>	args	= toAst( file, node.argumentList() );
-		if ( node.fqn() != null ) {
-			expr = toAst( file, node.fqn() );
-		}
-		if ( node.stringLiteral() != null ) {
-			expr = toAst( file, node.stringLiteral() );
-		}
-		if ( node.identifier() != null ) {
-			var tmp = toAst( file, node.identifier() );
-			if ( tmp instanceof BoxIdentifier bi ) {
-				prefix = bi;
-			} else {
-				prefix = new BoxIdentifier( ( ( BoxScope ) tmp ).getName(), getPosition( node.identifier() ), getSourceText( node.identifier() ) );
-			}
-
-		}
-		return new BoxNew( prefix, expr, args, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the ObjectExpression parser rule to the corresponding AST node. * @param file
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR LiteralExpressionContext rule
-	 *
-	 * @return corresponding AST BoxAccess or an LiteralExpressionContext
-	 *
-	 * @see BoxAccess subclasses
-	 * @see BoxIdentifier subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.LiteralExpressionContext node ) {
-		if ( node.stringLiteral() != null ) {
-			return toAst( file, node.stringLiteral() );
-		}
-		if ( node.integerLiteral() != null ) {
-			return toAst( file, node.integerLiteral() );
-		}
-		if ( node.floatLiteral() != null ) {
-			CFScriptGrammar.FloatLiteralContext fnode = node.floatLiteral();
-			return new BoxDecimalLiteral(
-			    fnode.getText(),
-			    getPosition( fnode ),
-			    getSourceText( fnode )
-			);
-		}
-		if ( node.booleanLiteral() != null ) {
-			CFScriptGrammar.BooleanLiteralContext bnode = node.booleanLiteral();
-			return new BoxBooleanLiteral(
-			    bnode.getText(),
-			    getPosition( bnode ),
-			    getSourceText( bnode ) );
-		}
-		if ( node.arrayExpression() != null ) {
-			return toAst( file, node.arrayExpression() );
-		}
-
-		if ( node.structExpression() != null ) {
-			return toAst( file, node.structExpression() );
-		}
-
-		issues.add( new Issue( "Literal expression not implemented", getPosition( node ) ) );
-		return null;
-
-	}
-
-	/**
-	 * Converts the IntegerLiteral parser rule to the corresponding AST node. *
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR IntegerLiteralContext rule
-	 *
-	 * @return corresponding AST BoxAccess or an IntegerLiteralContext
-	 *
-	 */
-	private BoxExpression toAst( File file, IntegerLiteralContext integerLiteral ) {
-		return new BoxIntegerLiteral(
-		    integerLiteral.getText(),
-		    getPosition( integerLiteral ),
-		    getSourceText( integerLiteral )
-		);
-	}
-
-	/**
-	 * Converts the Struct Expression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArrayExpressionContext rule
-	 *
-	 * @return corresponding AST BoxArray
-	 *
-	 * @see BoxArrayLiteral subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.StructExpressionContext node ) {
-		List<BoxExpression>	values	= new ArrayList<>();
-		BoxStructType		type	= node.RBRACKET() != null ? BoxStructType.Ordered : BoxStructType.Unordered;
-		if ( node.structMembers() != null ) {
-			for ( CFScriptGrammar.StructMemberContext pair : node.structMembers().structMember() ) {
-				if ( pair.stringLiteral() != null ) {
-					values.add( toAst( file, pair.stringLiteral() ) );
-				} else if ( pair.structKeyIdentifer() != null ) {
-					values.add( new BoxIdentifier( pair.structKeyIdentifer().getText(), getPosition( pair.structKeyIdentifer() ),
-					    getSourceText( pair.structKeyIdentifer() ) ) );
-				} else if ( pair.integerLiteral() != null ) {
-					values.add( toAst( file, pair.integerLiteral() ) );
-				} else if ( pair.structKeyFqn() != null ) {
-					// Lucee creates nested structs, adobe errors. We're just going to turn foo.bar into a quoted string for now.
-					values
-					    .add( new BoxStringLiteral( pair.structKeyFqn().getText(), getPosition( pair.structKeyFqn() ), getSourceText( pair.structKeyFqn() ) ) );
-				}
-				values.add( toAst( file, pair.expression() ) );
-			}
-		}
-		return new BoxStructLiteral( type, values, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Array Expression parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArrayExpressionContext rule
-	 *
-	 * @return corresponding AST BoxArray
-	 *
-	 * @see BoxArrayLiteral subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.ArrayExpressionContext node ) {
-		List<BoxExpression> values = new ArrayList<>();
-		if ( node.arrayValues() != null ) {
-			for ( CFScriptGrammar.ExpressionContext value : node.arrayValues().expression() ) {
-				values.add( toAst( file, value ) );
-			}
-		}
-		return new BoxArrayLiteral( values, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the Function Invocation parser rule to the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionInvokationContext rule
-	 *
-	 * @return corresponding AST BoxFunctionInvocation
-	 *
-	 * @see BoxFunctionInvocation subclasses
-	 * @see BoxArgument subclasses
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.FunctionInvokationContext node ) {
-		List<BoxArgument> args = toAst( file, node.invokationExpression().argumentList() );
-		return new BoxFunctionInvocation( node.identifier().getText(),
-		    args,
-		    getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the argument list to the corresponding List of AST nodes
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ArgumentListContext rule
-	 *
-	 * @return corresponding List of AST nodes
-	 *
-	 */
-	private List<BoxArgument> toAst( File file, CFScriptGrammar.ArgumentListContext node ) {
-		List<BoxArgument>	args	= new ArrayList<>();
-		Boolean				isNamed	= false;
-		if ( node != null ) {
-			for ( CFScriptGrammar.NamedArgumentContext arg : node.namedArgument() ) {
-				isNamed = true;
-				args.add( toAst( file, arg ) );
-			}
-			for ( CFScriptGrammar.PositionalArgumentContext arg : node.positionalArgument() ) {
-				if ( isNamed ) {
-					issues.add( new Issue( "You cannot mix named and positional arguments", getPosition( arg ) ) );
-				}
-				args.add( toAst( file, arg ) );
-			}
-		}
-		return args;
-	}
-
-	/**
-	 * Converts the PositionalArgumentContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PositionalArgumentContext rule
-	 *
-	 * @return corresponding AST PositionalArgumentContext
-	 *
-	 * @see BoxArgument
-	 */
-	private BoxArgument toAst( File file, CFScriptGrammar.PositionalArgumentContext node ) {
-		BoxExpression value = toAst( file, node.expression() );
-		return new BoxArgument( null, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the NamedArgumentContext parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR NamedArgumentContext rule
-	 *
-	 * @return corresponding AST NamedArgumentContext
-	 *
-	 * @see BoxArgument
-	 */
-	private BoxArgument toAst( File file, CFScriptGrammar.NamedArgumentContext node ) {
-		BoxExpression name;
-		if ( node.identifier() != null ) {
-			name = new BoxStringLiteral( node.identifier().getText(), getPosition( node ), getSourceText( node ) );
-		} else {
-			name = toAst( file, node.stringLiteral() );
-		}
-		BoxExpression value = toAst( file, node.expression() );
-		return new BoxArgument( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the interface Function declaration parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionContext rule
-	 *
-	 * @return corresponding AST AbstractFunctionContext
-	 *
-	 * @see AbstractFunctionContext
-	 */
-	private BoxFunctionDeclaration toAst( File file, AbstractFunctionContext node ) {
-		return processFunction(
-		    node.postannotation(),
-		    node.functionSignature().identifier().getText(),
-		    node.functionSignature(),
-		    null,
-		    node );
-	}
-
-	/**
-	 * Converts the Function declaration parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR FunctionContext rule
-	 *
-	 * @return corresponding AST BoxFunctionDeclaration
-	 *
-	 * @see BoxFunctionDeclaration
-	 */
-	private BoxFunctionDeclaration toAst( File file, CFScriptGrammar.FunctionContext node ) {
-		return processFunction(
-		    node.postannotation(),
-		    node.functionSignature().identifier().getText(),
-		    node.functionSignature(),
-		    node.statementBlock(),
-		    node );
-	}
-
-	private BoxFunctionDeclaration processFunction(
-	    List<CFScriptGrammar.PostannotationContext> postannotations,
-	    String name,
-	    CFScriptGrammar.FunctionSignatureContext functionSignature,
-	    CFScriptGrammar.StatementBlockContext statementBlock,
-	    ParserRuleContext node ) {
-
-		BoxReturnType						returnType		= null;
-		// Is null for interface function
-		List<BoxStatement>					body			= null;
-		List<BoxArgumentDeclaration>		args			= new ArrayList<>();
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-		List<BoxAnnotation>					annToRemove		= new ArrayList<>();
-		BoxAccessModifier					accessModifier	= null;
-		List<BoxMethodDeclarationModifier>	modifiers		= new ArrayList<>();
-
-		if ( functionSignature.modifiers() != null ) {
-			if ( !functionSignature.modifiers().STATIC().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.STATIC );
-			}
-			if ( !functionSignature.modifiers().FINAL().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.FINAL );
-			}
-			if ( !functionSignature.modifiers().ABSTRACT().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.ABSTRACT );
-			}
-			if ( !functionSignature.modifiers().DEFAULT().isEmpty() ) {
-				modifiers.add( BoxMethodDeclarationModifier.DEFAULT );
-			}
-			if ( functionSignature.modifiers().accessModifier() != null && !functionSignature.modifiers().accessModifier().isEmpty() ) {
-				var accessModifierNode = functionSignature.modifiers().accessModifier( 0 );
-				if ( accessModifierNode.PUBLIC() != null ) {
-					accessModifier = BoxAccessModifier.Public;
-				} else if ( accessModifierNode.PRIVATE() != null ) {
-					accessModifier = BoxAccessModifier.Private;
-				} else if ( accessModifierNode.REMOTE() != null ) {
-					accessModifier = BoxAccessModifier.Remote;
-				} else if ( accessModifierNode.PACKAGE() != null ) {
-					accessModifier = BoxAccessModifier.Package;
-				}
-			}
-		}
-
-		for ( CFScriptGrammar.PostannotationContext annotation : postannotations ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-
-		if ( functionSignature.functionParamList() != null ) {
-			for ( CFScriptGrammar.FunctionParamContext arg : functionSignature.functionParamList().functionParam() ) {
-				BoxArgumentDeclaration argDeclaration = toAst( file, arg );
-				/* Resolve annotations @name.key "value" */
-				for ( BoxAnnotation pre : annotations ) {
-					String prename = pre.getKey().getValue();
-					if ( prename.toLowerCase().startsWith( argDeclaration.getName().toLowerCase() ) ) {
-						if ( prename.indexOf( '.' ) > -1 ) {
-							prename = pre.getKey().getValue().substring( 0, pre.getKey().getValue().indexOf( "." ) );
-
-						} else {
-							prename = "hint";
-						}
-						BoxFQN key = new BoxFQN(
-						    pre.getKey().getValue().substring( pre.getKey().getValue().indexOf( "." ) + 1 ), pre.getPosition(),
-						    pre.getSourceText()
-						);
-						argDeclaration.getAnnotations().add(
-						    new BoxAnnotation( key, pre.getValue(), pre.getPosition(), pre.getSourceText() )
-						);
-						annToRemove.add( pre );
-					}
-				}
-
-				args.add( argDeclaration );
-			}
-		}
-
-		if ( functionSignature.returnType() != null ) {
-			String	targetType	= functionSignature.returnType().getText();
-			BoxType	boxType		= BoxType.fromString( targetType );
-			String	fqn			= boxType.equals( BoxType.Fqn ) ? targetType : null;
-			returnType = new BoxReturnType( boxType, fqn, getPosition( functionSignature.returnType() ), getSourceText( functionSignature.returnType() ) );
-		}
-		if ( statementBlock != null ) {
-			body = new ArrayList<>();
-			body.addAll( toAstStatementBlockAsList( file, statementBlock ) );
-		}
-		annotations.removeAll( annToRemove );
-
-		return new BoxFunctionDeclaration( accessModifier, modifiers, name, returnType, args, annotations, documentation, body, getPosition( node ),
-		    getSourceText( node ) );
-	}
-
-	/**
-	 * Converts the AttributeSimple parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR AttributeSimpleContext rule
-	 *
-	 * @return corresponding AST AttributeSimpleContext
-	 *
-	 */
-	private BoxExpression toAst( File file, CFScriptGrammar.AttributeSimpleContext node ) {
-		if ( node.literalExpression() != null ) {
-			return toAst( file, node.literalExpression() );
-		} else if ( node.identifier() != null ) {
-			// Converting an identifer to a string literal here in the AST removes ambiguity, but also loses the
-			// lexical context of the original source code.
-			return new BoxStringLiteral( node.identifier().getText(), getPosition( node ), getSourceText( node ) );
-		} else if ( node.fqn() != null ) {
-			// Converting an fqn to a string literal here in the AST removes ambiguity, but also loses the
-			// lexical context of the original source code.
-			return new BoxStringLiteral( node.fqn().getText(), getPosition( node ), getSourceText( node ) );
-		}
-		issues.add( new Issue( "Attribute simple not implemented", getPosition( node ) ) );
-		return null;
-	}
-
-	/**
-	 * Converts the Function argument parser rule to the corresponding AST node.
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR ParamContext rule
-	 *
-	 * @return corresponding AST BoxArgumentDeclaration
-	 *
-	 * @see BoxArgumentDeclaration
-	 */
-	private BoxArgumentDeclaration toAst( File file, CFScriptGrammar.FunctionParamContext node ) {
-		Boolean								required		= false;
-		String								type			= null;
-		String								name			= "undefined";
-		BoxExpression						expr			= null;
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-
-		name = node.identifier().getText();
-		if ( node.REQUIRED() != null ) {
-			required = true;
-		}
-
-		if ( node.expression() != null ) {
-			expr = toAst( file, node.expression() );
-		}
-		if ( node.type() != null ) {
-			type = node.type().getText();
-		}
-		for ( CFScriptGrammar.PostannotationContext annotation : node.postannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-
-		return new BoxArgumentDeclaration( required, type, name, expr, annotations, documentation, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts a post annotation into the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PostannotationContext rule
-	 *
-	 * @return corresponding AST PostannotationContext
-	 *
-	 * @see BoxAnnotation
-	 */
-	private BoxAnnotation toAst( File file, CFScriptGrammar.PostannotationContext node ) {
-
-		BoxFQN			name	= new BoxFQN( node.key.getText(), getPosition( node.key ), getSourceText( node.key ) );
-		BoxExpression	value;
-		if ( node.value != null ) {
-			value = toAst( file, node.value );
-		} else {
-			value = null;
-		}
-		return new BoxAnnotation( name, value, getPosition( node ), getSourceText( node ) );
-	}
-
-	/**
-	 * Converts a Property into the corresponding AST node
-	 *
-	 * @param file source file, if any
-	 * @param node ANTLR PropertyContext rule
-	 *
-	 * @return corresponding AST PropertyContext
-	 *
-	 */
-	private BoxProperty toAst( File file, CFScriptGrammar.PropertyContext node ) {
-		List<BoxAnnotation>					annotations		= new ArrayList<>();
-		List<BoxDocumentationAnnotation>	documentation	= new ArrayList<>();
-
-		for ( CFScriptGrammar.PostannotationContext annotation : node.postannotation() ) {
-			annotations.add( toAst( file, annotation ) );
-		}
-
-		return new BoxProperty( new ArrayList<BoxAnnotation>(), annotations, documentation, getPosition( node ), getSourceText( node ) );
-	}
-
 	public BoxExpression parseCFExpression( String code, Position position ) {
 		try {
-			ParsingResult result = new CFScriptParser( position.getStart().getLine(), position.getStart().getColumn() )
-			    .setSource( sourceToParse )
-			    .setSubParser( true )
-			    .parseExpression( code );
+			ParsingResult result = new CFScriptParser( position.getStart().getLine(), position.getStart().getColumn() ).setSource( sourceToParse )
+			    .setSubParser( true ).parseExpression( code );
 			this.comments.addAll( result.getComments() );
 			if ( result.getIssues().isEmpty() ) {
 				return ( BoxExpression ) result.getRoot();
@@ -2295,9 +457,13 @@ public class CFScriptParser extends AbstractParser {
 				return new BoxNull( null, null );
 			}
 		} catch ( IOException e ) {
-			issues.add( new Issue( "Error parsing expression " + e.getMessage(), position ) );
+			errorListener.semanticError( "Error parsing expression " + e.getMessage(), position );
 			return new BoxNull( null, null );
 		}
+	}
+
+	public Token getFirstToken() {
+		return firstToken;
 	}
 
 	@Override
@@ -2306,6 +472,7 @@ public class CFScriptParser extends AbstractParser {
 			return this;
 		}
 		this.sourceToParse = source;
+		this.errorListener.setSource( sourceToParse );
 		return this;
 	}
 
@@ -2315,4 +482,153 @@ public class CFScriptParser extends AbstractParser {
 		return this;
 	}
 
+	/**
+	 * Checks DOT access methods to ensure that nonsensical access methods are rejected at AST build time
+	 * and not left to the runtime, when it is not so useful!
+	 * <p>
+	 * This is necessarily quite an involved check as there are many combinations of left and right
+	 * </p>
+	 *
+	 * @param left  the left side of the dot access left.right
+	 * @param right the right side of the dot access left.right
+	 */
+	public void checkDotAccess( BoxExpression left, BoxExpression right ) {
+
+		// Check the right hand side to see if it is a valid access method
+		checkRight( right );
+
+		// Check to see if the left hand side is something that is valid to be accessed via a dot access
+		checkLeft( left );
+
+		// Now we know the LHS is valid for access by a dot method and the RHS is a valid access method, so
+		// we can check the combinations here if needed.
+		// TODO: @Brad - Add more checks here if needed
+	}
+
+	/**
+	 * Check the right hand side of a dot access to ensure it is a valid access method
+	 *
+	 * @param right the right side of the dot access left.right
+	 */
+	private void checkRight( BoxExpression right ) {
+		// Check the right hand side is a valid access method and fall through if it is not
+		switch ( right ) {
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxIdentifier ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxIntegerLiteral ignored -> {
+			}
+			case BoxMethodInvocation ignored -> {
+			}
+			case BoxNull ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxExpressionInvocation ignored -> {
+			}
+			default ->
+			    errorListener.semanticError( "dot access via " + right.getDescription() + " is not a valid access method", right.getPosition() );
+		}
+	}
+
+	/**
+	 * Check the left hand side of a dot access to ensure it is a valid construct for dot access
+	 *
+	 * @param left the left side of the dot access left.right
+	 */
+	private void checkLeft( BoxExpression left ) {
+		// Check the left hand side is a valid construct for dot access and fall through if it is not
+		switch ( left ) {
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxArrayAccess ignored -> {
+			}
+			case BoxIdentifier ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxStringLiteral ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxArrayLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxMethodInvocation ignored -> {
+			}
+			case BoxStructLiteral ignored -> {
+			}
+			case BoxNew ignored -> {
+			}
+			case BoxDecimalLiteral ignored -> {
+			}
+			case BoxParenthesis ignored -> {
+				// TODO: Brad - Should we allow this always, or check what is inside the parenthesis?
+			}
+			default ->
+			    errorListener.semanticError( left.getDescription() + " is not a valid construct for dot access", left.getPosition() );
+		}
+	}
+
+	/**
+	 * Check array access to ensure that nonsensical access methods are rejected at AST build time
+	 *
+	 * @param ctx    the Parsers ExprArrayAccessContext for source reference etc
+	 * @param object the object node that is being accessed as if it were an array
+	 * @param access the access node that is being used to access the object
+	 */
+	public void checkArrayAccess( CFScriptGrammar.ExprArrayAccessContext ctx, BoxExpression object, @SuppressWarnings( "unused" ) BoxExpression access ) {
+
+		switch ( object ) {
+			case BoxIdentifier ignored -> {
+			}
+			case BoxArrayAccess ignored -> {
+			}
+			case BoxDotAccess ignored -> {
+			}
+			case BoxStringLiteral ignored -> {
+			}
+			case BoxArrayLiteral ignored -> {
+			}
+			case BoxFunctionInvocation ignored -> {
+			}
+			case BoxNew ignored -> {
+			}
+			case BoxDecimalLiteral ignored -> {
+			}
+			case BoxBooleanLiteral ignored -> {
+			}
+			case BoxNull ignored -> {
+			}
+			case BoxStructLiteral ignored -> {
+			}
+			case BoxScope ignored -> {
+			}
+			case BoxIntegerLiteral ignored -> {
+			}
+			case BoxParenthesis ignored -> {
+				// TODO: Brad - Should we allow this always, or check what is inside the parenthesis?
+			}
+			default ->
+			    errorListener.semanticError( object.getDescription() + " is not a valid construct for array access ", getPosition( ctx ) );
+		}
+	}
+
+	public void reportExpressionError( BoxExpression expression ) {
+		errorListener.semanticError( "Invalid expression error: " + expression.getSourceText(), expression.getPosition() );
+	}
+
+	public void reportStatementError( BoxStatement statement ) {
+		errorListener.semanticError( "Invalid statement error: " + statement.getSourceText(), statement.getPosition() );
+	}
+
+	public void reportError( String message, Position position ) {
+		errorListener.semanticError( message, position );
+	}
 }

--- a/src/main/java/ortus/boxlang/compiler/parser/CFTemplateParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFTemplateParser.java
@@ -14,6 +14,26 @@
  */
 package ortus.boxlang.compiler.parser;
 
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import ortus.boxlang.compiler.ast.*;
+import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
+import ortus.boxlang.compiler.ast.expression.*;
+import ortus.boxlang.compiler.ast.statement.*;
+import ortus.boxlang.compiler.ast.statement.component.BoxComponent;
+import ortus.boxlang.compiler.ast.visitor.CFTranspilerVisitor;
+import ortus.boxlang.parser.antlr.CFTemplateGrammar;
+import ortus.boxlang.parser.antlr.CFTemplateGrammar.*;
+import ortus.boxlang.parser.antlr.CFTemplateLexer;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.components.ComponentDescriptor;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
+import ortus.boxlang.runtime.services.ComponentService;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,96 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BOMInputStream;
-
-import ortus.boxlang.compiler.ast.BoxClass;
-import ortus.boxlang.compiler.ast.BoxExpression;
-import ortus.boxlang.compiler.ast.BoxInterface;
-import ortus.boxlang.compiler.ast.BoxNode;
-import ortus.boxlang.compiler.ast.BoxScript;
-import ortus.boxlang.compiler.ast.BoxStatement;
-import ortus.boxlang.compiler.ast.BoxTemplate;
-import ortus.boxlang.compiler.ast.Issue;
-import ortus.boxlang.compiler.ast.Point;
-import ortus.boxlang.compiler.ast.Position;
-import ortus.boxlang.compiler.ast.Source;
-import ortus.boxlang.compiler.ast.SourceCode;
-import ortus.boxlang.compiler.ast.SourceFile;
-import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
-import ortus.boxlang.compiler.ast.expression.BoxClosure;
-import ortus.boxlang.compiler.ast.expression.BoxFQN;
-import ortus.boxlang.compiler.ast.expression.BoxIdentifier;
-import ortus.boxlang.compiler.ast.expression.BoxNull;
-import ortus.boxlang.compiler.ast.expression.BoxStringInterpolation;
-import ortus.boxlang.compiler.ast.expression.BoxStringLiteral;
-import ortus.boxlang.compiler.ast.statement.BoxAccessModifier;
-import ortus.boxlang.compiler.ast.statement.BoxAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxArgumentDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxBreak;
-import ortus.boxlang.compiler.ast.statement.BoxBufferOutput;
-import ortus.boxlang.compiler.ast.statement.BoxContinue;
-import ortus.boxlang.compiler.ast.statement.BoxDocumentationAnnotation;
-import ortus.boxlang.compiler.ast.statement.BoxExpressionStatement;
-import ortus.boxlang.compiler.ast.statement.BoxFunctionDeclaration;
-import ortus.boxlang.compiler.ast.statement.BoxIfElse;
-import ortus.boxlang.compiler.ast.statement.BoxImport;
-import ortus.boxlang.compiler.ast.statement.BoxMethodDeclarationModifier;
-import ortus.boxlang.compiler.ast.statement.BoxProperty;
-import ortus.boxlang.compiler.ast.statement.BoxRethrow;
-import ortus.boxlang.compiler.ast.statement.BoxReturn;
-import ortus.boxlang.compiler.ast.statement.BoxReturnType;
-import ortus.boxlang.compiler.ast.statement.BoxScriptIsland;
-import ortus.boxlang.compiler.ast.statement.BoxStatementBlock;
-import ortus.boxlang.compiler.ast.statement.BoxSwitch;
-import ortus.boxlang.compiler.ast.statement.BoxSwitchCase;
-import ortus.boxlang.compiler.ast.statement.BoxTry;
-import ortus.boxlang.compiler.ast.statement.BoxTryCatch;
-import ortus.boxlang.compiler.ast.statement.BoxType;
-import ortus.boxlang.compiler.ast.statement.BoxWhile;
-import ortus.boxlang.compiler.ast.statement.component.BoxComponent;
-import ortus.boxlang.compiler.ast.visitor.CFTranspilerVisitor;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ArgumentContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.AttributeContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.AttributeValueContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.BoxImportContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.BreakContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.CaseContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.CatchBlockContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ClassOrInterfaceContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ComponentContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ContinueContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.FunctionContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.GenericOpenCloseComponentContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.GenericOpenComponentContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.IncludeContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.InterfaceContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.InterpolatedExpressionContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.OutputContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.PropertyContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.RethrowContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ReturnContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ScriptContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.SetContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.StatementContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.StatementsContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.SwitchContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.TemplateContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.TextContentContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.ThrowContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.TryContext;
-import ortus.boxlang.parser.antlr.CFTemplateGrammar.WhileContext;
-import ortus.boxlang.parser.antlr.CFTemplateLexer;
-import ortus.boxlang.runtime.BoxRuntime;
-import ortus.boxlang.runtime.components.ComponentDescriptor;
-import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
-import ortus.boxlang.runtime.services.ComponentService;
 
 public class CFTemplateParser extends AbstractParser {
 
@@ -965,13 +895,13 @@ public class CFTemplateParser extends AbstractParser {
 
 	/**
 	 * Escape double up quotes and pounds in a string literal
-	 * 
+	 *
 	 * @param quoteChar the quote character used to surround the string
 	 * @param string    the string to escape
-	 * 
+	 *
 	 * @return the escaped string
 	 */
-	private String escapeStringLiteral( String quoteChar, String string ) {
+	public String escapeStringLiteral( String quoteChar, String string ) {
 		String escaped = string.replace( "##", "#" );
 		return escaped.replace( quoteChar + quoteChar, quoteChar );
 	}
@@ -1049,16 +979,16 @@ public class CFTemplateParser extends AbstractParser {
 
 	/**
 	 * A helper function to find a specific annotation by name and return the value expression
-	 * 
+	 *
 	 * @param annotations             the list of annotations to search
 	 * @param name                    the name of the annotation to find
 	 * @param required                whether the annotation is required. If required, and not present a parsing Issue is created.
 	 * @param defaultValue            the default value to return if the annotation is not found. Ignored if requried is false.
 	 * @param containingComponentName the name of the component that contains the annotation, used in error handling
 	 * @param position                the position of the component, used in error handling
-	 * 
+	 *
 	 * @return the value expression of the annotation, or the default value if the annotation is not found
-	 * 
+	 *
 	 */
 	private BoxExpression findExprInAnnotations( List<BoxAnnotation> annotations, String name, boolean required, BoxExpression defaultValue,
 	    String containingComponentName,
@@ -1078,11 +1008,11 @@ public class CFTemplateParser extends AbstractParser {
 	/**
 	 * A helper function to take a BoxExpr and return the value expression as a string.
 	 * If the expression is not a string literal, an Issue is created.
-	 * 
+	 *
 	 * @param expr       the expression to get the value from
 	 * @param name       the name of the attribute, used in error handling
 	 * @param allowEmpty whether an empty string is allowed. If not allowed, an Issue is created.
-	 * 
+	 *
 	 * @return the value of the expression as a string, or null if the expression is null
 	 */
 	private String getBoxExprAsString( BoxExpression expr, String name, boolean allowEmpty ) {
@@ -1247,6 +1177,7 @@ public class CFTemplateParser extends AbstractParser {
 			return this;
 		}
 		this.sourceToParse = source;
+		this.errorListener.setSource( sourceToParse );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/parser/DocParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/DocParser.java
@@ -195,6 +195,7 @@ public class DocParser extends AbstractParser {
 			return this;
 		}
 		this.sourceToParse = source;
+		this.errorListener.setSource( this.sourceToParse );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/parser/Parser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/Parser.java
@@ -154,7 +154,7 @@ public class Parser {
 	 *
 	 * @return a ParsingResult containing the AST with a BoxStatement as root and the list of errors (if any)
 	 *
-	 * 
+	 *
 	 * @see ParsingResult
 	 * @see BoxStatement
 	 */

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -17,27 +17,9 @@
  */
 package ortus.boxlang.runtime;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import ortus.boxlang.compiler.ClassInfo;
 import ortus.boxlang.compiler.IBoxpiler;
 import ortus.boxlang.compiler.asmboxpiler.ASMBoxpiler;
@@ -58,22 +40,9 @@ import ortus.boxlang.runtime.interceptors.Logging;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.logging.LoggingConfigurator;
-import ortus.boxlang.runtime.runnables.BoxScript;
-import ortus.boxlang.runtime.runnables.BoxTemplate;
-import ortus.boxlang.runtime.runnables.IBoxRunnable;
-import ortus.boxlang.runtime.runnables.IClassRunnable;
-import ortus.boxlang.runtime.runnables.RunnableLoader;
+import ortus.boxlang.runtime.runnables.*;
 import ortus.boxlang.runtime.scopes.Key;
-import ortus.boxlang.runtime.services.ApplicationService;
-import ortus.boxlang.runtime.services.AsyncService;
-import ortus.boxlang.runtime.services.CacheService;
-import ortus.boxlang.runtime.services.ComponentService;
-import ortus.boxlang.runtime.services.DatasourceService;
-import ortus.boxlang.runtime.services.FunctionService;
-import ortus.boxlang.runtime.services.IService;
-import ortus.boxlang.runtime.services.InterceptorService;
-import ortus.boxlang.runtime.services.ModuleService;
-import ortus.boxlang.runtime.services.SchedulerService;
+import ortus.boxlang.runtime.services.*;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
@@ -84,6 +53,23 @@ import ortus.boxlang.runtime.types.util.MathUtil;
 import ortus.boxlang.runtime.util.EncryptionUtil;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 import ortus.boxlang.runtime.util.Timer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Represents the top level runtime container for box lang. Config, global scopes, mappings, threadpools, etc all go here.

--- a/src/main/java/ortus/boxlang/runtime/interceptors/ASTCapture.java
+++ b/src/main/java/ortus/boxlang/runtime/interceptors/ASTCapture.java
@@ -1,14 +1,14 @@
 /**
  * [BoxLang]
- *
+ * <p>
  * Copyright [2023] [Ortus Solutions, Corp]
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,26 +17,23 @@
  */
 package ortus.boxlang.runtime.interceptors;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-
 import ortus.boxlang.compiler.parser.ParsingResult;
 import ortus.boxlang.runtime.events.BaseInterceptor;
 import ortus.boxlang.runtime.events.InterceptionPoint;
 import ortus.boxlang.runtime.types.IStruct;
+
+import java.io.IOException;
+import java.nio.file.*;
 
 /**
  * An interceptor that captures the AST and outputs it to the console or a file
  */
 public class ASTCapture extends BaseInterceptor {
 
-	private boolean	toConsole	= false;
-	private boolean	toFile		= false;
+	private boolean		toConsole	= false;
+	private boolean		toFile		= false;
 	// Default to current working directory
-	private Path	filePath	= Paths.get( "./grapher/data/" );
+	private final Path	filePath	= Paths.get( "./grapher/data/" );
 
 	/**
 	 * Constructor
@@ -65,16 +62,19 @@ public class ASTCapture extends BaseInterceptor {
 			}
 
 			if ( this.toFile ) {
-				Path file = Paths.get( filePath.toString(), "lastAST.json" );
-
-				// Ensure path exists
+				Path file = filePath.resolve( "lastAST.json" );
 				try {
+					// Ensure path exists
 					Files.createDirectories( file.getParent() );
-				} catch ( IOException e ) {
-					e.printStackTrace();
-				}
 
-				try {
+					// Backup the existing file if it exists. This means we get to see both the
+					// tree for the original script, and the tree for the second pass into a class.
+					if ( Files.exists( file ) ) {
+						Path backupFile = filePath.resolve( "prevAST.json" );
+						Files.copy( file, backupFile, StandardCopyOption.REPLACE_EXISTING );
+					}
+
+					// Write the JSON string to the new file
 					Files.writeString( file, JSON, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING );
 				} catch ( IOException e ) {
 					e.printStackTrace();

--- a/src/test/java/TestCases/asm/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/asm/phase1/CoreLangTest.java
@@ -17,21 +17,7 @@
  */
 package TestCases.asm.phase1;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.DocParser;
 import ortus.boxlang.compiler.parser.ParsingResult;
@@ -50,6 +36,13 @@ import ortus.boxlang.runtime.types.SampleUDF;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.NoFieldException;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CoreLangTest {
 
@@ -1036,14 +1029,14 @@ public class CoreLangTest {
 		    foo = "unfinished
 		     """,
 		    context ) );
-		assertThat( t.getMessage() ).contains( "Untermimated" );
+		assertThat( t.getMessage() ).contains( "Unterminated" );
 
 		t = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
 		    """
 		    foo = 'unfinished
 		     """,
 		    context ) );
-		assertThat( t.getMessage() ).contains( "Untermimated" );
+		assertThat( t.getMessage() ).contains( "Unterminated" );
 	}
 
 	@DisplayName( "It should throw BoxRuntimeException" )
@@ -1082,7 +1075,7 @@ public class CoreLangTest {
 		    context
 		)
 		);
-		assertThat( t.getMessage() ).contains( "Untermimated hash" );
+		assertThat( t.getMessage() ).contains( "Unterminated hash" );
 
 	}
 

--- a/src/test/java/TestCases/components/BoxTemplateTest.java
+++ b/src/test/java/TestCases/components/BoxTemplateTest.java
@@ -17,16 +17,7 @@
  */
 package TestCases.components;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -37,11 +28,10 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.Array;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
-import ortus.boxlang.runtime.types.exceptions.CustomException;
-import ortus.boxlang.runtime.types.exceptions.ExpressionException;
-import ortus.boxlang.runtime.types.exceptions.MissingIncludeException;
-import ortus.boxlang.runtime.types.exceptions.ParseException;
+import ortus.boxlang.runtime.types.exceptions.*;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BoxTemplateTest {
 

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -17,22 +17,7 @@
  */
 package TestCases.phase1;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Comparator;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.DocParser;
 import ortus.boxlang.compiler.parser.ParsingResult;
@@ -44,14 +29,25 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.LocalScope;
 import ortus.boxlang.runtime.scopes.VariablesScope;
-import ortus.boxlang.runtime.types.Argument;
-import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.*;
 import ortus.boxlang.runtime.types.Function.Access;
-import ortus.boxlang.runtime.types.IStruct;
-import ortus.boxlang.runtime.types.SampleUDF;
-import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.NoFieldException;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CoreLangTest {
 
@@ -354,7 +350,7 @@ public class CoreLangTest {
 
 	}
 
-	@DisplayName( "try multiple catche types" )
+	@DisplayName( "try multiple catch types" )
 	@Test
 	public void testTryMultipleCatchTypes() {
 
@@ -589,6 +585,44 @@ public class CoreLangTest {
 		         """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( 11 );
+
+	}
+
+	@DisplayName( "var sentinel" )
+	@Test
+	public void testVarSentinel() {
+
+		instance.executeSource(
+		    """
+		    result=0
+		    function runner() {
+		    	i=0
+		    	for( var i=0; i<10; i++ ) {
+		    		result+=1
+		    	}
+		    }
+		    runner()
+		    	  """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( 10 );
+
+	}
+
+	@DisplayName( "var assignment as expression" )
+	@Test
+	public void testVarAssignAsExpr() {
+
+		instance.executeSource(
+		    """
+		    function runner( arg ) {
+		    	return arg;
+		    }
+		    result = runner( (var brad = 5) )
+		    result2 = runner( arg=(var brad = 5) )
+		    	  """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( 5 );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( 5 );
 
 	}
 
@@ -1024,14 +1058,14 @@ public class CoreLangTest {
 		    foo = "unfinished
 		     """,
 		    context ) );
-		assertThat( t.getMessage() ).contains( "Untermimated" );
+		assertThat( t.getMessage() ).contains( "Unterminated" );
 
 		t = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
 		    """
 		    foo = 'unfinished
 		     """,
 		    context ) );
-		assertThat( t.getMessage() ).contains( "Untermimated" );
+		assertThat( t.getMessage() ).contains( "Unterminated" );
 	}
 
 	@DisplayName( "It should throw BoxRuntimeException" )
@@ -1068,7 +1102,7 @@ public class CoreLangTest {
 		    result = "I have locker #20";
 		    	""",
 		    context ) );
-		assertThat( t.getMessage() ).contains( "Untermimated hash" );
+		assertThat( t.getMessage() ).contains( "Unterminated hash" );
 
 	}
 
@@ -2813,6 +2847,32 @@ public class CoreLangTest {
 		assertThat( variables.get( Key.of( "type" ) ) ).isEqualTo( "java.math.BigDecimal" );
 		assertThat( variables.get( result ) ).isInstanceOf( Double.class );
 		assertThat( variables.get( result ) ).isEqualTo( 2 );
+	}
+
+	@Test
+	public void testArrayAccessOnMethod() {
+
+		instance.executeSource(
+		    """
+		    function getData() {
+		    	return [ "brad", "luis", "jon" ];
+		    }
+		    result = variables.getData()[ 2 ];
+		    	 """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "luis" );
+	}
+
+	@Test
+	public void testVariableNamedVar() {
+
+		instance.executeSource(
+		    """
+		    foo.var= "bar";
+		    result = foo.var.toString();
+		    	 """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "bar" );
 	}
 
 	@Test

--- a/src/test/java/TestCases/phase1/ExpressionValidAccessTest.java
+++ b/src/test/java/TestCases/phase1/ExpressionValidAccessTest.java
@@ -17,17 +17,10 @@
  */
 package TestCases.phase1;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.expression.BoxArrayAccess;
 import ortus.boxlang.compiler.ast.expression.BoxDecimalLiteral;
@@ -36,6 +29,12 @@ import ortus.boxlang.compiler.ast.expression.BoxMethodInvocation;
 import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
 import ortus.boxlang.runtime.BoxRuntime;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ExpressionValidAccessTest {
 
@@ -273,10 +272,10 @@ public class ExpressionValidAccessTest {
 
 	/**
 	 * Verify foo.bar is a BoxDotAccess and foo.bar() is a BoxMethodInvocation
-	 * 
+	 *
 	 * @param expression parsed expression
 	 * @param node       parsed node
-	 * 
+	 *
 	 * @return true if the node is correct
 	 */
 	private boolean isCorrectNode( String expression, BoxNode node ) {
@@ -322,10 +321,10 @@ public class ExpressionValidAccessTest {
 
 	/**
 	 * Verify foo[ bar ] is a BoxArrayAccess
-	 * 
+	 *
 	 * @param expression parsed expression
 	 * @param node       parsed node
-	 * 
+	 *
 	 * @return true if the node is correct
 	 */
 	private boolean isCorrectNodeArray( String expression, BoxNode node ) {
@@ -334,9 +333,9 @@ public class ExpressionValidAccessTest {
 
 	/**
 	 * Generate error detail
-	 * 
+	 *
 	 * @param result parsing result
-	 * 
+	 *
 	 * @return error detail
 	 */
 	private String generateErrorDetail( ParsingResult result ) {

--- a/src/test/java/TestCases/phase1/OperatorsTest.java
+++ b/src/test/java/TestCases/phase1/OperatorsTest.java
@@ -593,6 +593,23 @@ public class OperatorsTest {
 
 		result = instance.executeStatement( "!false", context );
 		assertThat( result ).isEqualTo( true );
+
+		/*
+		 * instance.executeSource( """
+		 * foo.bar = true;
+		 * result = !foo[ "bar" ];
+		 * """, context );
+		 * result = variables.get( resultKey );
+		 * assertThat( result ).isEqualTo( false );
+		 */
+
+		instance.executeSource( """
+		                        foo.bar.baz = ()->true;
+		                        result = !foo[ "bar" ].baz();
+		                        """, context );
+		result = variables.get( resultKey );
+		assertThat( result ).isEqualTo( false );
+
 	}
 
 	@DisplayName( "logical xor" )

--- a/src/test/java/TestCases/phase2/InvocationTest.java
+++ b/src/test/java/TestCases/phase2/InvocationTest.java
@@ -17,20 +17,15 @@
  */
 package TestCases.phase2;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class InvocationTest {
 
@@ -254,8 +249,8 @@ public class InvocationTest {
 		instance.executeSource(
 		    """
 		    structCount({})
-		      {}.len();
-		      """,
+		    {}.len();
+		    """,
 		    context );
 	}
 

--- a/src/test/java/TestCases/phase2/ObjectLiteralTest.java
+++ b/src/test/java/TestCases/phase2/ObjectLiteralTest.java
@@ -131,7 +131,7 @@ public class ObjectLiteralTest {
 
 	@Test
 	public void testfqnKey() {
-		// Workaround for Lucee compat. I'm not inclinded to support this in BL.
+		// Workaround for Lucee compat. I'm not inclined to support this in BL.
 		instance.executeSource(
 		    """
 		       result = {

--- a/src/test/java/ortus/boxlang/compiler/TestAST.java
+++ b/src/test/java/ortus/boxlang/compiler/TestAST.java
@@ -17,16 +17,15 @@
  */
 package ortus.boxlang.compiler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
-
 import ortus.boxlang.compiler.ast.expression.BoxBinaryOperation;
 import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestAST extends TestBase {
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/decision/IsNullTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/decision/IsNullTest.java
@@ -18,20 +18,15 @@
 
 package ortus.boxlang.runtime.bifs.global.decision;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class IsNullTest {
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/query/QueryClearTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/query/QueryClearTest.java
@@ -18,20 +18,15 @@
 
 package ortus.boxlang.runtime.bifs.global.query;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class QueryClearTest {
 
@@ -75,7 +70,7 @@ public class QueryClearTest {
 		assertThat( variables.get( result ) ).isEqualTo( 0 );
 	}
 
-	@DisplayName( "It should cler query using member function" )
+	@DisplayName( "It should clear query using member function" )
 	@Test
 	public void testQueryClearMemberFunction() {
 		instance.executeSource(

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructNewTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructNewTest.java
@@ -19,15 +19,7 @@
 
 package ortus.boxlang.runtime.bifs.global.struct;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
@@ -36,6 +28,9 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StructNewTest {
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetSystemSettingTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetSystemSettingTest.java
@@ -1,15 +1,6 @@
 package ortus.boxlang.runtime.bifs.global.system;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
@@ -17,6 +8,9 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class GetSystemSettingTest {
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/LockTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/LockTest.java
@@ -18,16 +18,7 @@
 
 package ortus.boxlang.runtime.bifs.global.system;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -36,6 +27,9 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.exceptions.LockException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class LockTest {
 

--- a/src/test/java/ortus/boxlang/runtime/components/jdbc/TransactionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/jdbc/TransactionTest.java
@@ -19,20 +19,16 @@
 
 package ortus.boxlang.runtime.components.jdbc;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import ortus.boxlang.runtime.bifs.global.jdbc.BaseJDBCTest;
 import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests the basics of the transaction component, especially attribute validation.

--- a/src/test/java/ortus/boxlang/runtime/components/system/ModuleTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/ModuleTest.java
@@ -18,14 +18,7 @@
 
 package ortus.boxlang.runtime.components.system;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.*;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -33,6 +26,8 @@ import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class ModuleTest {
 

--- a/src/test/java/ortus/boxlang/runtime/scripting/BoxScriptingEngineTest.java
+++ b/src/test/java/ortus/boxlang/runtime/scripting/BoxScriptingEngineTest.java
@@ -1,7 +1,13 @@
 package ortus.boxlang.runtime.scripting;
 
-import static com.google.common.truth.Truth.assertThat;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Array;
 
+import javax.script.*;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
@@ -10,19 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import javax.script.Bindings;
-import javax.script.CompiledScript;
-import javax.script.Invocable;
-import javax.script.ScriptException;
-import javax.script.SimpleBindings;
-
-import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import ortus.boxlang.runtime.scopes.Key;
-import ortus.boxlang.runtime.types.Array;
+import static com.google.common.truth.Truth.assertThat;
 
 public class BoxScriptingEngineTest {
 
@@ -140,7 +134,7 @@ public class BoxScriptingEngineTest {
 		Object result = engine
 		    .eval( """
 		           request.result = [1,2,3,4,5,6,7,8,9,10].filter( isEven )
-				  
+
 		           """, bindings );
 		// @formatter:on
 		assertThat( result ).isEqualTo( Array.of( 2, 4, 6, 8, 10 ) );


### PR DESCRIPTION


# Description

  - The ANTLR grammars are rewritten to use left recursion and be as context free as possible. With these languages, it is not possible to be completely context free.
  - The mix of hundreds ofd toAST() functions is replaced with true visitors to generate the AST
  - A new error strategy is provided for both parsers, which results in much cleaner and more accurate error messages. This is also a function of a cleaner, less ambiguous grammar.
  - A new error listener is provided, which generates human readable messages, which are much better at the command line, though IDE support may not use those messages if it has better ideas.
  - Dot access, array access are now checked semantically by the compiler, which results in cleaner error messages and avoids runtime exceptions where possible.
  - ALAW, MOT

## Jira Issues

I will let you fill this in Brad

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL/issues

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [x] Improvement
## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
