### PR TITLE
Fix for overeager escaping of quantifier sequences in REFind

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReFind.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReFind.java
@@ -244,39 +244,8 @@ public class ReFind extends BIF {
 	 * @return The escaped regular expression string
 	 */
 	public static String replaceNonQuantiferCurlyBraces( String input ) {
-		// String input = "Example regex with {{invalid}} and {valid{quantifiers}} like {2,4}";
-
-		// Regular expression to match valid quantifiers
-		String			quantifierRegex		= "\\{\\d*,?\\d*\\}";
-
-		// Pattern to match valid quantifiers
-		Pattern			quantifierPattern	= Pattern.compile( quantifierRegex );
-
-		// Matcher for the input string
-		Matcher			matcher				= quantifierPattern.matcher( input );
-
-		// Create a StringBuilder to build the final output
-		StringBuilder	escapedString		= new StringBuilder();
-
-		// Index to keep track of the position in the input string
-		int				lastIndex			= 0;
-
-		while ( matcher.find() ) {
-			// Append text between matches and the match itself
-			escapedString.append( input, lastIndex, matcher.start() );
-			escapedString.append( matcher.group() );
-
-			// Update lastIndex to the end of the current match
-			lastIndex = matcher.end();
-		}
-
-		// Append remaining text after the last match
-		escapedString.append( input.substring( lastIndex ) );
-
 		// Escape the remaining curly braces that are not part of valid quantifiers
-		String finalResult = escapedString.toString().replaceAll( "\\{", "\\\\{" ).replaceAll( "\\}", "\\\\}" );
-
-		return finalResult;
+		return input.toString().replaceAll( "\\{\\{", "\\\\{\\\\{" ).replaceAll( "\\}\\}", "\\\\}\\\\}" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/ReFindTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/ReFindTest.java
@@ -405,4 +405,26 @@ public class ReFindTest {
 		// @formatter:on
 	}
 
+	@DisplayName( "qb parse table name" )
+	@Test
+	public void testParseQBTableName() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			result = reFindNoCase(
+                "(.*?)(?:\\s(?:AS\\s){0,1})([^\\)]+)$",
+                "users people",
+                1,
+                true
+            );
+			""",
+		context );
+		// @formatter:on
+		assertThat( variables.get( result ) ).isEqualTo( Struct.of(
+		    "LEN", Array.of( 12, 5, 6 ),
+		    "MATCH", Array.of( "users people", "users", "people" ),
+		    "POS", Array.of( 1, 1, 7 )
+		) );
+	}
+
 }


### PR DESCRIPTION
Found in qb, the quantifier sequences are being escaped by the code that tries to escape PERL-like curly brace sequences.

This RegEx `(.*?)(?:\s(?:AS\s){0,1})([^\)]+)$` is having the curly braces escaped, despite being a valid quantifier sequence, and is then failing to match correctly.

The fix I did seems overly simplistic, but all tests are currently passing.  I'd love a closer look at it in case there are edge cases I'm missing.