### PR TITLE
Version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,9 @@ dependencies {
 	implementation 'org.ow2.asm:asm-tree:9.7.1'
 	// https://mvnrepository.com/artifact/org.ow2.asm/asm-util
 	implementation 'org.ow2.asm:asm-util:9.7.1'
+	// https://mvnrepository.com/artifact/org.semver4j/semver4j
+	implementation 'org.semver4j:semver4j:5.4.1'
+
 }
 
 /**

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta22] - 2024-11-15
+
 ## [1.0.0-beta21] - 2024-11-01
 
 ## [1.0.0-beta20] - 2024-10-25
@@ -55,7 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta1] - 2024-06-14
 
-[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta21...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta22...HEAD
+
+[1.0.0-beta22]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta21...v1.0.0-beta22
 
 [1.0.0-beta21]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0-beta20...v1.0.0-beta21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Fri Nov 01 20:41:48 UTC 2024
+#Fri Nov 15 22:11:50 UTC 2024
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.0.0-beta22
+version=1.0.0-beta23

--- a/src/main/antlr/SQLGrammar.g4
+++ b/src/main/antlr/SQLGrammar.g4
@@ -1,0 +1,858 @@
+// Based on MIT-licensed SQL Lite ANTLR4 grammar
+// https://github.com/antlr/grammars-v4/tree/master/sql/sqlite
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons ownLine
+
+parser grammar SQLGrammar;
+
+options {
+    tokenVocab = SQLLexer;
+}
+
+parse: (sql_stmt_list)* EOF
+;
+
+sql_stmt_list:
+    SCOL* sql_stmt (SCOL+ sql_stmt)* SCOL*
+;
+
+sql_stmt: (EXPLAIN_ (QUERY_ PLAN_)?)? (
+        alter_table_stmt
+        | analyze_stmt
+        | attach_stmt
+        | begin_stmt
+        | commit_stmt
+        | create_index_stmt
+        | create_table_stmt
+        | create_trigger_stmt
+        | create_view_stmt
+        | create_virtual_table_stmt
+        | delete_stmt
+        | delete_stmt_limited
+        | detach_stmt
+        | drop_stmt
+        | insert_stmt
+        | pragma_stmt
+        | reindex_stmt
+        | release_stmt
+        | rollback_stmt
+        | savepoint_stmt
+        | select_stmt
+        | update_stmt
+        | update_stmt_limited
+        | vacuum_stmt
+    )
+;
+
+alter_table_stmt:
+    ALTER_ TABLE_ (schema_name DOT)? table_name (
+        RENAME_ (
+            TO_ new_table_name = table_name
+            | COLUMN_? old_column_name = column_name TO_ new_column_name = column_name
+        )
+        | ADD_ COLUMN_? column_def
+        | DROP_ COLUMN_? column_name
+    )
+;
+
+analyze_stmt:
+    ANALYZE_ (schema_name | (schema_name DOT)? table_or_index_name)?
+;
+
+attach_stmt:
+    ATTACH_ DATABASE_? expr AS_ schema_name
+;
+
+begin_stmt:
+    BEGIN_ (DEFERRED_ | IMMEDIATE_ | EXCLUSIVE_)? (TRANSACTION_ transaction_name?)?
+;
+
+commit_stmt: (COMMIT_ | END_) TRANSACTION_?
+;
+
+rollback_stmt:
+    ROLLBACK_ TRANSACTION_? (TO_ SAVEPOINT_? savepoint_name)?
+;
+
+savepoint_stmt:
+    SAVEPOINT_ savepoint_name
+;
+
+release_stmt:
+    RELEASE_ SAVEPOINT_? savepoint_name
+;
+
+create_index_stmt:
+    CREATE_ UNIQUE_? INDEX_ (IF_ NOT_ EXISTS_)? (schema_name DOT)? index_name ON_ table_name OPEN_PAR indexed_column (
+        COMMA indexed_column
+    )* CLOSE_PAR (WHERE_ expr)?
+;
+
+indexed_column: (column_name | expr) (COLLATE_ collation_name)? asc_desc?
+;
+
+create_table_stmt:
+    CREATE_ (TEMP_ | TEMPORARY_)? TABLE_ (IF_ NOT_ EXISTS_)? (schema_name DOT)? table_name (
+        OPEN_PAR column_def (COMMA column_def)*? (COMMA table_constraint)* CLOSE_PAR (
+            WITHOUT_ row_ROW_ID = IDENTIFIER
+        )?
+        | AS_ select_stmt
+    )
+;
+
+column_def:
+    column_name type_name? column_constraint*
+;
+
+type_name:
+    name+? (
+        OPEN_PAR signed_number CLOSE_PAR
+        | OPEN_PAR signed_number COMMA signed_number CLOSE_PAR
+    )?
+;
+
+column_constraint: (CONSTRAINT_ name)? (
+        (PRIMARY_ KEY_ asc_desc? conflict_clause? AUTOINCREMENT_?)
+        | (NOT_? NULL_ | UNIQUE_) conflict_clause?
+        | CHECK_ OPEN_PAR expr CLOSE_PAR
+        | DEFAULT_ (signed_number | literal_value | OPEN_PAR expr CLOSE_PAR)
+        | COLLATE_ collation_name
+        | foreign_key_clause
+        | (GENERATED_ ALWAYS_)? AS_ OPEN_PAR expr CLOSE_PAR (STORED_ | VIRTUAL_)?
+    )
+;
+
+signed_number: (PLUS | MINUS)? NUMERIC_LITERAL
+;
+
+table_constraint: (CONSTRAINT_ name)? (
+        (PRIMARY_ KEY_ | UNIQUE_) OPEN_PAR indexed_column (COMMA indexed_column)* CLOSE_PAR conflict_clause?
+        | CHECK_ OPEN_PAR expr CLOSE_PAR
+        | FOREIGN_ KEY_ OPEN_PAR column_name (COMMA column_name)* CLOSE_PAR foreign_key_clause
+    )
+;
+
+foreign_key_clause:
+    REFERENCES_ foreign_table (OPEN_PAR column_name (COMMA column_name)* CLOSE_PAR)? (
+        ON_ (DELETE_ | UPDATE_) (
+            SET_ (NULL_ | DEFAULT_)
+            | CASCADE_
+            | RESTRICT_
+            | NO_ ACTION_
+        )
+        | MATCH_ name
+    )* (NOT_? DEFERRABLE_ (INITIALLY_ (DEFERRED_ | IMMEDIATE_))?)?
+;
+
+conflict_clause:
+    ON_ CONFLICT_ (ROLLBACK_ | ABORT_ | FAIL_ | IGNORE_ | REPLACE_)
+;
+
+create_trigger_stmt:
+    CREATE_ (TEMP_ | TEMPORARY_)? TRIGGER_ (IF_ NOT_ EXISTS_)? (schema_name DOT)? trigger_name (
+        BEFORE_
+        | AFTER_
+        | INSTEAD_ OF_
+    )? (DELETE_ | INSERT_ | UPDATE_ (OF_ column_name ( COMMA column_name)*)?) ON_ table_name (
+        FOR_ EACH_ ROW_
+    )? (WHEN_ expr)? BEGIN_ (
+        (update_stmt | insert_stmt | delete_stmt | select_stmt) SCOL
+    )+ END_
+;
+
+create_view_stmt:
+    CREATE_ (TEMP_ | TEMPORARY_)? VIEW_ (IF_ NOT_ EXISTS_)? (schema_name DOT)? view_name (
+        OPEN_PAR column_name (COMMA column_name)* CLOSE_PAR
+    )? AS_ select_stmt
+;
+
+create_virtual_table_stmt:
+    CREATE_ VIRTUAL_ TABLE_ (IF_ NOT_ EXISTS_)? (schema_name DOT)? table_name USING_ module_name (
+        OPEN_PAR module_argument (COMMA module_argument)* CLOSE_PAR
+    )?
+;
+
+with_clause:
+    WITH_ RECURSIVE_? cte_table_name AS_ OPEN_PAR select_stmt CLOSE_PAR (
+        COMMA cte_table_name AS_ OPEN_PAR select_stmt CLOSE_PAR
+    )*
+;
+
+cte_table_name:
+    table_name (OPEN_PAR column_name ( COMMA column_name)* CLOSE_PAR)?
+;
+
+recursive_cte:
+    cte_table_name AS_ OPEN_PAR initial_select UNION_ ALL_? recursive_select CLOSE_PAR
+;
+
+common_table_expression:
+    table_name (OPEN_PAR column_name ( COMMA column_name)* CLOSE_PAR)? AS_ OPEN_PAR select_stmt CLOSE_PAR
+;
+
+delete_stmt:
+    with_clause? DELETE_ FROM_ qualified_table_name (WHERE_ expr)? returning_clause?
+;
+
+delete_stmt_limited:
+    with_clause? DELETE_ FROM_ qualified_table_name (WHERE_ expr)? returning_clause? (
+        order_by_stmt? limit_stmt
+    )?
+;
+
+detach_stmt:
+    DETACH_ DATABASE_? schema_name
+;
+
+drop_stmt:
+    DROP_ object = (INDEX_ | TABLE_ | TRIGGER_ | VIEW_) (IF_ EXISTS_)? (
+        schema_name DOT
+    )? any_name
+;
+
+/*
+ SQLite understands the following binary operators, in order from highest to lowest precedence:
+    ||
+    * / %
+    + -
+    << >> & |
+    < <= > >=
+    = == != <> IS IS NOT IS DISTINCT FROM IS NOT DISTINCT FROM IN LIKE GLOB MATCH REGEXP
+    AND
+    OR
+ */
+expr:
+    literal_value
+    | BIND_PARAMETER
+    //| ((schema_name DOT)? table_name DOT)? column_name
+    | (table_name DOT)? column_name
+    | unary_operator expr
+    | expr PIPE2 expr
+    | expr ( STAR | DIV | MOD) expr
+    | expr ( PLUS | MINUS) expr
+    | expr ( LT2 | GT2 | AMP | PIPE) expr
+    | expr ( LT | LT_EQ | GT | GT_EQ) expr
+    | expr (
+        ASSIGN
+        | EQ
+        | NOT_EQ1
+        | NOT_EQ2
+        | IS_
+        | IS_ NOT_
+        // | IS_ NOT_? DISTINCT_ FROM_
+        // | IN_
+        | LIKE_
+        // | GLOB_
+        //  | MATCH_
+        // | REGEXP_
+    ) expr
+    | expr AND_ expr
+    | expr OR_ expr
+    | function_name OPEN_PAR ((DISTINCT_? expr ( COMMA expr)*) | STAR)? CLOSE_PAR // filter_clause? over_clause?
+    | OPEN_PAR expr CLOSE_PAR
+    //| OPEN_PAR expr (COMMA expr)* CLOSE_PAR
+    // | CAST_ OPEN_PAR expr AS_ type_name CLOSE_PAR
+    // | expr COLLATE_ collation_name
+    | expr NOT_? (LIKE_ | GLOB_ | REGEXP_ | MATCH_) expr (ESCAPE_ expr)?
+    | expr ( ISNULL_ | NOTNULL_ | NOT_ NULL_)
+    | expr IS_ NOT_? expr
+    | expr NOT_? BETWEEN_ expr AND_ expr
+    | expr NOT_? IN_ (
+        // OPEN_PAR (select_stmt | expr ( COMMA expr)*)? CLOSE_PAR
+        OPEN_PAR (expr ( COMMA expr)*)? CLOSE_PAR
+        // | ( schema_name DOT)? table_name
+        // | (schema_name DOT)? table_function_name OPEN_PAR (expr (COMMA expr)*)? CLOSE_PAR
+    )
+    //  | ((NOT_)? EXISTS_)? OPEN_PAR select_stmt CLOSE_PAR
+    //  | CASE_ expr? (WHEN_ expr THEN_ expr)+ (ELSE_ expr)? END_
+    // | raise_function
+;
+
+raise_function:
+    RAISE_ OPEN_PAR (IGNORE_ | (ROLLBACK_ | ABORT_ | FAIL_) COMMA error_message) CLOSE_PAR
+;
+
+literal_value:
+    NUMERIC_LITERAL
+    | STRING_LITERAL
+    //  | BLOB_LITERAL
+    | NULL_
+    | TRUE_
+    | FALSE_
+    //   | CURRENT_TIME_
+    //   | CURRENT_DATE_
+    //    | CURRENT_TIMESTAMP_
+;
+
+value_row:
+    OPEN_PAR expr (COMMA expr)* CLOSE_PAR
+;
+
+values_clause:
+    VALUES_ value_row (COMMA value_row)*
+;
+
+insert_stmt:
+    with_clause? (
+        INSERT_
+        | REPLACE_
+        | INSERT_ OR_ ( REPLACE_ | ROLLBACK_ | ABORT_ | FAIL_ | IGNORE_)
+    ) INTO_ (schema_name DOT)? table_name (AS_ table_alias)? (
+        OPEN_PAR column_name ( COMMA column_name)* CLOSE_PAR
+    )? (( ( values_clause | select_stmt) upsert_clause?) | DEFAULT_ VALUES_) returning_clause?
+;
+
+returning_clause:
+    RETURNING_ result_column (COMMA result_column)*
+;
+
+upsert_clause:
+    ON_ CONFLICT_ (
+        OPEN_PAR indexed_column (COMMA indexed_column)* CLOSE_PAR (WHERE_ expr)?
+    )? DO_ (
+        NOTHING_
+        | UPDATE_ SET_ (
+            (column_name | column_name_list) ASSIGN expr (
+                COMMA (column_name | column_name_list) ASSIGN expr
+            )* (WHERE_ expr)?
+        )
+    )
+;
+
+pragma_stmt:
+    PRAGMA_ (schema_name DOT)? pragma_name (
+        ASSIGN pragma_value
+        | OPEN_PAR pragma_value CLOSE_PAR
+    )?
+;
+
+pragma_value:
+    signed_number
+    | name
+    | STRING_LITERAL
+;
+
+reindex_stmt:
+    REINDEX_ (collation_name | (schema_name DOT)? (table_name | index_name))?
+;
+
+//select_stmt:    common_table_stmt? select_core (compound_operator select_core)* order_by_stmt? limit_stmt?;
+
+select_stmt:
+    select_core (UNION_ ALL_? select_core)* order_by_stmt? limit_stmt?
+;
+
+join_clause:
+    table (join_operator table join_constraint?)*
+;
+
+select_core: (
+        SELECT_ (DISTINCT_ /*| ALL_*/)? result_column (COMMA result_column)* (
+            FROM_ (table (COMMA table)* | join_clause)
+        )? (WHERE_ whereExpr = expr)? (
+            GROUP_ BY_ groupByExpr += expr (COMMA groupByExpr += expr)* (
+                HAVING_ havingExpr = expr
+            )?
+        )? //(WINDOW_ window_name AS_ window_defn ( COMMA window_name AS_ window_defn)*)?
+    )
+    // | values_clause
+;
+
+factored_select_stmt:
+    select_stmt
+;
+
+simple_select_stmt:
+    common_table_stmt? select_core order_by_stmt? limit_stmt?
+;
+
+compound_select_stmt:
+    common_table_stmt? select_core (
+        (UNION_ ALL_? | INTERSECT_ | EXCEPT_) select_core
+    )+ order_by_stmt? limit_stmt?
+;
+
+table:
+    (schema_name DOT)? table_name (AS_? table_alias)?
+;
+
+table_or_subquery: (
+        (schema_name DOT)? table_name (AS_? table_alias)? (
+            INDEXED_ BY_ index_name
+            | NOT_ INDEXED_
+        )?
+    )
+    | (schema_name DOT)? table_function_name OPEN_PAR expr (COMMA expr)* CLOSE_PAR (
+        AS_? table_alias
+    )?
+    | OPEN_PAR (table_or_subquery (COMMA table_or_subquery)* | join_clause) CLOSE_PAR
+    | OPEN_PAR select_stmt CLOSE_PAR (AS_? table_alias)?
+;
+
+result_column:
+    STAR
+    | table_name DOT STAR
+    | expr ( AS_? column_alias)?
+;
+
+join_operator:
+    // COMMA
+    //  | NATURAL_? ((LEFT_ | RIGHT_ | FULL_) OUTER_? | INNER_ | CROSS_)? JOIN_
+    (INNER_)? JOIN_
+;
+
+join_constraint:
+    ON_ expr
+    //  | USING_ OPEN_PAR column_name ( COMMA column_name)* CLOSE_PAR
+;
+
+compound_operator:
+    UNION_ ALL_?
+    | INTERSECT_
+    | EXCEPT_
+;
+
+update_stmt:
+    with_clause? UPDATE_ (OR_ (ROLLBACK_ | ABORT_ | REPLACE_ | FAIL_ | IGNORE_))? qualified_table_name SET_ (
+        column_name
+        | column_name_list
+    ) ASSIGN expr (COMMA (column_name | column_name_list) ASSIGN expr)* (
+        FROM_ (table_or_subquery (COMMA table_or_subquery)* | join_clause)
+    )? (WHERE_ expr)? returning_clause?
+;
+
+column_name_list:
+    OPEN_PAR column_name (COMMA column_name)* CLOSE_PAR
+;
+
+update_stmt_limited:
+    with_clause? UPDATE_ (OR_ (ROLLBACK_ | ABORT_ | REPLACE_ | FAIL_ | IGNORE_))? qualified_table_name SET_ (
+        column_name
+        | column_name_list
+    ) ASSIGN expr (COMMA (column_name | column_name_list) ASSIGN expr)* (WHERE_ expr)? returning_clause? (
+        order_by_stmt? limit_stmt
+    )?
+;
+
+qualified_table_name: (schema_name DOT)? table_name (AS_ alias)? (
+        INDEXED_ BY_ index_name
+        | NOT_ INDEXED_
+    )?
+;
+
+vacuum_stmt:
+    VACUUM_ schema_name? (INTO_ filename)?
+;
+
+filter_clause:
+    FILTER_ OPEN_PAR WHERE_ expr CLOSE_PAR
+;
+
+window_defn:
+    OPEN_PAR base_window_name? (PARTITION_ BY_ expr (COMMA expr)*)? (
+        ORDER_ BY_ ordering_term (COMMA ordering_term)*
+    ) frame_spec? CLOSE_PAR
+;
+
+over_clause:
+    OVER_ (
+        window_name
+        | OPEN_PAR base_window_name? (PARTITION_ BY_ expr (COMMA expr)*)? (
+            ORDER_ BY_ ordering_term (COMMA ordering_term)*
+        )? frame_spec? CLOSE_PAR
+    )
+;
+
+frame_spec:
+    frame_clause (EXCLUDE_ ( NO_ OTHERS_ | CURRENT_ ROW_ | GROUP_ | TIES_))?
+;
+
+frame_clause: (RANGE_ | ROWS_ | GROUPS_) (
+        frame_single
+        | BETWEEN_ frame_left AND_ frame_right
+    )
+;
+
+simple_function_invocation:
+    simple_func OPEN_PAR (expr (COMMA expr)* | STAR) CLOSE_PAR
+;
+
+aggregate_function_invocation:
+    aggregate_func OPEN_PAR (DISTINCT_? expr (COMMA expr)* | STAR)? CLOSE_PAR filter_clause?
+;
+
+window_function_invocation:
+    window_function OPEN_PAR (expr (COMMA expr)* | STAR)? CLOSE_PAR filter_clause? OVER_ (
+        window_defn
+        | window_name
+    )
+;
+
+common_table_stmt: //additional structures
+    WITH_ RECURSIVE_? common_table_expression (COMMA common_table_expression)*
+;
+
+order_by_stmt:
+    ORDER_ BY_ ordering_term (COMMA ordering_term)*
+;
+
+limit_stmt:
+    //LIMIT_ expr ((OFFSET_ | COMMA) expr)?
+    LIMIT_ NUMERIC_LITERAL
+;
+
+ordering_term:
+    //expr (COLLATE_ collation_name)? asc_desc? (NULLS_ (FIRST_ | LAST_))?
+    expr asc_desc?
+;
+
+asc_desc:
+    ASC_
+    | DESC_
+;
+
+frame_left:
+    expr PRECEDING_
+    | expr FOLLOWING_
+    | CURRENT_ ROW_
+    | UNBOUNDED_ PRECEDING_
+;
+
+frame_right:
+    expr PRECEDING_
+    | expr FOLLOWING_
+    | CURRENT_ ROW_
+    | UNBOUNDED_ FOLLOWING_
+;
+
+frame_single:
+    expr PRECEDING_
+    | UNBOUNDED_ PRECEDING_
+    | CURRENT_ ROW_
+;
+
+// unknown
+
+window_function: (FIRST_VALUE_ | LAST_VALUE_) OPEN_PAR expr CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr_asc_desc
+        frame_clause? CLOSE_PAR
+    | (CUME_DIST_ | PERCENT_RANK_) OPEN_PAR CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr? CLOSE_PAR
+    | (DENSE_RANK_ | RANK_ | ROW_NUMBER_) OPEN_PAR CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr_asc_desc CLOSE_PAR
+    | (LAG_ | LEAD_) OPEN_PAR expr offset? default_value? CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr_asc_desc CLOSE_PAR
+    | NTH_VALUE_ OPEN_PAR expr COMMA signed_number CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr_asc_desc frame_clause?
+        CLOSE_PAR
+    | NTILE_ OPEN_PAR expr CLOSE_PAR OVER_ OPEN_PAR partition_by? order_by_expr_asc_desc CLOSE_PAR
+;
+
+offset:
+    COMMA signed_number
+;
+
+default_value:
+    COMMA signed_number
+;
+
+partition_by:
+    PARTITION_ BY_ expr+
+;
+
+order_by_expr:
+    ORDER_ BY_ expr+
+;
+
+order_by_expr_asc_desc:
+    ORDER_ BY_ expr_asc_desc
+;
+
+expr_asc_desc:
+    expr asc_desc? (COMMA expr asc_desc?)*
+;
+
+//TODO BOTH OF THESE HAVE TO BE REWORKED TO FOLLOW THE SPEC
+initial_select:
+    select_stmt
+;
+
+recursive_select:
+    select_stmt
+;
+
+unary_operator:
+    MINUS
+    | PLUS
+    // | TILDE
+    | NOT_
+;
+
+error_message:
+    STRING_LITERAL
+;
+
+module_argument: // TODO check what exactly is permitted here
+    expr
+    | column_def
+;
+
+column_alias:
+    IDENTIFIER
+    | STRING_LITERAL
+;
+
+keyword:
+    ABORT_
+    | ACTION_
+    | ADD_
+    | AFTER_
+    | ALL_
+    | ALTER_
+    | ANALYZE_
+    | AND_
+    | AS_
+    | ASC_
+    | ATTACH_
+    | AUTOINCREMENT_
+    | BEFORE_
+    | BEGIN_
+    | BETWEEN_
+    | BY_
+    | CASCADE_
+    | CASE_
+    | CAST_
+    | CHECK_
+    | COLLATE_
+    | COLUMN_
+    | COMMIT_
+    | CONFLICT_
+    | CONSTRAINT_
+    | CREATE_
+    | CROSS_
+    | CURRENT_DATE_
+    | CURRENT_TIME_
+    | CURRENT_TIMESTAMP_
+    | DATABASE_
+    | DEFAULT_
+    | DEFERRABLE_
+    | DEFERRED_
+    | DELETE_
+    | DESC_
+    | DETACH_
+    | DISTINCT_
+    | DROP_
+    | EACH_
+    | ELSE_
+    | END_
+    | ESCAPE_
+    | EXCEPT_
+    | EXCLUSIVE_
+    | EXISTS_
+    | EXPLAIN_
+    | FAIL_
+    | FOR_
+    | FOREIGN_
+    | FROM_
+    | FULL_
+    | GLOB_
+    | GROUP_
+    | HAVING_
+    | IF_
+    | IGNORE_
+    | IMMEDIATE_
+    | IN_
+    | INDEX_
+    | INDEXED_
+    | INITIALLY_
+    | INNER_
+    | INSERT_
+    | INSTEAD_
+    | INTERSECT_
+    | INTO_
+    | IS_
+    | ISNULL_
+    | JOIN_
+    | KEY_
+    | LEFT_
+    | LIKE_
+    | LIMIT_
+    | MATCH_
+    | NATURAL_
+    | NO_
+    | NOT_
+    | NOTNULL_
+    | NULL_
+    | OF_
+    | OFFSET_
+    | ON_
+    | OR_
+    | ORDER_
+    | OUTER_
+    | PLAN_
+    | PRAGMA_
+    | PRIMARY_
+    | QUERY_
+    | RAISE_
+    | RECURSIVE_
+    | REFERENCES_
+    | REGEXP_
+    | REINDEX_
+    | RELEASE_
+    | RENAME_
+    | REPLACE_
+    | RESTRICT_
+    | RIGHT_
+    | ROLLBACK_
+    | ROW_
+    | ROWS_
+    | SAVEPOINT_
+    | SELECT_
+    | SET_
+    | TABLE_
+    | TEMP_
+    | TEMPORARY_
+    | THEN_
+    | TO_
+    | TRANSACTION_
+    | TRIGGER_
+    | UNION_
+    | UNIQUE_
+    | UPDATE_
+    | USING_
+    | VACUUM_
+    | VALUES_
+    | VIEW_
+    | VIRTUAL_
+    | WHEN_
+    | WHERE_
+    | WITH_
+    | WITHOUT_
+    | FIRST_VALUE_
+    | OVER_
+    | PARTITION_
+    | RANGE_
+    | PRECEDING_
+    | UNBOUNDED_
+    | CURRENT_
+    | FOLLOWING_
+    | CUME_DIST_
+    | DENSE_RANK_
+    | LAG_
+    | LAST_VALUE_
+    | LEAD_
+    | NTH_VALUE_
+    | NTILE_
+    | PERCENT_RANK_
+    | RANK_
+    | ROW_NUMBER_
+    | GENERATED_
+    | ALWAYS_
+    | STORED_
+    | TRUE_
+    | FALSE_
+    | WINDOW_
+    | NULLS_
+    | FIRST_
+    | LAST_
+    | FILTER_
+    | GROUPS_
+    | EXCLUDE_
+;
+
+// TODO: check all names below
+
+name:
+    any_name
+;
+
+function_name:
+    any_name
+;
+
+schema_name:
+    any_name
+;
+
+table_name:
+    any_name
+;
+
+table_or_index_name:
+    any_name
+;
+
+column_name:
+    any_name
+;
+
+collation_name:
+    any_name
+;
+
+foreign_table:
+    any_name
+;
+
+index_name:
+    any_name
+;
+
+trigger_name:
+    any_name
+;
+
+view_name:
+    any_name
+;
+
+module_name:
+    any_name
+;
+
+pragma_name:
+    any_name
+;
+
+savepoint_name:
+    any_name
+;
+
+table_alias:
+    any_name
+;
+
+transaction_name:
+    any_name
+;
+
+window_name:
+    any_name
+;
+
+alias:
+    any_name
+;
+
+filename:
+    any_name
+;
+
+base_window_name:
+    any_name
+;
+
+simple_func:
+    any_name
+;
+
+aggregate_func:
+    any_name
+;
+
+table_function_name:
+    any_name
+;
+
+any_name:
+    IDENTIFIER
+    | keyword
+    | STRING_LITERAL
+    | OPEN_PAR any_name CLOSE_PAR
+;

--- a/src/main/antlr/SQLLexer.g4
+++ b/src/main/antlr/SQLLexer.g4
@@ -1,0 +1,225 @@
+// Based on MIT-licensed SQL Lite ANTLR4 grammar
+// https://github.com/antlr/grammars-v4/tree/master/sql/sqlite
+
+// $antlr-format alignTrailingComments on, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments off, useTab off
+// $antlr-format allowShortRulesOnASingleLine on, alignSemicolons ownLine
+
+lexer grammar SQLLexer;
+
+options {
+    caseInsensitive = true;
+}
+
+SCOL: ';';
+DOT: '.';
+OPEN_PAR: '(';
+CLOSE_PAR: ')';
+COMMA: ',';
+ASSIGN: '=';
+STAR: '*';
+PLUS: '+';
+MINUS: '-';
+TILDE: '~';
+PIPE2: '||';
+DIV: '/';
+MOD: '%';
+// Not used?
+LT2: '<<';
+// Not used?
+GT2: '>>';
+AMP: '&';
+PIPE: '|';
+LT: '<';
+LT_EQ: '<=';
+GT: '>';
+GT_EQ: '>=';
+EQ: '==';
+NOT_EQ1: '!=';
+NOT_EQ2: '<>';
+
+ABORT_: 'ABORT';
+ACTION_: 'ACTION';
+ADD_: 'ADD';
+AFTER_: 'AFTER';
+ALL_: 'ALL';
+ALTER_: 'ALTER';
+ANALYZE_: 'ANALYZE';
+AND_: 'AND';
+AS_: 'AS';
+ASC_: 'ASC';
+ATTACH_: 'ATTACH';
+AUTOINCREMENT_: 'AUTOINCREMENT';
+BEFORE_: 'BEFORE';
+BEGIN_: 'BEGIN';
+BETWEEN_: 'BETWEEN';
+BY_: 'BY';
+CASCADE_: 'CASCADE';
+CASE_: 'CASE';
+CAST_: 'CAST';
+CHECK_: 'CHECK';
+COLLATE_: 'COLLATE';
+COLUMN_: 'COLUMN';
+COMMIT_: 'COMMIT';
+CONFLICT_: 'CONFLICT';
+CONSTRAINT_: 'CONSTRAINT';
+CREATE_: 'CREATE';
+CROSS_: 'CROSS';
+CURRENT_DATE_: 'CURRENT_DATE';
+CURRENT_TIME_: 'CURRENT_TIME';
+CURRENT_TIMESTAMP_: 'CURRENT_TIMESTAMP';
+DATABASE_: 'DATABASE';
+DEFAULT_: 'DEFAULT';
+DEFERRABLE_: 'DEFERRABLE';
+DEFERRED_: 'DEFERRED';
+DELETE_: 'DELETE';
+DESC_: 'DESC';
+DETACH_: 'DETACH';
+DISTINCT_: 'DISTINCT';
+DROP_: 'DROP';
+EACH_: 'EACH';
+ELSE_: 'ELSE';
+END_: 'END';
+ESCAPE_: 'ESCAPE';
+EXCEPT_: 'EXCEPT';
+EXCLUSIVE_: 'EXCLUSIVE';
+EXISTS_: 'EXISTS';
+EXPLAIN_: 'EXPLAIN';
+FAIL_: 'FAIL';
+FOR_: 'FOR';
+FOREIGN_: 'FOREIGN';
+FROM_: 'FROM';
+FULL_: 'FULL';
+GLOB_: 'GLOB';
+GROUP_: 'GROUP';
+HAVING_: 'HAVING';
+IF_: 'IF';
+IGNORE_: 'IGNORE';
+IMMEDIATE_: 'IMMEDIATE';
+IN_: 'IN';
+INDEX_: 'INDEX';
+INDEXED_: 'INDEXED';
+INITIALLY_: 'INITIALLY';
+INNER_: 'INNER';
+INSERT_: 'INSERT';
+INSTEAD_: 'INSTEAD';
+INTERSECT_: 'INTERSECT';
+INTO_: 'INTO';
+IS_: 'IS';
+ISNULL_: 'ISNULL';
+JOIN_: 'JOIN';
+KEY_: 'KEY';
+LEFT_: 'LEFT';
+LIKE_: 'LIKE';
+LIMIT_: 'LIMIT';
+MATCH_: 'MATCH';
+NATURAL_: 'NATURAL';
+NO_: 'NO';
+NOT_: 'NOT';
+NOTNULL_: 'NOTNULL';
+NULL_: 'NULL';
+OF_: 'OF';
+OFFSET_: 'OFFSET';
+ON_: 'ON';
+OR_: 'OR';
+ORDER_: 'ORDER';
+OUTER_: 'OUTER';
+PLAN_: 'PLAN';
+PRAGMA_: 'PRAGMA';
+PRIMARY_: 'PRIMARY';
+QUERY_: 'QUERY';
+RAISE_: 'RAISE';
+RECURSIVE_: 'RECURSIVE';
+REFERENCES_: 'REFERENCES';
+REGEXP_: 'REGEXP';
+REINDEX_: 'REINDEX';
+RELEASE_: 'RELEASE';
+RENAME_: 'RENAME';
+REPLACE_: 'REPLACE';
+RESTRICT_: 'RESTRICT';
+RETURNING_: 'RETURNING';
+RIGHT_: 'RIGHT';
+ROLLBACK_: 'ROLLBACK';
+ROW_: 'ROW';
+ROWS_: 'ROWS';
+SAVEPOINT_: 'SAVEPOINT';
+SELECT_: 'SELECT';
+SET_: 'SET';
+TABLE_: 'TABLE';
+TEMP_: 'TEMP';
+TEMPORARY_: 'TEMPORARY';
+THEN_: 'THEN';
+TO_: 'TO';
+TRANSACTION_: 'TRANSACTION';
+TRIGGER_: 'TRIGGER';
+UNION_: 'UNION';
+UNIQUE_: 'UNIQUE';
+UPDATE_: 'UPDATE';
+USING_: 'USING';
+VACUUM_: 'VACUUM';
+VALUES_: 'VALUES';
+VIEW_: 'VIEW';
+VIRTUAL_: 'VIRTUAL';
+WHEN_: 'WHEN';
+WHERE_: 'WHERE';
+WITH_: 'WITH';
+WITHOUT_: 'WITHOUT';
+FIRST_VALUE_: 'FIRST_VALUE';
+OVER_: 'OVER';
+PARTITION_: 'PARTITION';
+RANGE_: 'RANGE';
+PRECEDING_: 'PRECEDING';
+UNBOUNDED_: 'UNBOUNDED';
+CURRENT_: 'CURRENT';
+FOLLOWING_: 'FOLLOWING';
+CUME_DIST_: 'CUME_DIST';
+DENSE_RANK_: 'DENSE_RANK';
+LAG_: 'LAG';
+LAST_VALUE_: 'LAST_VALUE';
+LEAD_: 'LEAD';
+NTH_VALUE_: 'NTH_VALUE';
+NTILE_: 'NTILE';
+PERCENT_RANK_: 'PERCENT_RANK';
+RANK_: 'RANK';
+ROW_NUMBER_: 'ROW_NUMBER';
+GENERATED_: 'GENERATED';
+ALWAYS_: 'ALWAYS';
+STORED_: 'STORED';
+TRUE_: 'TRUE';
+FALSE_: 'FALSE';
+WINDOW_: 'WINDOW';
+NULLS_: 'NULLS';
+FIRST_: 'FIRST';
+LAST_: 'LAST';
+FILTER_: 'FILTER';
+GROUPS_: 'GROUPS';
+EXCLUDE_: 'EXCLUDE';
+TIES_: 'TIES';
+OTHERS_: 'OTHERS';
+DO_: 'DO';
+NOTHING_: 'NOTHING';
+
+IDENTIFIER:
+    '"' (~'"' | '""')* '"'
+    | '`' (~'`' | '``')* '`'
+    | '[' ~']'* ']'
+    | [A-Z_\u007F-\uFFFF] [A-Z_0-9\u007F-\uFFFF]*
+;
+
+NUMERIC_LITERAL: ((DIGIT+ ('.' DIGIT*)?) | ('.' DIGIT+)) ('E' [-+]? DIGIT+)? | '0x' HEX_DIGIT+;
+
+BIND_PARAMETER: '?' DIGIT* | [:@$] IDENTIFIER;
+
+STRING_LITERAL: '\'' ( ~'\'' | '\'\'')* '\'';
+
+BLOB_LITERAL: 'X' STRING_LITERAL;
+
+SINGLE_LINE_COMMENT: '--' ~[\r\n]* (('\r'? '\n') | EOF) -> channel(HIDDEN);
+
+MULTILINE_COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
+
+SPACES: [ \u000B\t\r\n] -> channel(HIDDEN);
+
+UNEXPECTED_CHAR: .;
+
+fragment HEX_DIGIT: [0-9A-F];
+fragment DIGIT: [0-9];

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/SQLNode.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/SQLNode.java
@@ -1,0 +1,34 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+
+/**
+ * Abstract Node class representing SQL Nodes
+ */
+public abstract class SQLNode extends BoxNode {
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLNode( Position position, String sourceText ) {
+		super( position, sourceText );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/SQLStatement.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/SQLStatement.java
@@ -1,0 +1,34 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql;
+
+import ortus.boxlang.compiler.ast.Position;
+
+/**
+ * Abstract Node class representing SQL statements
+ * A statement is a top level thing like SELECT, DELETE, INSERT, etc
+ */
+public abstract class SQLStatement extends SQLNode {
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLStatement( Position position, String sourceText ) {
+		super( position, sourceText );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLJoin.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLJoin.java
@@ -1,0 +1,106 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLNode;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+/**
+ * Abstract Node class representing SQL join
+ */
+public class SQLJoin extends SQLNode {
+
+	private SQLJoinType		type;
+
+	private SQLTable		table;
+
+	private SQLExpression	on;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLJoin( SQLJoinType type, SQLTable table, SQLExpression on, Position position, String sourceText ) {
+		super( position, sourceText );
+	}
+
+	/**
+	 * Get the join type
+	 */
+	public SQLJoinType getType() {
+		return type;
+	}
+
+	/**
+	 * Set the join type
+	 */
+	public void setType( SQLJoinType type ) {
+		this.type = type;
+	}
+
+	/**
+	 * Get the table
+	 */
+	public SQLTable getTable() {
+		return table;
+	}
+
+	/**
+	 * Set the table
+	 */
+	public void setTable( SQLTable table ) {
+		replaceChildren( this.table, table );
+		this.table = table;
+		this.table.setParent( this );
+	}
+
+	/**
+	 * Get the ON expression
+	 */
+	public SQLExpression getOn() {
+		return on;
+	}
+
+	/**
+	 * Set the ON expression
+	 */
+	public void setOn( SQLExpression on ) {
+		if ( !on.isBoolean() ) {
+			throw new BoxRuntimeException( "ON clause must be a boolean expression" );
+		}
+		replaceChildren( this.on, on );
+		this.on = on;
+		this.on.setParent( this );
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLJoinType.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLJoinType.java
@@ -1,0 +1,39 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+public enum SQLJoinType {
+
+	INNER,
+	LEFT,
+	RIGHT,
+	FULL;
+
+	public String getSymbol() {
+		switch ( this ) {
+			case INNER :
+				return "INNER JOIN";
+			case LEFT :
+				return "LEFT JOIN";
+			case RIGHT :
+				return "RIGHT JOIN";
+			case FULL :
+				return "FULL JOIN";
+			default :
+				throw new IllegalStateException( "Unknown join type: " + this );
+		}
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLResultColumn.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLResultColumn.java
@@ -1,0 +1,85 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLNode;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL result column declaration
+ */
+public class SQLResultColumn extends SQLNode {
+
+	private SQLNode	expression;
+
+	private String	alias;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLResultColumn( SQLNode expression, String alias, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+		setAlias( alias );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLNode getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLNode expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * Get the table alias
+	 */
+	public String getAlias() {
+		return alias;
+	}
+
+	/**
+	 * Set the table alias
+	 */
+	public void setAlias( String alias ) {
+		this.alias = alias;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLSelect.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLSelect.java
@@ -1,0 +1,192 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLNode;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+/**
+ * Abstract Node class representing SQL SELECT statement
+ */
+public class SQLSelect extends SQLNode {
+
+	private boolean					distinct;
+
+	private List<SQLResultColumn>	resultColumns;
+
+	private SQLTable				table;
+
+	private List<SQLJoin>			joins;
+
+	private SQLExpression			where;
+
+	private List<SQLExpression>		groupBys;
+
+	private SQLExpression			having;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLSelect( boolean distinct, List<SQLResultColumn> resultColumns, SQLTable table, List<SQLJoin> joins, SQLExpression where,
+	    List<SQLExpression> groupBys,
+	    SQLExpression having, Position position, String sourceText ) {
+		super( position, sourceText );
+		setDistinct( distinct );
+		setResultColumns( resultColumns );
+		setTable( table );
+		setJoins( joins );
+		setWhere( where );
+		setGroupBys( groupBys );
+		setHaving( having );
+	}
+
+	/**
+	 * Set the DISTINCT flag
+	 */
+	public void setDistinct( boolean distinct ) {
+		this.distinct = distinct;
+	}
+
+	/**
+	 * Set the result columns
+	 */
+	public void setResultColumns( List<SQLResultColumn> resultColumns ) {
+		replaceChildren( this.resultColumns, resultColumns );
+		this.resultColumns = resultColumns;
+		resultColumns.forEach( c -> c.setParent( this ) );
+	}
+
+	/**
+	 * Set the table
+	 */
+	public void setTable( SQLTable table ) {
+		replaceChildren( this.table, table );
+		this.table = table;
+		table.setParent( this );
+	}
+
+	/**
+	 * Set the JOINs
+	 */
+	public void setJoins( List<SQLJoin> joins ) {
+		replaceChildren( this.joins, joins );
+		this.joins = joins;
+		joins.forEach( j -> j.setParent( this ) );
+	}
+
+	/**
+	 * Set the WHERE node
+	 */
+	public void setWhere( SQLExpression where ) {
+		if ( !where.isBoolean() ) {
+			throw new BoxRuntimeException( "WHERE clause must be a boolean expression" );
+		}
+		replaceChildren( this.where, where );
+		this.where = where;
+		where.setParent( this );
+	}
+
+	/**
+	 * Set the GROUP BY nodes
+	 */
+	public void setGroupBys( List<SQLExpression> groupBys ) {
+		replaceChildren( this.groupBys, groupBys );
+		this.groupBys = groupBys;
+		groupBys.forEach( g -> g.setParent( this ) );
+	}
+
+	/**
+	 * Set the HAVING node
+	 */
+	public void setHaving( SQLExpression having ) {
+		if ( !having.isBoolean() ) {
+			throw new BoxRuntimeException( "HAVING clause must be a boolean expression" );
+		}
+		replaceChildren( this.having, having );
+		this.having = having;
+		having.setParent( this );
+	}
+
+	/**
+	 * Get the DISTINCT flag
+	 */
+	public boolean isDistinct() {
+		return distinct;
+	}
+
+	/**
+	 * Get the result columns
+	 */
+	public List<SQLResultColumn> getResultColumns() {
+		return resultColumns;
+	}
+
+	/**
+	 * Get the table
+	 */
+	public SQLTable getTable() {
+		return table;
+	}
+
+	/**
+	 * Get the JOINs
+	 */
+	public List<SQLJoin> getJoins() {
+		return joins;
+	}
+
+	/**
+	 * Get the WHERE node
+	 */
+	public SQLExpression getWhere() {
+		return where;
+	}
+
+	/**
+	 * Get the GROUP BY nodes
+	 */
+	public List<SQLExpression> getGroupBys() {
+		return groupBys;
+	}
+
+	/**
+	 * Get the HAVING node
+	 */
+	public SQLExpression getHaving() {
+		return having;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLSelectStatement.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLSelectStatement.java
@@ -1,0 +1,128 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLStatement;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLOrderBy;
+import ortus.boxlang.compiler.ast.sql.select.expression.literal.SQLNumberLiteral;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL SELECT statement
+ * I may represent more than one actual SQLSelect unioned together
+ */
+public class SQLSelectStatement extends SQLStatement {
+
+	private SQLSelect			select;
+	private List<SQLSelect>		unions;
+	private List<SQLOrderBy>	orderBys;
+	private SQLNumberLiteral	limit;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLSelectStatement( SQLSelect select, List<SQLSelect> unions, List<SQLOrderBy> orderBys, SQLNumberLiteral limit, Position position,
+	    String sourceText ) {
+		super( position, sourceText );
+		setSelect( select );
+		setUnions( unions );
+		setOrderBys( orderBys );
+		setLimit( limit );
+	}
+
+	/**
+	 * Set the SELECT statement
+	 */
+	public void setSelect( SQLSelect select ) {
+		replaceChildren( this.select, select );
+		this.select = select;
+		this.select.setParent( this );
+	}
+
+	/**
+	 * Get the SELECT statement
+	 */
+	public SQLSelect getSelect() {
+		return select;
+	}
+
+	/**
+	 * Set the UNIONed SELECT statements
+	 */
+	public void setUnions( List<SQLSelect> unions ) {
+		replaceChildren( this.unions, unions );
+		this.unions = unions;
+		unions.forEach( u -> u.setParent( this ) );
+	}
+
+	/**
+	 * Get the UNIONed SELECT statements
+	 */
+	public List<SQLSelect> getUnions() {
+		return unions;
+	}
+
+	/**
+	 * Set the ORDER BY nodes
+	 */
+	public void setOrderBys( List<SQLOrderBy> orderBys ) {
+		replaceChildren( this.orderBys, orderBys );
+		this.orderBys = orderBys;
+		orderBys.forEach( o -> o.setParent( this ) );
+	}
+
+	/**
+	 * Get the ORDER BY nodes
+	 */
+	public List<SQLOrderBy> getOrderBys() {
+		return orderBys;
+	}
+
+	/**
+	 * Set the LIMIT node
+	 */
+	public void setLimit( SQLNumberLiteral limit ) {
+		replaceChildren( this.limit, limit );
+		this.limit = limit;
+		limit.setParent( this );
+	}
+
+	/**
+	 * Get the LIMIT node
+	 */
+	public SQLNumberLiteral getLimit() {
+		return limit;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLTable.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/SQLTable.java
@@ -1,0 +1,100 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLNode;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL table declaration
+ */
+public class SQLTable extends SQLNode {
+
+	private String	schema;
+
+	private String	name;
+
+	private String	alias;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLTable( String schema, String name, String alias, Position position, String sourceText ) {
+		super( position, sourceText );
+		setSchema( schema );
+		setName( name );
+		setAlias( alias );
+	}
+
+	/**
+	 * Get the schema name
+	 */
+	public String getSchema() {
+		return schema;
+	}
+
+	/**
+	 * Set the schema name
+	 */
+	public void setSchema( String schema ) {
+		this.schema = schema;
+	}
+
+	/**
+	 * Get the table name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Set the table name
+	 */
+	public void setName( String name ) {
+		this.name = name;
+	}
+
+	/**
+	 * Get the table alias
+	 */
+	public String getAlias() {
+		return alias;
+	}
+
+	/**
+	 * Set the table alias
+	 */
+	public void setAlias( String alias ) {
+		this.alias = alias;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLColumn.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLColumn.java
@@ -1,0 +1,89 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.SQLTable;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL column reference
+ */
+public class SQLColumn extends SQLExpression {
+
+	private SQLTable	table;
+
+	private String		name;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLColumn( SQLTable table, String name, Position position, String sourceText ) {
+		super( position, sourceText );
+		setName( name );
+		setTable( table );
+	}
+
+	/**
+	 * Get the name of the function
+	 *
+	 * @return the name of the function
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Set the name of the function
+	 *
+	 * @param name the name of the function
+	 */
+	public void setName( String name ) {
+		this.name = name;
+	}
+
+	/**
+	 * Get the table
+	 */
+	public SQLTable getTable() {
+		return table;
+	}
+
+	/**
+	 * Set the table
+	 */
+	public void setTable( SQLTable table ) {
+		// This node has no parent/child relationship, it's just a reference
+		this.table = table;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLCountFunction.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLCountFunction.java
@@ -1,0 +1,68 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL count() function call
+ */
+public class SQLCountFunction extends SQLFunction {
+
+	private boolean distinct;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLCountFunction( String name, List<SQLExpression> arguments, boolean distinct, Position position, String sourceText ) {
+		super( name, arguments, position, sourceText );
+		setDistinct( distinct );
+	}
+
+	/**
+	 * Set distinct
+	 */
+	public void setDistinct( boolean distinct ) {
+		this.distinct = distinct;
+	}
+
+	/**
+	 * Get distinct
+	 */
+	public boolean isDistinct() {
+		return distinct;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLExpression.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLExpression.java
@@ -1,0 +1,49 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.SQLNode;
+
+/**
+ * Abstract Node class representing SQL expression
+ */
+public abstract class SQLExpression extends SQLNode {
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLExpression( Position position, String sourceText ) {
+		super( position, sourceText );
+	}
+
+	/**
+	 * Check if the expression is a literal
+	 */
+	public boolean isLiteral() {
+		return false;
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return false;
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLFunction.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLFunction.java
@@ -1,0 +1,103 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL function call
+ */
+public class SQLFunction extends SQLExpression {
+
+	private String				name;
+
+	private List<SQLExpression>	arguments;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLFunction( String name, List<SQLExpression> arguments, Position position, String sourceText ) {
+		super( position, sourceText );
+		setName( name );
+		setArguments( arguments );
+	}
+
+	/**
+	 * Get the name of the function
+	 *
+	 * @return the name of the function
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Set the name of the function
+	 *
+	 * @param name the name of the function
+	 */
+	public void setName( String name ) {
+		this.name = name;
+	}
+
+	/**
+	 * Get the arguments of the function
+	 *
+	 * @return the arguments of the function
+	 */
+	public List<SQLExpression> getArguments() {
+		return arguments;
+	}
+
+	/**
+	 * Set the arguments of the function
+	 *
+	 * @param arguments the arguments of the function
+	 */
+	public void setArguments( List<SQLExpression> arguments ) {
+		replaceChildren( this.arguments, arguments );
+		this.arguments = arguments;
+		this.arguments.forEach( a -> a.setParent( this ) );
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		// TODO implement based on name of function
+		return false;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLOrderBy.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLOrderBy.java
@@ -1,0 +1,85 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL Order By item
+ */
+public class SQLOrderBy extends SQLExpression {
+
+	private SQLExpression	expression;
+
+	private boolean			ascending;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLOrderBy( SQLExpression expression, boolean ascending, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+		setAscending( ascending );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLExpression getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLExpression expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * get the ascending flag
+	 */
+	public boolean isAscending() {
+		return ascending;
+	}
+
+	/**
+	 * set the ascending flag
+	 */
+	public void setAscending( boolean ascending ) {
+		this.ascending = ascending;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLParenthesis.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLParenthesis.java
@@ -1,0 +1,75 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL parenthetical expression
+ */
+public class SQLParenthesis extends SQLExpression {
+
+	private SQLExpression expression;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLParenthesis( SQLExpression expression, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLExpression getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLExpression expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return expression.isBoolean();
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLStarExpression.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLStarExpression.java
@@ -1,0 +1,68 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.SQLTable;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL * expression
+ */
+public class SQLStarExpression extends SQLExpression {
+
+	private SQLTable table;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLStarExpression( SQLTable table, Position position, String sourceText ) {
+		super( position, sourceText );
+		setTable( table );
+	}
+
+	/**
+	 * Get the table
+	 */
+	public SQLTable getTable() {
+		return table;
+	}
+
+	/**
+	 * Set the table
+	 */
+	public void setTable( SQLTable table ) {
+		// This node has no parent/child relationship, it's just a reference
+		this.table = table;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLBooleanLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLBooleanLiteral.java
@@ -1,0 +1,80 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.literal;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL boolean
+ */
+public class SQLBooleanLiteral extends SQLExpression {
+
+	private boolean value;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLBooleanLiteral( boolean value, Position position, String sourceText ) {
+		super( position, sourceText );
+		setValue( value );
+	}
+
+	/**
+	 * Get the value of the string literal
+	 *
+	 * @return the value of the string literal
+	 */
+	public boolean getValue() {
+		return value;
+	}
+
+	public void setValue( boolean value ) {
+		this.value = value;
+	}
+
+	/**
+	 * Check if the expression is a literal
+	 */
+	public boolean isLiteral() {
+		return true;
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNullLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNullLiteral.java
@@ -12,10 +12,11 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-package ortus.boxlang.compiler.ast.sql.select.expression;
+package ortus.boxlang.compiler.ast.sql.select.expression.literal;
 
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
 

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNullLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNullLiteral.java
@@ -1,0 +1,56 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL null
+ */
+public class SQLNullLiteral extends SQLExpression {
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLNullLiteral( Position position, String sourceText ) {
+		super( position, sourceText );
+	}
+
+	/**
+	 * Check if the expression is a literal
+	 */
+	public boolean isLiteral() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNumberLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLNumberLiteral.java
@@ -1,0 +1,73 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.literal;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL number literal
+ */
+public class SQLNumberLiteral extends SQLExpression {
+
+	private Number value;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLNumberLiteral( Number value, Position position, String sourceText ) {
+		super( position, sourceText );
+		setValue( value );
+	}
+
+	/**
+	 * Get the value of the Number literal
+	 *
+	 * @return the value of the Number literal
+	 */
+	public Number getValue() {
+		return value;
+	}
+
+	public void setValue( Number value ) {
+		this.value = value;
+	}
+
+	/**
+	 * Check if the expression is a literal
+	 */
+	public boolean isLiteral() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLStringLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLStringLiteral.java
@@ -12,10 +12,11 @@
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-package ortus.boxlang.compiler.ast.sql.select.expression;
+package ortus.boxlang.compiler.ast.sql.select.expression.literal;
 
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
 import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
 import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
 

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLStringLiteral.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/literal/SQLStringLiteral.java
@@ -1,0 +1,72 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL string literal
+ */
+public class SQLStringLiteral extends SQLExpression {
+
+	private String value;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLStringLiteral( String value, Position position, String sourceText ) {
+		super( position, sourceText );
+		setValue( value );
+	}
+
+	/**
+	 * Get the value of the string literal
+	 *
+	 * @return the value of the string literal
+	 */
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue( String value ) {
+		this.value = value;
+	}
+
+	/**
+	 * Check if the expression is a literal
+	 */
+	public boolean isLiteral() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBetweenOperation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBetweenOperation.java
@@ -1,0 +1,114 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL BETWEEN operation
+ */
+public class SQLBetweenOperation extends SQLExpression {
+
+	private SQLExpression	expression;
+
+	private SQLExpression	left;
+
+	private SQLExpression	right;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLBetweenOperation( SQLExpression expression, SQLExpression left, SQLExpression right, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+		setLeft( left );
+		setRight( right );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLExpression getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLExpression expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * Get the left
+	 */
+	public SQLExpression getLeft() {
+		return left;
+	}
+
+	/**
+	 * Set the left
+	 */
+	public void setLeft( SQLExpression left ) {
+		replaceChildren( this.left, left );
+		this.left = left;
+		this.left.setParent( this );
+	}
+
+	/**
+	 * Get the right
+	 */
+	public SQLExpression getRight() {
+		return right;
+	}
+
+	/**
+	 * Set the right
+	 */
+	public void setRight( SQLExpression right ) {
+		replaceChildren( this.right, right );
+		this.right = right;
+		this.right.setParent( this );
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBinaryOperation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBinaryOperation.java
@@ -1,0 +1,118 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+import java.util.Set;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL binary operation
+ */
+public class SQLBinaryOperation extends SQLExpression {
+
+	// EQUAL, NOTEQUAL, LESSTHAN, LESSTHANOREQUAL, GREATERTHAN, GREATERTHANOREQUAL, AND, OR
+	private static final Set<SQLBinaryOperator>	booleanOperators	= Set.of( SQLBinaryOperator.EQUAL, SQLBinaryOperator.NOTEQUAL, SQLBinaryOperator.LESSTHAN,
+	    SQLBinaryOperator.LESSTHANOREQUAL, SQLBinaryOperator.GREATERTHAN, SQLBinaryOperator.GREATERTHANOREQUAL, SQLBinaryOperator.AND, SQLBinaryOperator.OR );
+
+	private SQLExpression						left;
+
+	private SQLExpression						right;
+
+	private SQLBinaryOperator					operator;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLBinaryOperation( SQLExpression left, SQLExpression right, SQLBinaryOperator operator, Position position, String sourceText ) {
+		super( position, sourceText );
+		setLeft( left );
+		setRight( right );
+		setOperator( operator );
+	}
+
+	/**
+	 * Get the left
+	 */
+	public SQLExpression getLeft() {
+		return left;
+	}
+
+	/**
+	 * Set the left
+	 */
+	public void setLeft( SQLExpression left ) {
+		replaceChildren( this.left, left );
+		this.left = left;
+		this.left.setParent( this );
+	}
+
+	/**
+	 * Get the right
+	 */
+	public SQLExpression getRight() {
+		return right;
+	}
+
+	/**
+	 * Set the right
+	 */
+	public void setRight( SQLExpression right ) {
+		replaceChildren( this.right, right );
+		this.right = right;
+		this.right.setParent( this );
+	}
+
+	/**
+	 * Get the operator
+	 */
+	public SQLBinaryOperator getOperator() {
+		return operator;
+	}
+
+	/**
+	 * Set the operator
+	 */
+	public void setOperator( SQLBinaryOperator operator ) {
+		this.operator = operator;
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return booleanOperators.contains( operator );
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBinaryOperator.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLBinaryOperator.java
@@ -1,0 +1,66 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+public enum SQLBinaryOperator {
+
+	PLUS,
+	MINUS,
+	MULTIPLY,
+	DIVIDE,
+	MODULO,
+	EQUAL,
+	NOTEQUAL,
+	LESSTHAN,
+	LESSTHANOREQUAL,
+	GREATERTHAN,
+	GREATERTHANOREQUAL,
+	AND,
+	OR;
+
+	public String getSymbol() {
+		switch ( this ) {
+			case PLUS :
+				return "+";
+			case MINUS :
+				return "-";
+			case MULTIPLY :
+				return "*";
+			case DIVIDE :
+				return "/";
+			case MODULO :
+				return "%";
+			case EQUAL :
+				return "=";
+			case NOTEQUAL :
+				return "!=";
+			case LESSTHAN :
+				return "<";
+			case LESSTHANOREQUAL :
+				return "<=";
+			case GREATERTHAN :
+				return ">";
+			case GREATERTHANOREQUAL :
+				return ">=";
+			case AND :
+				return "AND";
+			case OR :
+				return "OR";
+			default :
+				return "";
+		}
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLInOperation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLInOperation.java
@@ -1,0 +1,114 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL IN operation
+ */
+public class SQLInOperation extends SQLExpression {
+
+	private boolean				not;
+
+	private SQLExpression		expression;
+
+	private List<SQLExpression>	values;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLInOperation( boolean not, SQLExpression expression, List<SQLExpression> values, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+		setValues( values );
+		setNot( not );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLExpression getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLExpression expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * Get the values
+	 */
+	public List<SQLExpression> getValues() {
+		return values;
+	}
+
+	/**
+	 * Set the values
+	 */
+	public void setValues( List<SQLExpression> values ) {
+		replaceChildren( this.values, values );
+		this.values = values;
+		this.values.forEach( v -> v.setParent( this ) );
+	}
+
+	/**
+	 * Get the not
+	 */
+	public boolean isNot() {
+		return not;
+	}
+
+	/**
+	 * Set the not
+	 */
+	public void setNot( boolean not ) {
+		this.not = not;
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return true;
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLUnaryOperation.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLUnaryOperation.java
@@ -1,0 +1,98 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+import java.util.Set;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.sql.select.expression.SQLExpression;
+import ortus.boxlang.compiler.ast.visitor.ReplacingBoxVisitor;
+import ortus.boxlang.compiler.ast.visitor.VoidBoxVisitor;
+
+/**
+ * Abstract Node class representing SQL unary operation
+ */
+public class SQLUnaryOperation extends SQLExpression {
+
+	// NOT, ISNULL, ISNOTNULL
+	private static final Set<SQLUnaryOperator>	booleanOperators	= Set.of( SQLUnaryOperator.NOT, SQLUnaryOperator.ISNULL, SQLUnaryOperator.ISNOTNULL );
+
+	private SQLExpression						expression;
+
+	private SQLUnaryOperator					operator;
+
+	/**
+	 * Constructor
+	 *
+	 * @param position   position of the statement in the source code
+	 * @param sourceText source code of the statement
+	 */
+	protected SQLUnaryOperation( SQLExpression expression, SQLUnaryOperator operator, Position position, String sourceText ) {
+		super( position, sourceText );
+		setExpression( expression );
+		setOperator( operator );
+	}
+
+	/**
+	 * Get the expression
+	 */
+	public SQLExpression getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Set the expression
+	 */
+	public void setExpression( SQLExpression expression ) {
+		replaceChildren( this.expression, expression );
+		this.expression = expression;
+		this.expression.setParent( this );
+	}
+
+	/**
+	 * Get the operator
+	 */
+	public SQLUnaryOperator getOperator() {
+		return operator;
+	}
+
+	/**
+	 * Set the operator
+	 */
+	public void setOperator( SQLUnaryOperator operator ) {
+		this.operator = operator;
+	}
+
+	/**
+	 * Check if the expression evaluates to a boolean value
+	 */
+	public boolean isBoolean() {
+		return booleanOperators.contains( operator );
+	}
+
+	@Override
+	public void accept( VoidBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+	@Override
+	public BoxNode accept( ReplacingBoxVisitor v ) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException( "Unimplemented method 'accept'" );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLUnaryOperator.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/operation/SQLUnaryOperator.java
@@ -1,0 +1,41 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.ast.sql.select.expression.operation;
+
+public enum SQLUnaryOperator {
+
+	PLUS,
+	MINUS,
+	NOT,
+	ISNULL,
+	ISNOTNULL;
+
+	public String getSymbol() {
+		switch ( this ) {
+			case PLUS :
+				return "+";
+			case MINUS :
+				return "-";
+			case NOT :
+				return "!";
+			case ISNULL :
+				return "IS NULL";
+			case ISNOTNULL :
+				return "IS NOT NULL";
+			default :
+				return "";
+		}
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -356,9 +356,13 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 			node.setName( BIFMap.get( name ) );
 		}
 
-		if ( name.equalsIgnoreCase( "structKeyExists" ) && node.getArguments().size() == 2 ) {
-			return transpileStructKeyExists( node );
-		}
+		// This is now done with runtime checks in the actual structKeyExist() BIF triggered by the compat module
+		/*
+		 * if ( name.equalsIgnoreCase( "structKeyExists" ) && node.getArguments().size() == 2 ) {
+		 * return transpileStructKeyExists( node );
+		 * }
+		 */
+
 		// Look for valueList( myQry.columnName ) or valueList( myQry[ "columnName" ] )
 		if ( name.equalsIgnoreCase( "valueList" ) && node.getArguments().size() > 0 && node.getArguments().get( 0 ).getValue() instanceof BoxAccess ) {
 			return transpileValueList( node );

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxBreakTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxBreakTransformer.java
@@ -20,6 +20,11 @@ import com.github.javaparser.ast.Node;
 
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.statement.BoxBreak;
+import ortus.boxlang.compiler.ast.statement.BoxDo;
+import ortus.boxlang.compiler.ast.statement.BoxForIn;
+import ortus.boxlang.compiler.ast.statement.BoxForIndex;
+import ortus.boxlang.compiler.ast.statement.BoxSwitch;
+import ortus.boxlang.compiler.ast.statement.BoxWhile;
 import ortus.boxlang.compiler.javaboxpiler.JavaTranspiler;
 import ortus.boxlang.compiler.javaboxpiler.transformer.AbstractTransformer;
 import ortus.boxlang.compiler.javaboxpiler.transformer.TransformerContext;
@@ -45,9 +50,11 @@ public class BoxBreakTransformer extends AbstractTransformer {
 		if ( exitsAllowed.equals( ExitsAllowed.COMPONENT ) ) {
 			template = "if(true) return Component.BodyResult.ofBreak(" + componentLabel + ");";
 		} else if ( exitsAllowed.equals( ExitsAllowed.LOOP ) ) {
+			@SuppressWarnings( "unchecked" )
+			BoxNode	specificExit		= node.getFirstNodeOfTypes( BoxDo.class, BoxForIndex.class, BoxForIn.class, BoxSwitch.class, BoxWhile.class );
 			String	breakDetectionName	= null;
 			Integer	breakCounter		= transpiler.peekForLoopBreakCounter();
-			if ( breakCounter != null ) {
+			if ( specificExit instanceof BoxForIndex && breakCounter != null ) {
 				breakDetectionName	= "didBreak" + breakCounter;
 				template			= "if(true) { " + breakDetectionName + "=true; break " + breakLabel + "; }";
 			} else {

--- a/src/main/java/ortus/boxlang/compiler/parser/SQLLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/SQLLexerCustom.java
@@ -1,0 +1,183 @@
+/**
+ * [BoxLang]
+ * <p>
+ * Copyright [2023] [Ortus Solutions, Corp]
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+
+import ortus.boxlang.parser.antlr.SQLLexer;
+
+/**
+ * I extend the generated ANTLR lexer to add some custom methods for getting unpopped modes
+ * so we can perform better validation after parsing.
+ */
+public class SQLLexerCustom extends SQLLexer {
+
+	/**
+	 * The error listener
+	 */
+	ErrorListener	errorListener;
+
+	/**
+	 * The parser
+	 */
+	SQLParser		parser;
+
+	/**
+	 * Constructor
+	 *
+	 * @param input input stream
+	 */
+	public SQLLexerCustom( CharStream input, ErrorListener errorListener, SQLParser parser ) {
+		super( input );
+		this.errorListener	= errorListener;
+		this.parser			= parser;
+		reset();
+	}
+
+	/**
+	 * Check if there are unpopped modes on the Lexer's mode stack
+	 *
+	 * @return true if there are unpopped modes
+	 */
+	public boolean hasUnpoppedModes() {
+		return !_modeStack.isEmpty();
+	}
+
+	/**
+	 * Get the unpopped modes on the Lexer's mode stack
+	 *
+	 * @return list of unpopped modes
+	 */
+	public List<Integer> getUnpoppedModesInts() {
+		List<Integer> results = new ArrayList<Integer>();
+		for ( int mode : _modeStack.toArray() ) {
+			results.add( 0, mode );
+		}
+		results.add( 0, _mode );
+		return results;
+	}
+
+	/**
+	 * Get the unpopped modes on the Lexer's mode stack
+	 *
+	 * @return list of unpopped modes
+	 */
+	public List<String> getUnpoppedModes() {
+		return getUnpoppedModesInts().stream().map( mode -> modeNames[ mode ] ).toList();
+	}
+
+	/**
+	 * Check if the last mode was a specific mode
+	 *
+	 * @param mode mode to check
+	 *
+	 * @return true if the last mode was the specified mode
+	 */
+	public boolean lastModeWas( int mode ) {
+		if ( !hasUnpoppedModes() ) {
+			return false;
+		}
+		return getUnpoppedModesInts().get( 0 ) == mode;
+	}
+
+	/**
+	 * Get the last token of a specific type
+	 *
+	 * @param type type of token to find
+	 *
+	 * @return the last token of the specified type
+	 */
+	public Token findPreviousToken( int type ) {
+		reset();
+		var tokens = getAllTokens();
+		for ( int i = tokens.size() - 1; i >= 0; i-- ) {
+			Token t = tokens.get( i );
+			if ( t.getType() == type ) {
+				return t;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Back up to the closest unclosed brace
+	 * Return null if none found
+	 * *
+	 *
+	 * @return the unmatched opening brace
+	 */
+	public Token findUnclosedToken( int start, int end ) {
+		int count = 0;
+		reset();
+		var tokens = getAllTokens();
+		for ( int i = tokens.size() - 1; i >= 0; i-- ) {
+			Token t = tokens.get( i );
+			if ( t.getType() == start ) {
+				count--;
+			} else if ( t.getType() == end ) {
+				count++;
+			}
+			if ( count < 0 ) {
+				return t;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Check if a specific mode is on the stack
+	 *
+	 * @param mode mode to check
+	 *
+	 * @return true if the mode is on the stack
+	 */
+	public boolean hasMode( int mode ) {
+		if ( !hasUnpoppedModes() ) {
+			return false;
+		}
+		return getUnpoppedModesInts().contains( mode );
+	}
+
+	/**
+	 * Get the last token of a specific type and the next x siblings
+	 * Returns empty list if not found
+	 * 
+	 * @param type  type of token to find
+	 * @param count number of siblings to find
+	 * 
+	 * @return the list of tokens starting from the specified type
+	 */
+	public List<Token> findPreviousTokenAndXSiblings( int type, int count ) {
+		reset();
+		List<Token>	results	= new ArrayList<Token>();
+		var			tokens	= getAllTokens();
+		for ( int i = tokens.size() - 1; i >= 0; i-- ) {
+			Token t = tokens.get( i );
+			if ( t.getType() == type ) {
+				results.add( t );
+				for ( int j = 1; j <= count; j++ ) {
+					results.add( tokens.get( i + j ) );
+				}
+				return results;
+			}
+		}
+		return results;
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/parser/SQLParser.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/SQLParser.java
@@ -1,0 +1,241 @@
+/**
+ * [BoxLang]
+ * <p>
+ * Copyright [2023] [Ortus Solutions, Corp]
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.compiler.parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.ast.BoxScript;
+import ortus.boxlang.compiler.ast.Position;
+import ortus.boxlang.compiler.ast.Source;
+import ortus.boxlang.compiler.ast.SourceCode;
+import ortus.boxlang.compiler.ast.SourceFile;
+import ortus.boxlang.compiler.ast.comment.BoxMultiLineComment;
+import ortus.boxlang.compiler.ast.comment.BoxSingleLineComment;
+import ortus.boxlang.compiler.toolchain.SQLVisitor;
+import ortus.boxlang.parser.antlr.SQLGrammar;
+import ortus.boxlang.parser.antlr.SQLLexer;
+
+/**
+ * Parser for QoQ scripts
+ */
+public class SQLParser extends AbstractParser {
+
+	private SQLVisitor expressionVisitor = new SQLVisitor( this );
+
+	/**
+	 * Constructor
+	 */
+	public SQLParser() {
+		super();
+	}
+
+	public SQLParser( int startLine, int startColumn ) {
+		super( startLine, startColumn );
+	}
+
+	/**
+	 * Parse a QoQ script file
+	 *
+	 * @param file source file to parse
+	 *
+	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
+	 *
+	 * @throws IOException if the input stream is in error
+	 *
+	 * @see ParsingResult
+	 */
+	public ParsingResult parse( File file, boolean isScript ) throws IOException {
+		this.file = file;
+		setSource( new SourceFile( file ) );
+		BOMInputStream	inputStream			= getInputStream( file );
+		Boolean			classOrInterface	= false;
+		BoxNode			ast					= parserFirstStage( inputStream, classOrInterface, isScript );
+
+		return new ParsingResult( ast, issues, comments );
+	}
+
+	/**
+	 * Parse a QoQ string
+	 *
+	 * @param code source code to parse
+	 *
+	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
+	 *
+	 * @throws IOException if the input stream is in error
+	 *
+	 * @see BoxScript
+	 * @see ParsingResult
+	 */
+	public ParsingResult parse( String code, boolean isScript ) throws IOException {
+		return parse( code, false, isScript );
+	}
+
+	public ParsingResult parse( String code ) throws IOException {
+		return parse( code, false, true );
+	}
+
+	/**
+	 * Parse a QoQ script string
+	 *
+	 * @param code source code to parse
+	 *
+	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
+	 *
+	 * @throws IOException if the input stream is in error
+	 *
+	 * @see BoxScript
+	 * @see ParsingResult
+	 */
+	@Override
+	public ParsingResult parse( String code, boolean classOrInterface, boolean isScript ) throws IOException {
+		this.sourceCode = code;
+		setSource( new SourceCode( code ) );
+		InputStream	inputStream	= IOUtils.toInputStream( code, StandardCharsets.UTF_8 );
+
+		BoxNode		ast			= parserFirstStage( inputStream, classOrInterface, isScript );
+		return new ParsingResult( ast, issues, comments );
+	}
+
+	/**
+	 * Fist stage parser
+	 *
+	 * @param stream input stream (file or string) of the source code
+	 *
+	 * @return the ANTLR ParserRule representing the parse tree of the code
+	 *
+	 * @throws IOException io error
+	 */
+	@Override
+	protected BoxNode parserFirstStage( InputStream stream, boolean classOrInterface, boolean isScript ) throws IOException {
+
+		SQLLexerCustom	lexer	= new SQLLexerCustom( CharStreams.fromStream( stream, StandardCharsets.UTF_8 ), errorListener, this );
+		SQLGrammar		parser	= new SQLGrammar( new CommonTokenStream( lexer ) );
+
+		// DEBUG: Will print a trace of all parser rules visited:
+		// boxParser.setTrace( true );
+		addErrorListeners( lexer, parser );
+		parser.setErrorHandler( new BoxParserErrorStrategy() );
+
+		ParserRuleContext parseTree = parser.parse();
+
+		// This must run FIRST before resetting the lexer
+		validateParse( lexer );
+
+		// This can add issues to an otherwise successful parse
+		extractComments( lexer );
+
+		lexer.reset();
+		BoxNode rootNode;
+
+		try {
+			// Create the visitor we will use to build the AST
+			var visitor = new SQLVisitor( this );
+			rootNode = parseTree.accept( visitor );
+		} catch ( Exception e ) {
+			// Ignore issues creating AST if the parsing already had failures
+			if ( issues.isEmpty() ) {
+				throw e;
+			}
+			return null;
+		}
+
+		if ( rootNode == null ) {
+			return null;
+		}
+
+		// associate all comments in the source with the appropriate AST nodes
+		rootNode.associateComments( this.comments );
+
+		return rootNode;
+	}
+
+	private void validateParse( SQLLexerCustom lexer ) {
+
+		// Check if there are unconsumed tokens
+		Token token = lexer._token;
+		while ( token.getType() != Token.EOF && ( token.getChannel() == SQLLexerCustom.HIDDEN ) ) {
+			token = lexer.nextToken();
+		}
+		if ( token.getType() != Token.EOF ) {
+			StringBuilder	extraText	= new StringBuilder();
+			int				startLine	= token.getLine();
+			int				startColumn	= token.getCharPositionInLine();
+			int				endColumn	= startColumn + token.getText().length();
+			Position		position	= createOffsetPosition( startLine, startColumn, startLine, endColumn );
+			while ( token.getType() != Token.EOF && extraText.length() < 100 ) {
+				extraText.append( token.getText() );
+				token = lexer.nextToken();
+			}
+			errorListener.semanticError( "Extra char(s) [" + extraText + "] at the end of parsing.", position );
+		}
+
+		// If there is already a parsing issue, try to get a more specific error
+		if ( issues.isEmpty() ) {
+
+			Token unclosedParen = lexer.findUnclosedToken( SQLLexer.OPEN_PAR, SQLLexer.CLOSE_PAR );
+			if ( unclosedParen != null ) {
+				issues.clear();
+				errorListener.reset();
+				errorListener.semanticError( "Unclosed parenthesis [(] on line " + ( unclosedParen.getLine() + this.startLine ), createOffsetPosition(
+				    unclosedParen.getLine(), unclosedParen.getCharPositionInLine(), unclosedParen.getLine(), unclosedParen.getCharPositionInLine() + 1 ) );
+			}
+		}
+	}
+
+	private void extractComments( SQLLexerCustom lexer ) throws IOException {
+		lexer.reset();
+		Token token = lexer.nextToken();
+		while ( token.getType() != Token.EOF ) {
+			if ( token.getType() == SQLLexer.SINGLE_LINE_COMMENT ) {
+				String commentText = token.getText().trim().substring( 2 ).trim();
+				comments.add( new BoxSingleLineComment( commentText, getPosition( token ), token.getText() ) );
+			} else if ( token.getType() == SQLLexer.MULTILINE_COMMENT ) {
+				comments.add( new BoxMultiLineComment( extractMultiLineCommentText( token.getText(), false ), getPosition( token ), token.getText() ) );
+			}
+			token = lexer.nextToken();
+		}
+	}
+
+	@Override
+	SQLParser setSource( Source source ) {
+		if ( this.sourceToParse != null ) {
+			return this;
+		}
+		this.sourceToParse = source;
+		this.errorListener.setSource( sourceToParse );
+		return this;
+	}
+
+	@Override
+	public SQLParser setSubParser( boolean subParser ) {
+		this.subParser = subParser;
+		return this;
+	}
+
+	public void reportError( String message, Position position ) {
+		errorListener.semanticError( message, position );
+	}
+}

--- a/src/main/java/ortus/boxlang/compiler/toolchain/SQLVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/toolchain/SQLVisitor.java
@@ -1,0 +1,90 @@
+package ortus.boxlang.compiler.toolchain;
+
+import java.util.List;
+
+import ortus.boxlang.compiler.ast.BoxNode;
+import ortus.boxlang.compiler.parser.SQLParser;
+import ortus.boxlang.parser.antlr.SQLGrammar.ParseContext;
+import ortus.boxlang.parser.antlr.SQLGrammar.Select_stmtContext;
+import ortus.boxlang.parser.antlr.SQLGrammar.Sql_stmtContext;
+import ortus.boxlang.parser.antlr.SQLGrammar.Sql_stmt_listContext;
+import ortus.boxlang.parser.antlr.SQLGrammarBaseVisitor;
+
+/**
+ * This class is responsible for creating the SQL AST from the ANTLR generated parse tree.
+ */
+public class SQLVisitor extends SQLGrammarBaseVisitor<BoxNode> {
+
+	private final SQLParser tools;
+
+	public SQLVisitor( SQLParser tools ) {
+		this.tools = tools;
+	}
+
+	/**
+	 * Visit the class or interface context to generate the AST node for the
+	 * top level node
+	 *
+	 * @param ctx the parse tree
+	 *
+	 * @return the AST node representing the class or interface
+	 */
+	@Override
+	public BoxNode visitParse( ParseContext ctx ) {
+		List<Sql_stmt_listContext>	statements	= ctx.sql_stmt_list();
+		var							pos			= tools.getPosition( ctx );
+
+		if ( statements.isEmpty() ) {
+			tools.reportError( "No SQL statements found in query of query.", pos );
+		}
+		if ( statements.size() > 1 ) {
+			tools.reportError( "Only one SQL statement is allowed per query of query.", pos );
+		}
+
+		return visit( statements.get( 0 ) );
+	}
+
+	/**
+	 * Visit the class or interface context to generate the AST node for the
+	 * top level node
+	 *
+	 * @param ctx the parse tree
+	 *
+	 * @return the AST node representing the class or interface
+	 */
+	@Override
+	public BoxNode visitSql_stmt_list( Sql_stmt_listContext ctx ) {
+		List<Sql_stmtContext>	statements	= ctx.sql_stmt();
+		var						pos			= tools.getPosition( ctx );
+
+		if ( statements.isEmpty() ) {
+			tools.reportError( "No SQL statements found in query of query.", pos );
+		}
+		if ( statements.size() > 1 ) {
+			tools.reportError( "Only one SQL statement is allowed per query of query.", pos );
+		}
+
+		Sql_stmtContext statement = statements.get( 0 );
+		if ( statement.select_stmt() == null ) {
+			tools.reportError( "Only SELECT statements are allowed in query of query.", pos );
+		}
+
+		return visit( statement );
+	}
+
+	/**
+	 * Visit the class or interface context to generate the AST node for the
+	 * top level node
+	 *
+	 * @param ctx the parse tree
+	 *
+	 * @return the AST node representing the class or interface
+	 */
+	@Override
+	public BoxNode visitSelect_stmt( Select_stmtContext ctx ) {
+		var pos = tools.getPosition( ctx );
+
+		return null;
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -433,8 +433,10 @@ public class BoxRuntime implements java.io.Closeable {
 	 * once the instance is set in order to avoid circular dependencies.
 	 *
 	 * Any logic that requires any services or operations to be seeded first, then go here.
+	 * 
+	 * @param debugMode True if the runtime should be started in debug mode
 	 */
-	private void startup() {
+	private void startup( Boolean debugMode ) {
 		// Internal timer
 		timerUtil.start( "runtime-startup" );
 
@@ -458,7 +460,7 @@ public class BoxRuntime implements java.io.Closeable {
 		this.classLocator		= ClassLocator.getInstance( this );
 
 		// Load the configurations and overrides
-		loadConfiguration( this.debugMode, this.configPath );
+		loadConfiguration( debugMode, this.configPath );
 		// Anythying below might use configuration items
 
 		// Ensure home assets
@@ -616,7 +618,7 @@ public class BoxRuntime implements java.io.Closeable {
 				}
 			}
 			// We split in order to avoid circular dependencies on the runtime
-			instance.startup();
+			instance.startup( debugMode );
 		}
 		return instance;
 	}

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -92,7 +92,8 @@ import ortus.boxlang.runtime.util.ResolvedFilePath;
 import ortus.boxlang.runtime.util.Timer;
 
 /**
- * Represents the top level runtime container for box lang. Config, global scopes, mappings, threadpools, etc all go here.
+ * Represents the top level runtime container for box lang. Config, global
+ * scopes, mappings, threadpools, etc all go here.
  * All threads, requests, invocations, etc share this.
  */
 public class BoxRuntime implements java.io.Closeable {
@@ -123,6 +124,16 @@ public class BoxRuntime implements java.io.Closeable {
 	 * Logger for the runtime
 	 */
 	private Logger								logger;
+
+	/**
+	 * The logging configuration for the runtime
+	 * This is set by the first call to `getLogger()` which happens in the
+	 *
+	 * <pre>
+	 * startup()
+	 * </pre>
+	 */
+	private LoggingConfigurator					loggingConfigurator;
 
 	/**
 	 * The timestamp when the runtime was started
@@ -158,7 +169,8 @@ public class BoxRuntime implements java.io.Closeable {
 
 	/**
 	 * Runtime global services.
-	 * This can be used to store ANY service and make it available to the entire runtime as a singleton.
+	 * This can be used to store ANY service and make it available to the entire
+	 * runtime as a singleton.
 	 */
 	private ConcurrentHashMap<Key, IService>	globalServices			= new ConcurrentHashMap<>();
 
@@ -225,10 +237,12 @@ public class BoxRuntime implements java.io.Closeable {
 	private ModuleService						moduleService;
 
 	/**
-	 * The BoxPiler implementation the runtime will use. At this time we offer two choices:
+	 * The BoxPiler implementation the runtime will use. At this time we offer two
+	 * choices:
 	 * 1. JavaBoxpiler - Generates Java source code and compiles it via the JDK
 	 * 2. ASMBoxpiler - Generates bytecode directly via ASM
-	 * However, developers can create their own Boxpiler implementations and register them with the runtime
+	 * However, developers can create their own Boxpiler implementations and
+	 * register them with the runtime
 	 * via configuration.
 	 */
 	private IBoxpiler							boxpiler;
@@ -275,7 +289,8 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @param debugMode   true if the runtime should be started in debug mode
 	 * @param configPath  The path to the configuration file to load as overrides
 	 * @param runtimeHome The path to the runtime home directory
-	 * @param options     The CLI Options that were used to start the runtime or null if not started via CLI
+	 * @param options     The CLI Options that were used to start the runtime or
+	 *                    null if not started via CLI
 	 */
 	private BoxRuntime( Boolean debugMode, String configPath, String runtimeHome, CLIOptions options ) {
 		Map<String, String> envVars = System.getenv();
@@ -311,7 +326,8 @@ public class BoxRuntime implements java.io.Closeable {
 	 * Hierarchical loading of the configuration
 	 *
 	 * @param debugMode  The debug mode to load in the configuration
-	 * @param configPath The path to the configuration file to load as overrides, this can be null
+	 * @param configPath The path to the configuration file to load as overrides,
+	 *                   this can be null
 	 */
 	private void loadConfiguration( Boolean debugMode, String configPath ) {
 		ConfigLoader loader = ConfigLoader.getInstance();
@@ -320,18 +336,17 @@ public class BoxRuntime implements java.io.Closeable {
 
 		this.interceptorService.announce(
 		    BoxEvent.ON_CONFIGURATION_LOAD,
-		    Struct.of( "config", this.configuration )
-		);
+		    Struct.of( "config", this.configuration ) );
 
-		// 2. Runtime Home Override? Check runtime home for a ${boxlang-home}/config/boxlang.json
+		// 2. Runtime Home Override? Check runtime home for a
+		// ${boxlang-home}/config/boxlang.json
 		String runtimeHomeConfigPath = Paths.get( getRuntimeHome().toString(), "config", "boxlang.json" ).toString();
 		if ( Files.exists( Path.of( runtimeHomeConfigPath ) ) ) {
 			IStruct appliedConfig = loader.mergeEnvironmentOverrides( loader.deserializeConfig( runtimeHomeConfigPath ) );
 			this.configuration.process( appliedConfig );
 			this.interceptorService.announce(
 			    BoxEvent.ON_CONFIGURATION_OVERRIDE_LOAD,
-			    Struct.of( "config", this.configuration, "configOverride", runtimeHomeConfigPath )
-			);
+			    Struct.of( "config", this.configuration, "configOverride", runtimeHomeConfigPath ) );
 		}
 
 		// 3. CLI or ENV Config Path Override, which comes via the arguments
@@ -340,8 +355,7 @@ public class BoxRuntime implements java.io.Closeable {
 			this.configuration.process( appliedConfig );
 			this.interceptorService.announce(
 			    BoxEvent.ON_CONFIGURATION_OVERRIDE_LOAD,
-			    Struct.of( "config", this.configuration, "configOverride", configPath )
-			);
+			    Struct.of( "config", this.configuration, "configOverride", configPath ) );
 		}
 
 		// Finally verify if we overwrote the debugmode in one of the configs above
@@ -349,24 +363,21 @@ public class BoxRuntime implements java.io.Closeable {
 			this.debugMode = this.configuration.debugMode;
 			// Reconfigure the logging if enabled
 			if ( this.debugMode ) {
-				LoggingConfigurator.reconfigureDebugMode( this.debugMode );
+				this.loggingConfigurator.reconfigureDebugMode( this.debugMode );
 			}
 			this.logger.info( "+ DebugMode detected in config, overriding to {}", this.debugMode );
 		}
 
 		// AST Capture experimental feature
 		BooleanCaster.attempt(
-		    this.configuration.experimental.getOrDefault( "ASTCapture", false )
-		).ifSuccessful(
-		    astCapture -> {
-			    if ( astCapture ) {
-				    this.interceptorService.register(
-				        DynamicObject.of( new ASTCapture( false, true ) ),
-				        Key.onParse
-				    );
-			    }
-		    }
-		);
+		    this.configuration.experimental.getOrDefault( "ASTCapture", false ) ).ifSuccessful(
+		        astCapture -> {
+			        if ( astCapture ) {
+				        this.interceptorService.register(
+				            DynamicObject.of( new ASTCapture( false, true ) ),
+				            Key.onParse );
+			        }
+		        } );
 
 		// Load core logger and other core interceptions
 		this.interceptorService.register( new Logging( this ) );
@@ -381,7 +392,8 @@ public class BoxRuntime implements java.io.Closeable {
 			try {
 				Files.createDirectories( this.runtimeHome );
 			} catch ( IOException e ) {
-				throw new BoxRuntimeException( "Could not create runtime home directory at [" + this.runtimeHome + "]", e );
+				throw new BoxRuntimeException( "Could not create runtime home directory at [" + this.runtimeHome + "]",
+				    e );
 			}
 		}
 
@@ -393,7 +405,8 @@ public class BoxRuntime implements java.io.Closeable {
 				    try {
 					    Files.createDirectories( dirPath );
 				    } catch ( IOException e ) {
-					    throw new BoxRuntimeException( "Could not create runtime home directory at [" + dirPath + "]", e );
+					    throw new BoxRuntimeException(
+					        "Could not create runtime home directory at [" + dirPath + "]", e );
 				    }
 			    }
 		    } );
@@ -408,22 +421,26 @@ public class BoxRuntime implements java.io.Closeable {
 			}
 		}
 
-		// If we don't have the config/boxlang.json file in the runtime home, copy it from the resources
+		// If we don't have the config/boxlang.json file in the runtime home, copy it
+		// from the resources
 		Path runtimeHomeConfigPath = Paths.get( this.runtimeHome.toString(), "config", "boxlang.json" );
 		if ( !Files.exists( runtimeHomeConfigPath ) ) {
 			try ( InputStream inputStream = BoxRuntime.class.getResourceAsStream( "/config/boxlang.json" ) ) {
 				Files.copy( inputStream, runtimeHomeConfigPath );
 			} catch ( IOException e ) {
-				throw new BoxRuntimeException( "Could not copy runtime home configuration file to [" + runtimeHomeConfigPath + "]", e );
+				throw new BoxRuntimeException(
+				    "Could not copy runtime home configuration file to [" + runtimeHomeConfigPath + "]", e );
 			}
 		}
 
-		// Copy the META-INF/boxlang/version.properties to the runtime home always, and overwrite if it exists
+		// Copy the META-INF/boxlang/version.properties to the runtime home always, and
+		// overwrite if it exists
 		Path runtimeHomeVersionPath = Paths.get( this.runtimeHome.toString(), "version.properties" );
 		try ( InputStream inputStream = BoxRuntime.class.getResourceAsStream( "/META-INF/boxlang/version.properties" ) ) {
 			Files.copy( inputStream, runtimeHomeVersionPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING );
 		} catch ( IOException e ) {
-			throw new BoxRuntimeException( "Could not copy runtime home version file to [" + runtimeHomeVersionPath + "]", e );
+			throw new BoxRuntimeException(
+			    "Could not copy runtime home version file to [" + runtimeHomeVersionPath + "]", e );
 		}
 
 	}
@@ -432,8 +449,9 @@ public class BoxRuntime implements java.io.Closeable {
 	 * This is the startup of the runtime called internally by the constructor
 	 * once the instance is set in order to avoid circular dependencies.
 	 *
-	 * Any logic that requires any services or operations to be seeded first, then go here.
-	 * 
+	 * Any logic that requires any services or operations to be seeded first, then
+	 * go here.
+	 *
 	 * @param debugMode True if the runtime should be started in debug mode
 	 */
 	private void startup( Boolean debugMode ) {
@@ -441,6 +459,8 @@ public class BoxRuntime implements java.io.Closeable {
 		timerUtil.start( "runtime-startup" );
 
 		// Startup basic logging
+		// Here is where LogBack looks via ServiceLoader for a `Configurator` class
+		// Which in our case is our {@link LoggingConfigurator} class.
 		this.logger = LoggerFactory.getLogger( BoxRuntime.class );
 		// We can now log the startup
 		this.logger.info( "+ Starting up BoxLang Runtime" );
@@ -456,7 +476,8 @@ public class BoxRuntime implements java.io.Closeable {
 		this.schedulerService	= new SchedulerService( this );
 		this.dataSourceService	= new DatasourceService( this );
 
-		// Initiate the Class Locator Service in charge of doing all the class resolutions
+		// Initiate the Class Locator Service in charge of doing all the class
+		// resolutions
 		this.classLocator		= ClassLocator.getInstance( this );
 
 		// Load the configurations and overrides
@@ -471,8 +492,7 @@ public class BoxRuntime implements java.io.Closeable {
 		    Key.runtime,
 		    getConfiguration().getJavaLibraryPaths(),
 		    this.getClass().getClassLoader(),
-		    true
-		);
+		    true );
 		// Startup the right Compiler
 		this.boxpiler		= chooseBoxpiler();
 		// Seed Mathematical Precision for the runtime
@@ -485,15 +505,19 @@ public class BoxRuntime implements java.io.Closeable {
 		this.componentService.onStartup();
 		this.applicationService.onStartup();
 
-		// Create our runtime context that will be the granddaddy of all contexts that execute inside this runtime
+		// Create our runtime context that will be the granddaddy of all contexts that
+		// execute inside this runtime
 		this.runtimeContext = new RuntimeBoxContext();
 		// Now startup the modules so we can have a runtime context available to them
 		this.moduleService.onStartup();
-		// Now the cache service can be started, this allows for modules to register caches
+		// Now the cache service can be started, this allows for modules to register
+		// caches
 		this.cacheService.onStartup();
-		// Now all schedulers can be started, this allows for modules to register schedulers
+		// Now all schedulers can be started, this allows for modules to register
+		// schedulers
 		this.schedulerService.onStartup();
-		// Now the datasource manager can be started, this allows for modules to register datasources
+		// Now the datasource manager can be started, this allows for modules to
+		// register datasources
 		this.dataSourceService.onStartup();
 
 		// Global Services are now available, start them up
@@ -509,13 +533,11 @@ public class BoxRuntime implements java.io.Closeable {
 		this.logger.debug(
 		    "+ BoxLang Runtime Started at [{}] in [{}]ms",
 		    Instant.now(),
-		    timerUtil.stopAndGetMillis( "runtime-startup" )
-		);
+		    timerUtil.stopAndGetMillis( "runtime-startup" ) );
 
 		// Announce it baby! Runtime is up
 		this.interceptorService.announce(
-		    BoxEvent.ON_RUNTIME_START
-		);
+		    BoxEvent.ON_RUNTIME_START );
 	}
 
 	/**
@@ -542,7 +564,8 @@ public class BoxRuntime implements java.io.Closeable {
 	/**
 	 * Get or startup a BoxLang Runtime instance.
 	 * <p>
-	 * Another variation for NON-cli applications using just the debug mode and a config override.
+	 * Another variation for NON-cli applications using just the debug mode and a
+	 * config override.
 	 *
 	 * @param debugMode  True if the runtime should be started in debug mode
 	 * @param configPath The path to the configuration file to load as overrides
@@ -557,11 +580,13 @@ public class BoxRuntime implements java.io.Closeable {
 	/**
 	 * Get or startup a BoxLang Runtime instance.
 	 * <p>
-	 * This is for NON-cli applications using just a runtime home directory and config path.
+	 * This is for NON-cli applications using just a runtime home directory and
+	 * config path.
 	 * The debug mode will be identified by ENV or configuration.
 	 *
 	 * @param configPath  The path to the configuration file to load as overrides
-	 * @param runtimeHome The path to the runtime home directory where all the runtime assets are stored
+	 * @param runtimeHome The path to the runtime home directory where all the
+	 *                    runtime assets are stored
 	 *
 	 * @return A BoxRuntime instance
 	 *
@@ -575,7 +600,8 @@ public class BoxRuntime implements java.io.Closeable {
 	 * <p>
 	 * This method is used exclusively to start a CLI runtime instance.
 	 *
-	 * @param options The CLI Options that were used to start the runtime or null if not started via CLI
+	 * @param options The CLI Options that were used to start the runtime or null if
+	 *                not started via CLI
 	 *
 	 * @return A BoxRuntime instance
 	 */
@@ -586,11 +612,13 @@ public class BoxRuntime implements java.io.Closeable {
 	/**
 	 * Get or startup a BoxLang Runtime instance.
 	 * <p>
-	 * This variation doesn't use the CLIOptions as most likely this method is used by NON-CLI applications.
+	 * This variation doesn't use the CLIOptions as most likely this method is used
+	 * by NON-CLI applications.
 	 *
 	 * @param debugMode   True if the runtime should be started in debug mode
 	 * @param configPath  The path to the configuration file to load as overrides
-	 * @param runtimeHome The path to the runtime home directory where all the runtime assets are stored
+	 * @param runtimeHome The path to the runtime home directory where all the
+	 *                    runtime assets are stored
 	 *
 	 * @return A BoxRuntime instance
 	 */
@@ -605,8 +633,10 @@ public class BoxRuntime implements java.io.Closeable {
 	 *
 	 * @param debugMode   True if the runtime should be started in debug mode
 	 * @param configPath  The path to the configuration file to load as overrides
-	 * @param runtimeHome The path to the runtime home directory where all the runtime assets are stored
-	 * @param options     The CLI Options that were used to start the runtime or null if not started via CLI
+	 * @param runtimeHome The path to the runtime home directory where all the
+	 *                    runtime assets are stored
+	 * @param options     The CLI Options that were used to start the runtime or
+	 *                    null if not started via CLI
 	 *
 	 * @return A BoxRuntime instance
 	 */
@@ -624,7 +654,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Get the singleton instance. This can be null if the runtime has not been started yet.
+	 * Get the singleton instance. This can be null if the runtime has not been
+	 * started yet.
 	 *
 	 * @return BoxRuntime instance or null if not started
 	 */
@@ -742,6 +773,27 @@ public class BoxRuntime implements java.io.Closeable {
 	 */
 
 	/**
+	 * Get the configured Logging Configurator for the runtime
+	 *
+	 * @return The Configurator
+	 */
+	public LoggingConfigurator getLoggingConfigurator() {
+		return instance.loggingConfigurator;
+	}
+
+	/**
+	 * Set the Logging Configurator
+	 *
+	 * @param configurator The configurator to set
+	 *
+	 * @return The Runtime
+	 */
+	public BoxRuntime setLoggingConfigurator( LoggingConfigurator configurator ) {
+		instance.loggingConfigurator = configurator;
+		return instance;
+	}
+
+	/**
 	 * Get runtime class loader
 	 *
 	 * @return {@link DynamicClassLoader} or null if the runtime has not started
@@ -815,7 +867,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Get the CLI Options that were used to start the runtime. This can be null if not started via CLI
+	 * Get the CLI Options that were used to start the runtime. This can be null if
+	 * not started via CLI
 	 *
 	 * @return The CLI Options or null if not started via CLI
 	 */
@@ -842,7 +895,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Announce an event with the provided {@link IStruct} of data short-hand for {@link #getInterceptorService()}.announce()
+	 * Announce an event with the provided {@link IStruct} of data short-hand for
+	 * {@link #getInterceptorService()}.announce()
 	 *
 	 * @param state The Key state to announce
 	 * @param data  The data to announce
@@ -852,7 +906,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Announce an event with the provided {@link IStruct} of data short-hand for {@link #getInterceptorService()}.announce()
+	 * Announce an event with the provided {@link IStruct} of data short-hand for
+	 * {@link #getInterceptorService()}.announce()
 	 *
 	 * @param state The state to announce
 	 * @param data  The data to announce
@@ -862,7 +917,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Announce an event with the provided {@link IStruct} of data short-hand for {@link #getInterceptorService()}.announce()
+	 * Announce an event with the provided {@link IStruct} of data short-hand for
+	 * {@link #getInterceptorService()}.announce()
 	 *
 	 * @param state The Key state to announce
 	 * @param data  The data to announce
@@ -888,7 +944,8 @@ public class BoxRuntime implements java.io.Closeable {
 	/**
 	 * Shut down the runtime with the option to force it
 	 *
-	 * @force If true, forces the shutdown of the runtime, nothing will be gracefully shutdown
+	 * @force If true, forces the shutdown of the runtime, nothing will be
+	 *        gracefully shutdown
 	 */
 	public synchronized void shutdown( Boolean force ) {
 		if ( instance == null ) {
@@ -899,8 +956,7 @@ public class BoxRuntime implements java.io.Closeable {
 		// Announce it globally!
 		instance.interceptorService.announce(
 		    BoxEvent.ON_RUNTIME_SHUTDOWN,
-		    Struct.of( "runtime", this, "force", force )
-		);
+		    Struct.of( "runtime", this, "force", force ) );
 
 		// Shutdown the global services first
 		this.globalServices.values()
@@ -1009,7 +1065,8 @@ public class BoxRuntime implements java.io.Closeable {
 		// Lazy Load the version info
 		if ( this.versionInfo == null ) {
 			Properties properties = new Properties();
-			try ( InputStream inputStream = BoxRunner.class.getResourceAsStream( "/META-INF/boxlang/version.properties" ) ) {
+			try ( InputStream inputStream = BoxRunner.class
+			    .getResourceAsStream( "/META-INF/boxlang/version.properties" ) ) {
 				properties.load( inputStream );
 			} catch ( IOException e ) {
 				e.printStackTrace();
@@ -1074,26 +1131,26 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @param args         The arguments to pass to the template
 	 */
 	public void executeTemplate( String templatePath, IBoxContext context, String[] args ) {
-		// If the templatePath is a .cfs, .cfm then use the loadTemplateAbsolute, if it's a .cfc, .bx then use the loadClass
+		// If the templatePath is a .cfs, .cfm then use the loadTemplateAbsolute, if
+		// it's a .cfc, .bx then use the loadClass
 		if ( StringUtils.endsWithAny( templatePath, ".cfc", ".bx" ) ) {
 			// Load the class
 			Class<IBoxRunnable> targetClass = RunnableLoader.getInstance().loadClass(
 			    ResolvedFilePath.of( Paths.get( templatePath ) ),
-			    this.runtimeContext
-			);
+			    this.runtimeContext );
 			executeClass( targetClass, templatePath, context, args );
 		} else {
 			// Load the template
 			BoxTemplate targetTemplate = RunnableLoader.getInstance().loadTemplateAbsolute(
 			    this.runtimeContext,
-			    ResolvedFilePath.of( Paths.get( templatePath ) )
-			);
+			    ResolvedFilePath.of( Paths.get( templatePath ) ) );
 			executeTemplate( targetTemplate, context );
 		}
 	}
 
 	/**
-	 * Execute a single template in an existing context using a {@see URL} of the template to execution
+	 * Execute a single template in an existing context using a {@see URL} of the
+	 * template to execution
 	 *
 	 * @param templateURL A URL location to execution
 	 * @param context     The context to execute the template in
@@ -1110,7 +1167,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Execute a single template in its own context using a {@see URL} of the template to execution
+	 * Execute a single template in its own context using a {@see URL} of the
+	 * template to execution
 	 *
 	 * @param templateURL A URL location to execution
 	 *
@@ -1120,7 +1178,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Execute a single template in its own context using an already-loaded template runnable
+	 * Execute a single template in its own context using an already-loaded template
+	 * runnable
 	 *
 	 * @param template A template to execute
 	 *
@@ -1136,7 +1195,8 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @param args   The arguments to pass to the module
 	 *
 	 * @throws BoxRuntimeException if the module does not exist
-	 * @throws BoxRuntimeException If the module is not executable, meaning it doesn't have a main method
+	 * @throws BoxRuntimeException If the module is not executable, meaning it
+	 *                             doesn't have a main method
 	 */
 	public void executeModule( String module, String[] args ) {
 		// Verify module exists or throw an exception
@@ -1161,7 +1221,8 @@ public class BoxRuntime implements java.io.Closeable {
 	 */
 	public void executeClass( Class<IBoxRunnable> targetClass, String templatePath, IBoxContext context, String[] args ) {
 		IBoxContext				scriptingContext	= ensureRequestTypeContext( context, Paths.get( templatePath ).toUri() );
-		BaseApplicationListener	listener			= scriptingContext.getParentOfType( RequestBoxContext.class ).getApplicationListener();
+		BaseApplicationListener	listener			= scriptingContext.getParentOfType( RequestBoxContext.class )
+		    .getApplicationListener();
 		Throwable				errorToHandle		= null;
 		IClassRunnable			target				= ( IClassRunnable ) DynamicObject.of( targetClass )
 		    .invokeConstructor( scriptingContext )
@@ -1176,7 +1237,8 @@ public class BoxRuntime implements java.io.Closeable {
 				boolean result = listener.onRequestStart( scriptingContext, new Object[] { templatePath } );
 				if ( result ) {
 					// Not sure onClassRequest() works here since we already have the class loaded
-					target.dereferenceAndInvoke( scriptingContext, Key.main, new Object[] { Array.fromArray( args ) }, false );
+					target.dereferenceAndInvoke( scriptingContext, Key.main, new Object[] { Array.fromArray( args ) },
+					    false );
 				}
 			} catch ( AbortException e ) {
 				try {
@@ -1192,7 +1254,8 @@ public class BoxRuntime implements java.io.Closeable {
 				}
 			} catch ( MissingIncludeException e ) {
 				try {
-					// Not sure this is reachable since this method is probably only reached if the template existed. But just in case.
+					// Not sure this is reachable since this method is probably only reached if the
+					// template existed. But just in case.
 					if ( !listener.onMissingTemplate( scriptingContext, new Object[] { e.getMissingFileName() } ) ) {
 						errorToHandle = e;
 					}
@@ -1227,13 +1290,15 @@ public class BoxRuntime implements java.io.Closeable {
 				Thread.currentThread().setContextClassLoader( oldClassLoader );
 			}
 		} else {
-			throw new BoxRuntimeException( "Class [" + targetClass.getName() + "] does not have a main method to execute." );
+			throw new BoxRuntimeException(
+			    "Class [" + targetClass.getName() + "] does not have a main method to execute." );
 		}
 
 	}
 
 	/**
-	 * Execute a single template in an existing context using an already-loaded template runnable
+	 * Execute a single template in an existing context using an already-loaded
+	 * template runnable
 	 *
 	 * @param template A template to execute
 	 * @param context  The context to execute the template in
@@ -1242,16 +1307,20 @@ public class BoxRuntime implements java.io.Closeable {
 		String templatePath = template.getRunnablePath().absolutePath().toString();
 		instance.logger.debug( "Executing template [{}]", template.getRunnablePath() );
 
-		IBoxContext				scriptingContext	= ensureRequestTypeContext( context, template.getRunnablePath().absolutePath().toUri() );
-		BaseApplicationListener	listener			= scriptingContext.getParentOfType( RequestBoxContext.class ).getApplicationListener();
+		IBoxContext				scriptingContext	= ensureRequestTypeContext( context,
+		    template.getRunnablePath().absolutePath().toUri() );
+		BaseApplicationListener	listener			= scriptingContext.getParentOfType( RequestBoxContext.class )
+		    .getApplicationListener();
 		Throwable				errorToHandle		= null;
 		RequestBoxContext.setCurrent( scriptingContext.getParentOfType( RequestBoxContext.class ) );
 		ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
 		try {
 			boolean result = listener.onRequestStart( scriptingContext, new Object[] { templatePath } );
 			if ( result ) {
-				// Not sure if this works in this concext, since it's expected to include the template itself, but in this case our template is a loaded
-				// class, not a path which may or may not be a file and may or may not be inside of a mapping allowing a relative path to it
+				// Not sure if this works in this concext, since it's expected to include the
+				// template itself, but in this case our template is a loaded
+				// class, not a path which may or may not be a file and may or may not be inside
+				// of a mapping allowing a relative path to it
 				// listener.onRequest( scriptingContext, new Object[] { templatePath } );
 				template.invoke( scriptingContext );
 			}
@@ -1269,7 +1338,8 @@ public class BoxRuntime implements java.io.Closeable {
 			}
 		} catch ( MissingIncludeException e ) {
 			try {
-				// Not sure this is reachable since this method is probably only reached if the template existed. But just in case.
+				// Not sure this is reachable since this method is probably only reached if the
+				// template existed. But just in case.
 				if ( !listener.onMissingTemplate( scriptingContext, new Object[] { e.getMissingFileName() } ) ) {
 					errorToHandle = e;
 				}
@@ -1443,7 +1513,8 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * This is our REPL (Read-Eval-Print-Loop) method that allows for interactive BoxLang execution
+	 * This is our REPL (Read-Eval-Print-Loop) method that allows for interactive
+	 * BoxLang execution
 	 *
 	 * @param sourceStream An input stream to read
 	 * @param context      The context to execute the source in
@@ -1477,7 +1548,8 @@ public class BoxRuntime implements java.io.Closeable {
 
 				try {
 
-					BoxScript	scriptRunnable		= RunnableLoader.getInstance().loadStatement( context, source, BoxSourceType.BOXSCRIPT );
+					BoxScript	scriptRunnable		= RunnableLoader.getInstance().loadStatement( context, source,
+					    BoxSourceType.BOXSCRIPT );
 
 					// Fire!!!
 					Object		result				= scriptRunnable.invoke( scriptingContext );
@@ -1523,12 +1595,14 @@ public class BoxRuntime implements java.io.Closeable {
 
 	/**
 	 * Print the transpiled Java code for a given source file.
-	 * This is useful for debugging and understanding how the BoxLang code is transpiled to Java.
+	 * This is useful for debugging and understanding how the BoxLang code is
+	 * transpiled to Java.
 	 *
 	 * @param filePath The path to the source file
 	 */
 	public void printTranspiledJavaCode( String filePath ) {
-		ClassInfo		classInfo	= ClassInfo.forTemplate( ResolvedFilePath.of( "", "", Path.of( filePath ).getParent().toString(), filePath ),
+		ClassInfo		classInfo	= ClassInfo.forTemplate(
+		    ResolvedFilePath.of( "", "", Path.of( filePath ).getParent().toString(), filePath ),
 		    BoxSourceType.BOXSCRIPT,
 		    this.boxpiler );
 		ParsingResult	result		= boxpiler.parseOrFail( Path.of( filePath ).toFile() );
@@ -1548,8 +1622,10 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Check the given context to see if it has a variables scope. If not, create a new scripting
-	 * context that has a variables scope and return that with the original context as the parent.
+	 * Check the given context to see if it has a variables scope. If not, create a
+	 * new scripting
+	 * context that has a variables scope and return that with the original context
+	 * as the parent.
 	 *
 	 * @param context The context to check
 	 *
@@ -1560,8 +1636,10 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Check the given context to see if it has a request scope. If not, create a new scripting
-	 * context that has a request scope and return that with the original context as the parent.
+	 * Check the given context to see if it has a request scope. If not, create a
+	 * new scripting
+	 * context that has a request scope and return that with the original context as
+	 * the parent.
 	 *
 	 * @param context  The context to check
 	 * @param template The template to use for the context if needed

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyExists.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyExists.java
@@ -25,6 +25,7 @@ import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.IStruct;
 
 @BoxBIF
 @BoxMember( type = BoxLangType.STRUCT )
@@ -53,7 +54,17 @@ public class StructKeyExists extends BIF {
 	 * @argument.key The key within the struct to test for existence
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Object result = arguments.getAsStruct( Key.struct ).getRaw( Key.of( arguments.get( Key.key ) ) );
+		Key		keyKey	= Key.of( arguments.get( Key.key ) );
+		IStruct	struct	= arguments.getAsStruct( Key.struct );
+
+		// First check if the key exists in the struct. This is here to filter out keys which are accessible, but
+		// not actually returned by the keySet() method, such as the `1` key in an arguments scope. You can access it, but it's not really there as a key.
+		if ( !struct.containsKey( keyKey ) ) {
+			return false;
+		}
+
+		// If the key exists, then we need to check if the value is defined based on our current null settings.
+		Object result = struct.getRaw( keyKey );
 		return context.isDefined( result );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.bifs.BoxMember;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
@@ -123,6 +124,12 @@ public class Dump extends BIF {
 	 * @argument.showUDFs Show UDFs or not. Default is true. (Only in HTML output)
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		// Abort as String and empty means true <bx:dump var="" abort>
+		Object abort = arguments.get( Key.abort );
+		if ( abort instanceof String castedAbort && castedAbort.isEmpty() ) {
+			arguments.put( Key.abort, true );
+		}
+
 		// Dump the object
 		DumpUtil.dump(
 		    context,
@@ -130,7 +137,7 @@ public class Dump extends BIF {
 		    arguments.getAsString( Key.label ),
 		    IntegerCaster.cast( arguments.get( Key.top ) ),
 		    arguments.getAsBoolean( Key.expand ),
-		    arguments.getAsBoolean( Key.abort ),
+		    BooleanCaster.cast( arguments.get( Key.abort ) ),
 		    arguments.getAsString( Key.output ).toLowerCase(),
 		    arguments.getAsString( Key.format ),
 		    arguments.getAsBoolean( Key.showUDFs )

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
@@ -85,7 +85,7 @@ public class Dump extends BIF {
 		    // Whether to do a hard abort the request after dumping
 		    new Argument( false, Argument.BOOLEAN, Key.abort, false ),
 		    // The output location which can be "buffer", "console", or "{absolute file path}", default is "buffer" (backwards compat => browser)
-		    new Argument( false, Argument.STRING, Key.output, "buffer", Set.of( Validator.NON_EMPTY ) ),
+		    new Argument( false, Argument.STRING, Key.output, Set.of( Validator.NON_EMPTY ) ),
 		    // The output format which can be "html" or "text". The default is based on the output location
 		    new Argument( false, Argument.STRING, Key.format, Set.of( Validator.valueOneOf( "html", "text" ), Validator.NON_EMPTY ) ),
 		    // Show UDFs or not
@@ -138,7 +138,7 @@ public class Dump extends BIF {
 		    IntegerCaster.cast( arguments.get( Key.top ) ),
 		    arguments.getAsBoolean( Key.expand ),
 		    BooleanCaster.cast( arguments.get( Key.abort ) ),
-		    arguments.getAsString( Key.output ).toLowerCase(),
+		    arguments.getAsString( Key.output ),
 		    arguments.getAsString( Key.format ),
 		    arguments.getAsBoolean( Key.showUDFs )
 		);

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetSemver.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetSemver.java
@@ -1,0 +1,108 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.system;
+
+import org.semver4j.Semver;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+
+@BoxBIF
+public class GetSemver extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public GetSemver() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( false, "string", Key.version, "" )
+		};
+	}
+
+	/**
+	 * Parses and returns a Semver object version of the passed version string or if you do not pass
+	 * in a version, we will return to you a Semver builder {@link Semver#of()} object, so you can programmaticaly build
+	 * a version object.
+	 * <p>
+	 * Semver is a tool that provides useful methods to manipulate versions that follow the "semantic versioning"
+	 * specification (see <a href="http://semver.org">semver.org</a> and <a href="https://github.com/semver4j/semver4j">github</a>).
+	 * <p>
+	 * Some of the methods provided by Semver are:
+	 * <ul>
+	 * <li>{@link Semver#compare(Semver)}: Compares two versions and returns -1, 0, or 1 if the first version is less than,
+	 * equal to, or greater than the second version, respectively.</li>
+	 * <li>{@link Semver#satisfies(String)}: Checks if the version satisfies the given range.</li>
+	 * <li>{@link Semver#valid()}: Checks if the version is valid.</li>
+	 * <li>{@link Semver#incMajor()}: Increments the major version.</li>
+	 * <li>{@link Semver#incMinor()}: Increments the minor version.</li>
+	 * <li>{@link Semver#incPatch()}: Increments the patch version.</li>
+	 * <li>{@link Semver#incPreRelease()}: Increments the pre-release version.</li>
+	 * <li>{@link Semver#incBuild()}: Increments the build version.</li>
+	 * <li>{@link Semver#isStable()}: Checks if the version is stable.</li>
+	 * </ul>
+	 * <p>
+	 * Here are some examples of how to parse and manipulate versions using Semver:
+	 *
+	 * <pre>
+	 *
+	 * var version = GetSemver( "1.2.3-alpha+20151212" );
+	 * var version = GetSemver( "1.2.3-alpha" );
+	 * var version = GetSemver( "1.2.3" );
+	 * var version = GetSemver( "1.2.3+20151212" );
+	 * var version = GetSemver( "1.2.3-alpha.1" );
+	 * var version = GetSemver( "1.2.3-alpha.beta" );
+	 * </pre>
+	 *
+	 * Here are some examples of comparing versions using Semver:
+	 *
+	 * <pre>
+	 * var version1 = GetSemver( "1.2.3" );
+	 * var version2 = GetSemver( "1.2.4" );
+	 * var version3 = GetSemver( "1.3.0" );
+	 *
+	 * version1.compare( version2 ); // -1
+	 * version1.compare( version3 ); // -1
+	 * version2.compare( version3 ); // -1
+	 * </pre>
+	 *
+	 * <p>
+	 * To use the builder you can do something like this:
+	 *
+	 * <pre>
+	 *
+	 * var version = GetSemver().withMajor( 1 ).withMinor( 2 ).withPatch( 3 ).withPreRelease( "alpha" ).toSemver();
+	 * var versionString = GetSemver().withMajor( 1 ).withMinor( 2 ).withPatch( 3 ).withPreRelease( "alpha" ).toString();
+	 * </pre>
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @argument.version The version string to parse.
+	 *
+	 * @return A Semver object
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		String version = arguments.getAsString( Key.version );
+		return ( version.isEmpty() ) ? Semver.of() : new Semver( version );
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Print.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Print.java
@@ -21,6 +21,7 @@ import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.RequestBoxContext;
+import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -48,7 +49,7 @@ public class Print extends BIF {
 	 * @argument.message The message to print
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Object obj = arguments.get( Key.message );
+		Object obj = DynamicObject.unWrap( arguments.get( Key.message ) );
 
 		// If it's a BoxLang type, let's use the string representation
 		if ( obj instanceof IType t ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Println.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Println.java
@@ -21,6 +21,7 @@ import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.RequestBoxContext;
+import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -48,7 +49,7 @@ public class Println extends BIF {
 	 * @argument.message The message to print
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Object obj = arguments.get( Key.message );
+		Object obj = DynamicObject.unWrap( arguments.get( Key.message ) );
 
 		// If it's a BoxLang type, let's use the string representation
 		if ( obj instanceof IType t ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
@@ -19,8 +19,10 @@ package ortus.boxlang.runtime.bifs.global.system;
 
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.events.BoxEvent;
+import ortus.boxlang.runtime.interceptors.Logging;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -35,9 +37,10 @@ public class WriteLog extends BIF {
 		super();
 		declaredArguments = new Argument[] {
 		    new Argument( true, "string", Key.text ),
+		    new Argument( false, "string", Key.type, Logging.DEFAULT_LOG_LEVEL ),
+		    new Argument( false, "boolean", Key.application, true ),
 		    new Argument( false, "string", Key.file ),
-		    new Argument( false, "string", Key.log, "Application" ),
-		    new Argument( false, "string", Key.type, "Information" ),
+		    new Argument( false, "string", Key.log, Logging.DEFAULT_LOG_TYPE ),
 		};
 	}
 
@@ -48,14 +51,24 @@ public class WriteLog extends BIF {
 	 * @param arguments Argument scope for the BIF.
 	 *
 	 * @argument.text The text of the log message
-	 * 
-	 * @argument.file A custom log file to write to
-	 * 
-	 * @argument.log If a custom file is not specified the log category to write to
-	 * 
+	 *
 	 * @argument.type The log level ( debug, info, warn, error )
+	 *
+	 * @argument.application If true, it logs the application name alongside the message. Default is true.
+	 *
+	 * @argument.file A custom log file to write to
+	 *
+	 * @argument.log If a custom file is not specified the log category to write to
+	 *
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		// Get the application name
+		ApplicationBoxContext appContext = context.getApplicationContext();
+		// Set the application name if not null
+		if ( appContext != null ) {
+			arguments.put( Key.application, appContext.getApplication().getName() );
+		}
+		// Announce the log message
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, arguments );
 		return null;
 	}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
@@ -22,7 +22,7 @@ import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.events.BoxEvent;
-import ortus.boxlang.runtime.interceptors.Logging;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -37,7 +37,7 @@ public class WriteLog extends BIF {
 		super();
 		declaredArguments = new Argument[] {
 		    new Argument( true, "string", Key.text ),
-		    new Argument( false, "string", Key.type, Logging.DEFAULT_LOG_LEVEL ),
+		    new Argument( false, "string", Key.type, LoggingService.DEFAULT_LOG_LEVEL ),
 		    new Argument( false, "boolean", Key.application, true ),
 		    new Argument( false, "string", Key.file ),
 		    new Argument( false, "string", Key.log )

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/WriteLog.java
@@ -40,7 +40,7 @@ public class WriteLog extends BIF {
 		    new Argument( false, "string", Key.type, Logging.DEFAULT_LOG_LEVEL ),
 		    new Argument( false, "boolean", Key.application, true ),
 		    new Argument( false, "string", Key.file ),
-		    new Argument( false, "string", Key.log, Logging.DEFAULT_LOG_TYPE ),
+		    new Argument( false, "string", Key.log )
 		};
 	}
 
@@ -52,21 +52,21 @@ public class WriteLog extends BIF {
 	 *
 	 * @argument.text The text of the log message
 	 *
-	 * @argument.type The log level ( debug, info, warn, error )
+	 * @argument.type The log level of the entry. One of "Information", "Warning", "Error", "Debug", "Trace"
 	 *
 	 * @argument.application If true, it logs the application name alongside the message. Default is true.
 	 *
-	 * @argument.file A custom log file to write to
+	 * @argument.file The log file to write to. If not specified, the default log file is used.
 	 *
-	 * @argument.log If a custom file is not specified the log category to write to
+	 * @argument.log Shortcut to a specific logfile. Available log files are: Application, Scheduler, etc. (MOVE TO CFML-COMPAT MODULE, IT'S DUMB)
 	 *
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		// Get the application name
 		ApplicationBoxContext appContext = context.getApplicationContext();
-		// Set the application name if not null
-		if ( appContext != null ) {
-			arguments.put( Key.application, appContext.getApplication().getName() );
+		// Set the application name if not null and the application argument is true
+		if ( appContext != null && arguments.getAsBoolean( Key.application ) ) {
+			arguments.put( Key.applicationName, appContext.getApplication().getName() );
 		}
 		// Announce the log message
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, arguments );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/type/Len.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/type/Len.java
@@ -20,7 +20,6 @@ import ortus.boxlang.runtime.bifs.BoxMember;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.ArrayCaster;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
-import ortus.boxlang.runtime.dynamic.casters.DateTimeCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
@@ -28,7 +27,6 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.BoxLangType;
-import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
@@ -38,13 +36,13 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 @BoxBIF( alias = "ArrayLen" )
 @BoxBIF( alias = "StringLen" )
 @BoxBIF( alias = "QueryRecordCount" )
+@BoxMember( type = BoxLangType.STRING )
 @BoxMember( type = BoxLangType.STRUCT, name = "count" )
 @BoxMember( type = BoxLangType.STRUCT, name = "len" )
+@BoxMember( type = BoxLangType.ARRAY )
+@BoxMember( type = BoxLangType.QUERY )
 @BoxMember( type = BoxLangType.DATETIME, name = "len" )
 @BoxMember( type = BoxLangType.DATE, name = "len" )
-@BoxMember( type = BoxLangType.ARRAY )
-@BoxMember( type = BoxLangType.STRING )
-@BoxMember( type = BoxLangType.QUERY )
 public class Len extends BIF {
 
 	/**
@@ -102,13 +100,10 @@ public class Len extends BIF {
 			return q.size();
 		}
 
-		if ( object instanceof DateTime dt ) {
-			return dt.toString().length();
-		}
-
-		CastAttempt<DateTime> dateTimeAttempt = DateTimeCaster.attempt( object );
-		if ( dateTimeAttempt.wasSuccessful() ) {
-			return dateTimeAttempt.get().toString().length();
+		// Dates are all handled inside the string caster, since they only have a "length" as a string
+		CastAttempt<String> stringAttempt = StringCaster.attempt( object );
+		if ( stringAttempt.wasSuccessful() ) {
+			return stringAttempt.get().length();
 		}
 
 		CastAttempt<Array> arrayAttempt = ArrayCaster.attempt( object );
@@ -119,11 +114,6 @@ public class Len extends BIF {
 		CastAttempt<IStruct> structAttempt = StructCaster.attempt( object );
 		if ( structAttempt.wasSuccessful() ) {
 			return structAttempt.get().size();
-		}
-
-		CastAttempt<String> stringAttempt = StringCaster.attempt( object );
-		if ( stringAttempt.wasSuccessful() ) {
-			return stringAttempt.get().length();
 		}
 
 		throw new BoxRuntimeException( "Cannot determine length of object of type " + object.getClass().getName() );

--- a/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
@@ -19,11 +19,11 @@ package ortus.boxlang.runtime.components.system;
 
 import java.util.Set;
 
-import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.components.Attribute;
 import ortus.boxlang.runtime.components.BoxComponent;
 import ortus.boxlang.runtime.components.Component;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.Key;
@@ -48,7 +48,7 @@ public class Dump extends Component {
 		    new Attribute( Key.top, "numeric", 0 ),
 		    new Attribute( Key.expand, "boolean" ),
 		    new Attribute( Key.abort, "any", false ),
-		    new Attribute( Key.output, "string", "buffer", Set.of( Validator.NON_EMPTY ) ),
+		    new Attribute( Key.output, "string", Set.of( Validator.NON_EMPTY ) ),
 		    new Attribute( Key.format, "string", Set.of( Validator.valueOneOf( "html", "text" ), Validator.NON_EMPTY ) ),
 		    new Attribute( Key.showUDFs, "boolean", true )
 		};
@@ -101,7 +101,7 @@ public class Dump extends Component {
 		    IntegerCaster.cast( attributes.get( Key.top ) ),
 		    attributes.getAsBoolean( Key.expand ),
 		    BooleanCaster.cast( attributes.get( Key.abort ) ),
-		    attributes.getAsString( Key.output ).toLowerCase(),
+		    attributes.getAsString( Key.output ),
 		    attributes.getAsString( Key.format ),
 		    attributes.getAsBoolean( Key.showUDFs )
 		);

--- a/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.components.system;
 
 import java.util.Set;
 
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.components.Attribute;
 import ortus.boxlang.runtime.components.BoxComponent;
 import ortus.boxlang.runtime.components.Component;
@@ -46,7 +47,7 @@ public class Dump extends Component {
 		    new Attribute( Key.label, "string", "" ),
 		    new Attribute( Key.top, "numeric", 0 ),
 		    new Attribute( Key.expand, "boolean" ),
-		    new Attribute( Key.abort, "boolean", false ),
+		    new Attribute( Key.abort, "any", false ),
 		    new Attribute( Key.output, "string", "buffer", Set.of( Validator.NON_EMPTY ) ),
 		    new Attribute( Key.format, "string", Set.of( Validator.valueOneOf( "html", "text" ), Validator.NON_EMPTY ) ),
 		    new Attribute( Key.showUDFs, "boolean", true )
@@ -87,13 +88,19 @@ public class Dump extends Component {
 	 *
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {
+		// Abort as String and empty means true <bx:dump var="" abort>
+		Object abort = attributes.get( Key.abort );
+		if ( abort instanceof String castedAbort && castedAbort.isEmpty() ) {
+			attributes.put( Key.abort, true );
+		}
+
 		DumpUtil.dump(
 		    context,
 		    DynamicObject.unWrap( attributes.get( Key.var ) ),
 		    attributes.getAsString( Key.label ),
 		    IntegerCaster.cast( attributes.get( Key.top ) ),
 		    attributes.getAsBoolean( Key.expand ),
-		    attributes.getAsBoolean( Key.abort ),
+		    BooleanCaster.cast( attributes.get( Key.abort ) ),
 		    attributes.getAsString( Key.output ).toLowerCase(),
 		    attributes.getAsString( Key.format ),
 		    attributes.getAsBoolean( Key.showUDFs )

--- a/src/main/java/ortus/boxlang/runtime/components/system/Log.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Log.java
@@ -22,8 +22,10 @@ package ortus.boxlang.runtime.components.system;
 import ortus.boxlang.runtime.components.Attribute;
 import ortus.boxlang.runtime.components.BoxComponent;
 import ortus.boxlang.runtime.components.Component;
+import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.events.BoxEvent;
+import ortus.boxlang.runtime.interceptors.Logging;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
 
@@ -39,8 +41,9 @@ public class Log extends Component {
 		declaredAttributes = new Attribute[] {
 		    new Attribute( Key.text, "string" ),
 		    new Attribute( Key.file, "string" ),
-		    new Attribute( Key.log, "string", "Application" ),
-		    new Attribute( Key.type, "string", "Information" ),
+		    new Attribute( Key.log, "string", Logging.DEFAULT_LOG_TYPE ),
+		    new Attribute( Key.type, "string", Logging.DEFAULT_LOG_LEVEL ),
+		    new Attribute( Key.application, "boolean", true )
 		};
 	}
 
@@ -53,15 +56,24 @@ public class Log extends Component {
 	 * @param executionState The execution state of the Component
 	 *
 	 * @attribute.text The text to log
-	 * 
+	 *
 	 * @attribute.file An optional explicit file to log to
-	 * 
+	 *
 	 * @attribute.log The log category to write to
-	 * 
+	 *
+	 *
+	 * @argument.application If true, it logs the application name alongside the message. Default is true.
+	 *
 	 * @attribute.type The log level of the entry. One of "Information", "Warning", "Error", "Debug", "Trace"
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {
-
+		// Get the application name
+		ApplicationBoxContext appContext = context.getApplicationContext();
+		// Set the application name if not null
+		if ( appContext != null ) {
+			attributes.put( Key.application, appContext.getApplication().getName() );
+		}
+		// Announce the log message
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, attributes );
 
 		return DEFAULT_RETURN;

--- a/src/main/java/ortus/boxlang/runtime/components/system/Log.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Log.java
@@ -25,7 +25,7 @@ import ortus.boxlang.runtime.components.Component;
 import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.events.BoxEvent;
-import ortus.boxlang.runtime.interceptors.Logging;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
 
@@ -42,7 +42,7 @@ public class Log extends Component {
 		    new Attribute( Key.text, "string" ),
 		    new Attribute( Key.file, "string" ),
 		    new Attribute( Key.log, "string" ),
-		    new Attribute( Key.type, "string", Logging.DEFAULT_LOG_LEVEL ),
+		    new Attribute( Key.type, "string", LoggingService.DEFAULT_LOG_LEVEL ),
 		    new Attribute( Key.application, "boolean", true )
 		};
 	}

--- a/src/main/java/ortus/boxlang/runtime/components/system/Log.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Log.java
@@ -41,7 +41,7 @@ public class Log extends Component {
 		declaredAttributes = new Attribute[] {
 		    new Attribute( Key.text, "string" ),
 		    new Attribute( Key.file, "string" ),
-		    new Attribute( Key.log, "string", Logging.DEFAULT_LOG_TYPE ),
+		    new Attribute( Key.log, "string" ),
 		    new Attribute( Key.type, "string", Logging.DEFAULT_LOG_LEVEL ),
 		    new Attribute( Key.application, "boolean", true )
 		};
@@ -57,25 +57,23 @@ public class Log extends Component {
 	 *
 	 * @attribute.text The text to log
 	 *
-	 * @attribute.file An optional explicit file to log to
-	 *
-	 * @attribute.log The log category to write to
-	 *
-	 *
 	 * @argument.application If true, it logs the application name alongside the message. Default is true.
 	 *
 	 * @attribute.type The log level of the entry. One of "Information", "Warning", "Error", "Debug", "Trace"
+	 *
+	 * @attribute.file The log file to write to. If not specified, the default log file is used.
+	 *
+	 * @attribute.log Shortcut to a specific logfile. Available log files are: Application, Scheduler, etc. (MOVE TO CFML-COMPAT MODULE, IT'S DUMB)
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {
 		// Get the application name
 		ApplicationBoxContext appContext = context.getApplicationContext();
 		// Set the application name if not null
-		if ( appContext != null ) {
-			attributes.put( Key.application, appContext.getApplication().getName() );
+		if ( appContext != null && attributes.getAsBoolean( Key.application ) ) {
+			attributes.put( Key.applicationName, appContext.getApplication().getName() );
 		}
 		// Announce the log message
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, attributes );
-
 		return DEFAULT_RETURN;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -637,13 +637,13 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 			targetCustom = StructUtil.toQueryString( ( IStruct ) this.properties.get( Key.custom ), delimiter );
 		}
 
-		// Incorporate URI Delimiter if it doesn't exist
-		if ( !target.contains( URIDelimiter ) ) {
-			target += URIDelimiter;
-		}
-
 		// Append the custom parameters
 		if ( targetCustom.length() > 0 ) {
+			// Incorporate URI Delimiter if it doesn't exist
+			if ( !target.contains( URIDelimiter ) ) {
+				target += URIDelimiter;
+			}
+			// Now add the custom parameters
 			target += targetCustom;
 		}
 

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -516,6 +516,10 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 		if ( this.properties.get( Key.custom ) instanceof String castedCustomParams ) {
 			this.properties.put( Key.custom, StructUtil.fromQueryString( castedCustomParams ) );
 		}
+		// Incorporate the driver's default 'custom' properties
+		IStruct customParams = this.properties.getAsStruct( Key.custom );
+		driverOrDefault.getDefaultCustomParams().entrySet().stream().forEach( entry -> customParams.putIfAbsent( entry.getKey(), entry.getValue() ) );
+		this.properties.put( Key.custom, customParams );
 
 		// Build out the JDBC URL according to the driver chosen or url chosen
 		result.setJdbcUrl( getOrBuildConnectionString( driverOrDefault ) );

--- a/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
@@ -951,7 +951,7 @@ public class BaseBoxContext implements IBoxContext {
 		if ( !force ) {
 			Boolean explicitOutput = ( Boolean ) getConfigItem( Key.enforceExplicitOutput, false );
 			if ( explicitOutput ) {
-				// If we are requiring to be in an output compo nent, let's look fo r it
+				// If we are requiring to be in an output component, let's look fo r it
 				outputState = findClosestComponent( Key.output );
 				if ( outputState == null ) {
 					return this;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Locale;
@@ -134,11 +135,18 @@ public class StringCaster implements IBoxCaster {
 		if ( object instanceof Path path ) {
 			return path.toString();
 		}
+
+		// Date classes
+
+		// This check needs to run BEFORE the next one since a java.sql.Date IS a java.util.Date, but the toInstance() method will throw an unchecked exception
+		if ( object instanceof java.sql.Date sDate ) {
+			return sDate.toString();
+		}
 		if ( object instanceof java.util.Date date ) {
-			return new DateTime( date ).toString();
+			return date.toString();
 		}
 		if ( object instanceof Instant instant ) {
-			return new DateTime( instant ).toString();
+			return instant.toString();
 		}
 		if ( object instanceof DateTime dt ) {
 			return dt.toString();
@@ -146,11 +154,31 @@ public class StringCaster implements IBoxCaster {
 		if ( object instanceof Locale lc ) {
 			return lc.toString();
 		}
-		if ( object instanceof java.util.UUID uuid ) {
-			return uuid.toString();
-		}
 		if ( object instanceof ZoneId castedZone ) {
 			return castedZone.getId();
+		}
+		if ( object instanceof LocalTime targetTimestamp ) {
+			return targetTimestamp.toString();
+		}
+		if ( object instanceof java.time.LocalDateTime targetLocalDateTime ) {
+			return targetLocalDateTime.toString();
+		}
+		if ( object instanceof java.time.LocalDate targetLocalDate ) {
+			return targetLocalDate.toString();
+		}
+		if ( object instanceof java.sql.Timestamp targetTimestamp ) {
+			return targetTimestamp.toString();
+		}
+		if ( object instanceof java.time.ZonedDateTime targetZonedDateTime ) {
+			return targetZonedDateTime.toString();
+		}
+		if ( object instanceof java.util.Calendar targetCalendar ) {
+			return targetCalendar.getTime().toString();
+		}
+		// End date classes
+
+		if ( object instanceof java.util.UUID uuid ) {
+			return uuid.toString();
 		}
 		if ( object instanceof StringBuilder sb ) {
 			return sb.toString();

--- a/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
+++ b/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
@@ -71,6 +71,8 @@ public class Logging extends BaseInterceptor {
 	 * The <code>log</code> key is a shortcut to a specific log file. Available log files are: Application, Scheduler, etc.
 	 * Which is dumb and should be moved to the CFML compatibility module. Leaving until we move it.
 	 *
+	 * TODO: Encapsulate all logic to the service for reuse
+	 *
 	 * @param data The data to be passed to the interceptor
 	 *
 	 * @throws IIllegalArgumentException If the log level is not valid

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
@@ -128,7 +128,7 @@ public final class ExecutedQuery {
 			}
 		}
 
-		IStruct	queryMeta		= Struct.of(
+		IStruct queryMeta = Struct.of(
 		    "cached", false,
 		    "cacheKey", pendingQuery.getCacheKey(),
 		    "sql", pendingQuery.getOriginalSql(),

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
@@ -21,7 +21,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -80,14 +79,6 @@ public final class ExecutedQuery {
 		this.results		= results;
 		this.generatedKey	= generatedKey;
 		this.queryMeta		= queryMeta;
-
-		// Set defaults for cache metadata, just in case they are not set.
-		this.queryMeta.putIfAbsent( Key.executionTime, 0 );
-		this.queryMeta.putIfAbsent( Key.cached, false );
-		this.queryMeta.putIfAbsent( Key.cacheKey, null );
-		this.queryMeta.putIfAbsent( Key.cacheProvider, null );
-		this.queryMeta.computeIfAbsent( Key.cacheTimeout, key -> Duration.ZERO );
-		this.queryMeta.computeIfAbsent( Key.cacheLastAccessTimeout, key -> Duration.ZERO );
 
 		// important that we set the metadata on the Query object for later getBoxMeta(), i.e. $bx.meta calls.
 		this.results.setMetadata( this.queryMeta );

--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -41,6 +41,7 @@ import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
 import ortus.boxlang.runtime.types.util.ListUtil;
@@ -298,7 +299,7 @@ public class PendingQuery {
 			logger.debug( "Checking cache for query: {}", this.cacheKey );
 			Attempt<Object> cachedQuery = cacheProvider.get( this.cacheKey );
 			if ( cachedQuery.isPresent() ) {
-				return respondWithCachedQuery( cachedQuery );
+				return respondWithCachedQuery( (ExecutedQuery) cachedQuery.get() );
 			}
 			logger.debug( "Query is NOT present, continuing to execute query: {}", this.cacheKey );
 		}
@@ -329,7 +330,7 @@ public class PendingQuery {
 			// we use separate get() and set() calls over a .getOrSet() so we can run `.setIsCached()` on discovered/cached results.
 			Attempt<Object> cachedQuery = this.cacheProvider.get( this.cacheKey );
 			if ( cachedQuery.isPresent() ) {
-				return respondWithCachedQuery( cachedQuery );
+				return respondWithCachedQuery( (ExecutedQuery) cachedQuery.get() );
 			}
 
 			ExecutedQuery executedQuery = executeStatement( connection );
@@ -405,7 +406,7 @@ public class PendingQuery {
 	 * <p>
 	 * This method assumes cachedQuery.isPresent() has already been checked, and populates the ExecutedQuery instance with the query cache metadata, such as cacheKey, cacheProvider, etc.
 	 */
-	private ExecutedQuery respondWithCachedQuery( Attempt<Object> cachedQuery ) {
+	private ExecutedQuery respondWithCachedQuery( ExecutedQuery cachedQuery ) {
 		logger.debug( "Query is present, returning cached result: {}", this.cacheKey );
 		IStruct cacheMeta = Struct.of(
 		    "cached", true,
@@ -414,7 +415,11 @@ public class PendingQuery {
 		    "cacheTimeout", this.queryOptions.cacheTimeout,
 		    "cacheLastAccessTimeout", this.queryOptions.cacheLastAccessTimeout
 		);
-		return ExecutedQuery.fromCachedQuery( ( ExecutedQuery ) cachedQuery.get(), cacheMeta );
+		Query results = cachedQuery.getResults();
+		Struct queryMeta = new Struct( cachedQuery.getQueryMeta() );
+		queryMeta.addAll( cacheMeta );
+		results.setMetadata( queryMeta );
+		return new ExecutedQuery( results, cachedQuery.getGeneratedKey() );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/jdbc/drivers/GenericJDBCDriver.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/drivers/GenericJDBCDriver.java
@@ -248,7 +248,12 @@ public class GenericJDBCDriver implements IJDBCDriver {
 
 		// If the custom parameters are a string, convert them to a struct
 		if ( config.properties.get( Key.custom ) instanceof String castedParams ) {
-			config.properties.put( Key.custom, StructUtil.fromQueryString( castedParams, getDefaultDelimiter() ) );
+			String parseDelimiter = getDefaultDelimiter();
+			if ( !castedParams.contains( parseDelimiter ) && !parseDelimiter.equals( "&" ) ) {
+				// No custom delimiter found; the custom parameters are probably ampersand-separated
+				parseDelimiter = "&";
+			}
+			config.properties.put( Key.custom, StructUtil.fromQueryString( castedParams, parseDelimiter ) );
 		}
 
 		// Add all the custom parameters to the params struct

--- a/src/main/java/ortus/boxlang/runtime/jdbc/drivers/IJDBCDriver.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/drivers/IJDBCDriver.java
@@ -60,4 +60,27 @@ public interface IJDBCDriver {
 	 * Get default custom parameters for the driver to incorporate into the datasource config
 	 */
 	public IStruct getDefaultCustomParams();
+
+	/**
+	 * Get the default URI delimiter
+	 */
+	public String getDefaultURIDelimiter();
+
+	/**
+	 * Get the default custom params delimiter
+	 */
+	public String getDefaultDelimiter();
+
+	/**
+	 * This helper method is used to convert the custom parameters in the config (Key.custom)
+	 * to a query string that can be used by the driver to build the connection URL.
+	 * <p>
+	 * We incorporate the default parameters into the custom parameters and return the query string
+	 * using the driver's default delimiter.
+	 *
+	 * @param config The datasource config
+	 *
+	 * @return The custom parameters as a query string
+	 */
+	public String customParamsToQueryString( DatasourceConfig config );
 }

--- a/src/main/java/ortus/boxlang/runtime/logging/LogLevel.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LogLevel.java
@@ -30,6 +30,7 @@ import ortus.boxlang.runtime.scopes.Key;
  */
 public class LogLevel {
 
+	// Standard Logging Libraries log levels.
 	public static final Key	OFF		= Key.of( "off" );
 	public static final Key	FATAL	= Key.of( "fatal" );
 	public static final Key	ERROR	= Key.of( "error" );
@@ -37,10 +38,9 @@ public class LogLevel {
 	public static final Key	INFO	= Key.of( "info" );
 	public static final Key	DEBUG	= Key.of( "debug" );
 	public static final Key	TRACE	= Key.of( "trace" );
-	public static final Key	ALL		= Key.of( "all" );
 
 	/**
-	 * Convert a string to a LogLevel Key
+	 * Convert a human-readable log level to a LogLevel Key
 	 *
 	 * @param level The string to convert into a LogLevel Key
 	 * @param safe  If true, then it will return null instead of the exception
@@ -68,8 +68,6 @@ public class LogLevel {
 				return DEBUG;
 			case "trace" :
 				return TRACE;
-			case "all" :
-				return ALL;
 			default : {
 				if ( safe ) {
 					return null;
@@ -94,7 +92,7 @@ public class LogLevel {
 	 * @return The levels as an array of keys
 	 */
 	public static Key[] getLevels() {
-		return new Key[] { OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL };
+		return new Key[] { OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE };
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingConfigurator.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingConfigurator.java
@@ -17,8 +17,6 @@
  */
 package ortus.boxlang.runtime.logging;
 
-import org.slf4j.LoggerFactory;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -112,9 +110,9 @@ public class LoggingConfigurator extends LoggerContextAwareBase implements Confi
 	 */
 	public static void reconfigureDebugMode( Boolean debugMode ) {
 		// Get root Logger from the logger context and set the log level to DEBUG
-		Level	logLevel	= Boolean.TRUE.equals( debugMode ) ? Level.DEBUG : Level.INFO;
-		Logger	rootLogger	= ( Logger ) LoggerFactory.getLogger( Logger.ROOT_LOGGER_NAME );
-		rootLogger.setLevel( logLevel );
+		Level logLevel = Boolean.TRUE.equals( debugMode ) ? Level.DEBUG : Level.INFO;
+		// rootLogger = ( Logger ) LoggerFactory.getLogger( Logger.ROOT_LOGGER_NAME );
+		// rootLogger.setLevel( logLevel );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -17,6 +17,8 @@
  */
 package ortus.boxlang.runtime.logging;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -242,11 +244,50 @@ public class LoggingService {
 	}
 
 	/**
+	 * Verify if we have the passed in filePath appender
+	 *
+	 * @return True if the appender exists, false otherwise
+	 */
+	public boolean hasAppender( String filePath ) {
+		return this.appendersMap.containsKey( filePath.toLowerCase() );
+	}
+
+	/**
+	 * Remove the appender from the cache using the file path
+	 *
+	 * @param filePath The file path to remove the appender for
+	 *
+	 * @return True if the appender was removed, false otherwise
+	 */
+	public boolean removeAppender( String filePath ) {
+		return this.appendersMap.remove( filePath.toLowerCase() ) != null;
+	}
+
+	/**
+	 * Get a list of all registered file appenders
+	 *
+	 * @return The list of appenders
+	 */
+	public List<String> getAppendersList() {
+		return new ArrayList<>( this.appendersMap.keySet() );
+	}
+
+	/**
+	 * Shutdown all the appenders
+	 *
+	 * @return The logging service
+	 */
+	public LoggingService shutdownAppenders() {
+		this.appendersMap.values().forEach( FileAppender::stop );
+		return instance;
+	}
+
+	/**
 	 * Shutdown the logging service
 	 */
 	public LoggingService shutdown() {
 		// Shutdown all the appenders
-		this.appendersMap.values().forEach( FileAppender::stop );
+		shutdownAppenders();
 		return instance;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -1,0 +1,5 @@
+package ortus.boxlang.runtime.logging;
+
+public class LoggingService {
+
+}

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -1,5 +1,253 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ortus.boxlang.runtime.logging;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.FileAppender;
+import ortus.boxlang.runtime.BoxRuntime;
+
+/**
+ * This service allows BoxLang to leverage logging facilities and interact with the logging system.
+ * <p>
+ * It also manages all custom logging events, appenders and loggers.
+ * <p>
+ * It's not a true BoxLang service, due to the chicken and egg problem of logging being needed before the runtime starts.
+ */
 public class LoggingService {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Public Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	public static final String							DEFAULT_LOG_LEVEL		= "info";
+	public static final String							DEFAULT_LOG_TYPE		= "Application";
+	public static final String							DEFAULT_LOG_CATEGORY	= "boxruntime";
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Private Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	private static LoggingService						instance;
+
+	/**
+	 * The linked runtime
+	 */
+	private BoxRuntime									runtime;
+
+	/**
+	 * The logging configuration for the runtime
+	 * This is set by the first call to `getLogger()` which happens in the
+	 *
+	 * <pre>
+	 * startup()
+	 * </pre>
+	 */
+	private LoggingConfigurator							loggingConfigurator;
+
+	/**
+	 * The root logger for the runtime
+	 */
+	private Logger										rootLogger;
+
+	/**
+	 * The BoxLang pattern encoder we use for logging
+	 */
+	private PatternLayoutEncoder						encoder;
+
+	/**
+	 * A map of appenders
+	 */
+	private Map<String, FileAppender<ILoggingEvent>>	appendersMap			= new ConcurrentHashMap<>();
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Constructors
+	 * --------------------------------------------------------------------------
+	 */
+
+	private LoggingService( BoxRuntime runtime ) {
+		// Private constructor to prevent instantiation
+		this.runtime = runtime;
+	}
+
+	/**
+	 * Get the singleton instance of the LoggingService and initializing it with the runtime
+	 * This is called by the Runtime only!
+	 *
+	 * @return The LoggingService instance
+	 */
+	public static LoggingService getInstance( BoxRuntime runtime ) {
+		if ( instance == null ) {
+			synchronized ( LoggingService.class ) {
+				if ( instance == null ) {
+					instance = new LoggingService( runtime );
+				}
+			}
+		}
+		return instance;
+	}
+
+	/**
+	 * Get the singleton instance of the LoggingService
+	 *
+	 * @throws IllegalStateException If the LoggingService has not been initialized yet
+	 *
+	 * @return The LoggingService instance
+	 */
+	public static LoggingService getInstance() {
+		// Check if null and throw an exception
+		if ( instance == null ) {
+			throw new IllegalStateException( "LoggingService has not been initialized yet" );
+		}
+		return instance;
+	}
+
+	/**
+	 * Get the configured Logging Configurator for the runtime
+	 *
+	 * @return The Configurator
+	 */
+	public LoggingConfigurator getLoggingConfigurator() {
+		return this.loggingConfigurator;
+	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Get the root logger
+	 *
+	 * @return The root logger
+	 */
+	public Logger getRootLogger() {
+		return this.rootLogger;
+	}
+
+	/**
+	 * Set the root logger
+	 *
+	 * @param logger The logger to set
+	 *
+	 * @return The logging service
+	 */
+	public LoggingService setRootLogger( Logger logger ) {
+		this.rootLogger = logger;
+		return instance;
+	}
+
+	/**
+	 * Get the BoxLang pattern encoder
+	 *
+	 * @return The encoder
+	 */
+	public PatternLayoutEncoder getEncoder() {
+		return this.encoder;
+	}
+
+	/**
+	 * Store the BoxLang pattern encoder
+	 *
+	 * @param encoder The encoder to store
+	 *
+	 * @return LoggingService
+	 */
+	public LoggingService setEncoder( PatternLayoutEncoder encoder ) {
+		this.encoder = encoder;
+		return instance;
+	}
+
+	/**
+	 * Set the Logging Configurator
+	 *
+	 * @param configurator The configurator to set
+	 *
+	 * @return The Runtime
+	 */
+	public LoggingService setLoggingConfigurator( LoggingConfigurator configurator ) {
+		this.loggingConfigurator = configurator;
+		return instance;
+	}
+
+	/**
+	 * Enable debug mode for the runtime's root logger or not.
+	 *
+	 * This is usually a convenience method for the runtime to enable or disable
+	 * debug mode
+	 * via configuration overrides
+	 *
+	 * @param debugMode True to enable debug mode, false to disable
+	 */
+	public LoggingService reconfigureDebugMode( Boolean debugMode ) {
+		this.rootLogger.setLevel( Boolean.TRUE.equals( debugMode ) ? Level.DEBUG : Level.INFO );
+		return instance;
+	}
+
+	/**
+	 * Get the runtime's log directory as per the configuration
+	 */
+	public String getLogsDirectory() {
+		return this.runtime.getConfiguration().logsDirectory;
+	}
+
+	/**
+	 * Get the requested file appender according to log location
+	 *
+	 * @param filePath   The file path to get the appender for
+	 * @param logContext The logger context requested for the appender
+	 * @param logger     The logger to add the appender to
+	 *
+	 * @return The file appender, computed or from cache
+	 */
+	public FileAppender<ILoggingEvent> getOrBuildAppender( String filePath, LoggerContext logContext ) {
+		return this.appendersMap.computeIfAbsent( filePath.toLowerCase(), key -> {
+			var appender = new FileAppender<ILoggingEvent>();
+			appender.setFile( filePath );
+			appender.setEncoder( getEncoder() );
+			appender.setContext( logContext );
+			appender.setAppend( true );
+			appender.setImmediateFlush( true );
+			appender.setPrudent( true );
+			appender.start();
+			return appender;
+		} );
+	}
+
+	/**
+	 * Shutdown the logging service
+	 */
+	public LoggingService shutdown() {
+		// Shutdown all the appenders
+		this.appendersMap.values().forEach( FileAppender::stop );
+		return instance;
+	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -254,11 +254,15 @@ public class ModuleRecord {
 		Path	directoryPath	= Path.of( physicalPath );
 		Path	boxjsonPath		= directoryPath.resolve( MODULE_CONFIG_FILE );
 
+		// Load the module name from the box.json file if it exists
 		if ( Files.exists( boxjsonPath ) ) {
 			DataNavigator
 			    .of( boxjsonPath )
 			    .from( "boxlang" )
-			    .ifPresent( "moduleName", value -> this.name = Key.of( value ) );
+			    .ifPresent( "moduleName", value -> this.name = Key.of( value ) )
+			    .ifPresent( "minimumVersion",
+			        value -> BoxRuntime.getInstance().getModuleService().verifyModuleAndBoxLangVersion( ( String ) value, directoryPath )
+			    );
 		}
 
 		// Default to the directory name if the box.json file does not exist

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -43,9 +43,13 @@ import ortus.boxlang.runtime.bifs.BIFDescriptor;
 import ortus.boxlang.runtime.bifs.BoxLangBIFProxy;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
 import ortus.boxlang.runtime.cache.providers.ICacheProvider;
+import ortus.boxlang.runtime.components.BoxLangComponentProxy;
 import ortus.boxlang.runtime.components.Component;
+import ortus.boxlang.runtime.components.Component.ComponentBody;
+import ortus.boxlang.runtime.components.ComponentDescriptor;
 import ortus.boxlang.runtime.config.segments.ModuleConfig;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.events.IInterceptor;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.jdbc.drivers.DriverShim;
@@ -53,6 +57,7 @@ import ortus.boxlang.runtime.jdbc.drivers.IJDBCDriver;
 import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.runnables.RunnableLoader;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.ThisScope;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -63,6 +68,7 @@ import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.services.ModuleService;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.DynamicFunction;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
@@ -147,6 +153,11 @@ public class ModuleRecord {
 	 * The BIFS collaborated by the module
 	 */
 	public Array				bifs						= new Array();
+
+	/**
+	 * The Components collaborated by the module
+	 */
+	public Array				components					= new Array();
 
 	/**
 	 * The member Methods collaborated by the module
@@ -429,11 +440,19 @@ public class ModuleRecord {
 		// Register BoxLang Bifs if they exist
 		Path bifsPath = this.physicalPath.resolve( ModuleService.MODULE_BIFS );
 		if ( Files.exists( bifsPath ) && Files.isDirectory( bifsPath ) ) {
-
 			// Iterate over all files *.cfc/bx and register them
 			// These are the BoxLang Bifs
 			for ( File targetFile : bifsPath.toFile().listFiles() ) {
 				registerBIF( targetFile, context );
+			}
+		}
+
+		// Register BoxLang Components if they exists
+		Path componentPaths = this.physicalPath.resolve( ModuleService.MODULE_COMPONENTS );
+		if ( Files.exists( componentPaths ) && Files.isDirectory( componentPaths ) ) {
+			// Iterate over all files *.cfc/bx and register them
+			for ( File targetFile : componentPaths.toFile().listFiles() ) {
+				registerComponent( targetFile, context );
 			}
 		}
 
@@ -495,259 +514,6 @@ public class ModuleRecord {
 		this.registeredOn = Instant.now();
 
 		return this;
-	}
-
-	/**
-	 * Register a BIF with the runtime
-	 *
-	 * @param targetFile The target file to register that represents the BIF on disk
-	 * @param context    The current context of execution
-	 *
-	 * @return The ModuleRecord
-	 */
-	private ModuleRecord registerBIF( File targetFile, IBoxContext context ) {
-		// System.out.println( "Processing " + targetFile.getAbsolutePath() );
-
-		// Skip directories and non CFC/BX files
-		// We are not doing recursive registration for the moment.
-		if ( targetFile.isDirectory() || !targetFile.getName().matches( "^.*\\.(cfc|bx)$" ) ) {
-			return this;
-		}
-
-		// Nice References
-		BoxRuntime			runtime				= BoxRuntime.getInstance();
-		FunctionService		functionService		= runtime.getFunctionService();
-		InterceptorService	interceptorService	= runtime.getInterceptorService();
-
-		// Try to load the BoxLang class
-		Key					className			= Key.of( FilenameUtils.getBaseName( targetFile.getAbsolutePath() ) );
-		IClassRunnable		oBIF				= ( IClassRunnable ) DynamicObject.of(
-		    RunnableLoader.getInstance().loadClass(
-		        ResolvedFilePath.of(
-		            null,
-		            null,
-		            ( this.invocationPath + "." + ModuleService.MODULE_BIFS ).replaceAll( "\\.", Matcher.quoteReplacement( File.separator ) ) + File.separator
-		                + FilenameUtils.getBaseName( targetFile.getAbsolutePath() ),
-		            targetFile.toPath()
-		        ),
-		        context
-		    )
-		).invokeConstructor( context )
-		    .getTargetInstance();
-
-		/*
-		 * --------------------------------------------------------------------------
-		 * DI Injections
-		 * --------------------------------------------------------------------------
-		 * Inject the following references into the BoxLang BIF
-		 * - boxRuntime : BoxLangRuntime
-		 * - log : A logger
-		 * - functionService : The BoxLang FunctionService
-		 * - interceptorService : The BoxLang InterceptorService
-		 * - moduleRecord : The ModuleRecord instance
-		 */
-
-		oBIF.getVariablesScope().put( Key.moduleRecord, this );
-		oBIF.getVariablesScope().put( Key.boxRuntime, runtime );
-		oBIF.getVariablesScope().put( Key.functionService, functionService );
-		oBIF.getVariablesScope().put( Key.interceptorService, interceptorService );
-		oBIF.getVariablesScope().put( Key.log, LoggerFactory.getLogger( oBIF.getClass() ) );
-
-		/*
-		 * --------------------------------------------------------------------------
-		 * BIF Registration
-		 * --------------------------------------------------------------------------
-		 */
-		BIFDescriptor	bifDescriptor	= new BIFDescriptor(
-		    className,
-		    oBIF.getClass(),
-		    this.name.getName(),
-		    null,
-		    true,
-		    new BoxLangBIFProxy( oBIF )
-		);
-		Key[]			bifAliases		= buildBIFAliases( oBIF, className );
-		for ( Key bifAlias : bifAliases ) {
-			// Register the mapping in the runtime
-			functionService.registerGlobalFunction(
-			    bifDescriptor,
-			    bifAlias,
-			    true
-			);
-			logger.info(
-			    "> Registered Module [{}] BIF [{}] with alias [{}]",
-			    this.name.getName(),
-			    className.getName(),
-			    bifAlias.getName()
-			);
-			this.bifs.push( bifAlias );
-		}
-
-		/*
-		 * --------------------------------------------------------------------------
-		 * BIF Member Method(s) Registration
-		 * --------------------------------------------------------------------------
-		 */
-		Array bifMemberMethods = discoverMemberMethods( oBIF, className );
-		for ( Object memberMethod : bifMemberMethods ) {
-			Key			memberKey		= Key.of( ( ( IStruct ) memberMethod ).getAsString( Key._NAME ) );
-			BoxLangType	memberType		= ( BoxLangType ) ( ( IStruct ) memberMethod ).get( Key.type );
-			String		objectArgument	= ( ( IStruct ) memberMethod ).getAsString( Key.objectArgument );
-
-			// Call to register
-			functionService.registerMemberMethod(
-			    memberKey,
-			    new MemberDescriptor(
-			        memberKey,
-			        memberType,
-			        java.lang.Object.class,
-			        // Pass null if objectArgument is empty
-			        objectArgument.isEmpty() ? null : Key.of( objectArgument ),
-			        bifDescriptor
-			    )
-			);
-			logger.info(
-			    "> Registered Module [{}] MemberMethod [{}]",
-			    this.name.getName(),
-			    memberMethod
-			);
-			this.memberMethods.push( memberMethod );
-		}
-
-		return this;
-	}
-
-	/**
-	 * Discover member methods by getting the {@code BoxMember} annotation on the Class.
-	 *
-	 * @param targetBIF The target BIF to discover member methods for
-	 * @param className The class name of the BIF
-	 *
-	 * @return An array of member methods for the BIF: {@code [ { name : "", objectArgument: "", type : BoxLangType } ] }
-	 */
-	private Array discoverMemberMethods( IClassRunnable targetBIF, Key className ) {
-		// Get the BoxMember annotation
-		Object boxMembers = targetBIF.getBoxMeta().getMeta().getAsStruct( Key.annotations ).getOrDefault( Key.boxMember, null );
-
-		// System.out.println( className.getName() + " BoxMembers Found [" + boxMembers + "]" );
-
-		// Case 0: If null, then we don't have any :)
-		if ( boxMembers == null ) {
-			return new Array();
-		}
-
-		// Case 1 : This is a simple String with no value, throw an exception
-		// @BoxMember
-		if ( boxMembers instanceof String castedBoxMember && castedBoxMember.isBlank() ) {
-			throw new BoxRuntimeException( className.getName() + " BoxMember annotation is missing it's type value, which is mandatory" );
-		}
-
-		// Case 2 : This is a simple String with a value which is the type. Validate it, default it's record and return it
-		// ClassName : ArrayFoo
-		// @BoxMember "array" -> { "name": "foo", "objectArgument": null, type: BoxLangType.ARRAY }
-		if ( boxMembers instanceof String castedBoxMember && !castedBoxMember.isBlank() ) {
-			// Validate the type is valid else throw an exception
-			if ( !BoxLangType.isValid( castedBoxMember ) ) {
-				throw new BoxRuntimeException(
-				    className.getName() + " BoxMember annotation has an invalid type value [" + castedBoxMember + "]" +
-				        "Valid types are: " + Arrays.toString( BoxLangType.values() )
-				);
-			}
-			BoxLangType boxType = BoxLangType.valueOf( castedBoxMember.toUpperCase() );
-			return Array.of(
-			    Struct.of(
-			        // Default member name for class ArrayFoo with BoxType of Array is just foo()
-			        Key._NAME, className.getNameNoCase().replaceAll( boxType.getKey().getNameNoCase(), "" ),
-			        Key.objectArgument, "",
-			        Key.type, boxType
-			    )
-			);
-		}
-
-		// Case 3 : We have a struct of member methods, validate them and return them
-		// @BoxMember { "string": { "name": "append", "objectArgument": "string" } }
-		if ( boxMembers instanceof IStruct castedBoxMember ) {
-			Array result = new Array();
-
-			// Iterate over all entries and validate them
-			for ( IStruct.Entry<Key, ?> entry : castedBoxMember.entrySet() ) {
-				// Validate Type first which is the key of the entry
-				Key type = entry.getKey();
-				if ( !BoxLangType.isValid( type ) ) {
-					throw new BoxRuntimeException(
-					    className.getName() + " BoxMember annotation has an invalid type value [" + type.getName() + "]" +
-					        "Valid types are: " + Arrays.toString( BoxLangType.values() )
-					);
-				}
-
-				// Now the value of this key must be a struct with the following keys: name, objectArgument
-				// Validate the value is a struct
-				if ( ! ( entry.getValue() instanceof IStruct memberRecord ) ) {
-					throw new BoxRuntimeException(
-					    className.getName() + " BoxMember annotation value must be a struct with the following keys: [name], [objectArgument]"
-					);
-				}
-
-				// Prepare the record now
-				BoxLangType boxType = BoxLangType.valueOf( type.getNameNoCase() );
-				memberRecord.put( Key.type, boxType );
-				memberRecord.computeIfAbsent( Key._NAME, k -> className.getNameNoCase().replaceAll( type.getNameNoCase(), "" )
-				);
-				memberRecord.putIfAbsent( Key.objectArgument, "" );
-				result.push( memberRecord );
-			}
-
-			return result;
-		}
-
-		// Who knows what this is, just return an empty struct
-		return new Array();
-	}
-
-	/**
-	 * Build an array of Key aliases for the BIF based on the following rules:
-	 * - If the BIF has any `BoxBIF` annoations that have a value, use those
-	 * - If the BIF has any `BoxBIF` annoations that have no value, use the BIF name
-	 *
-	 * {@code
-	 * // No value : use the class name
-	 * @BoxBIF
-	 * // Use the MyBif value as a simple string
-	 *
-	 * @BoxBIF "MyBif"
-	 *         // Use the array of aliases
-	 * @BoxBIF [ "bif1", "bif2"]
-	 *         }
-	 *
-	 * @param targetBIF The target BIF to build aliases for
-	 * @param className The class name of the BIF
-	 *
-	 * @return An array of Key aliases for the BIF
-	 */
-	private Key[] buildBIFAliases( IClassRunnable targetBIF, Key className ) {
-		// Get the BoxBIF annotation
-		Object boxBifAnnotation = targetBIF.getBoxMeta().getMeta().getAsStruct( Key.annotations ).getOrDefault( Key.boxBif, "" );
-
-		// Case 1 : This is a simple String with no value, just return
-		if ( boxBifAnnotation instanceof String castedAnnotation && castedAnnotation.isBlank() ) {
-			return new Key[] { className };
-		}
-
-		// Case 2 : This is a simple String with a value, return the value as the alias instead of the name of the file on disk
-		if ( boxBifAnnotation instanceof String castedAnnotationWithValue && !castedAnnotationWithValue.isBlank() ) {
-			return new Key[] {
-			    Key.of( castedAnnotationWithValue )
-			};
-		}
-
-		// Case 3 : We have an Array of aliases, and they have values, return them alongside the class name
-		if ( boxBifAnnotation instanceof Array castedAliases ) {
-			// convert the values in the array to Keys
-			return castedAliases.push( className ).stream().map( Key::of ).toArray( Key[]::new );
-		}
-
-		// Default : Just return the class name
-		return new Key[] { className };
 	}
 
 	/**
@@ -916,7 +682,7 @@ public class ModuleRecord {
 		);
 	}
 
-	/*
+	/**
 	 * --------------------------------------------------------------------------
 	 * Getters
 	 * --------------------------------------------------------------------------
@@ -973,6 +739,365 @@ public class ModuleRecord {
 		    "version", version,
 		    "webURL", webURL
 		);
+	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Private Helpers
+	 * --------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Register a BoxLang based Component with the runtime
+	 *
+	 * @param targetFile The target file to register that represents the Component on disk
+	 * @param context    The current context of execution
+	 *
+	 * @return The ModuleRecord
+	 */
+	private ModuleRecord registerComponent( File targetFile, IBoxContext context ) {
+		// System.out.println( "Processing component: " + targetFile.getAbsolutePath() );
+
+		// Skip directories and non CFC/BX files
+		// We are not doing recursive registration for the moment.
+		if ( targetFile.isDirectory() || !targetFile.getName().matches( "^.*\\.(cfc|bx)$" ) ) {
+			return this;
+		}
+
+		// Nice References
+		BoxRuntime				runtime				= BoxRuntime.getInstance();
+		ComponentService		componentService	= runtime.getComponentService();
+		// Try to load the BoxLang class and proxy
+		Key						className			= Key.of( FilenameUtils.getBaseName( targetFile.getAbsolutePath() ) );
+		IClassRunnable			oComponent			= loadClassRunnable( targetFile, ModuleService.MODULE_COMPONENTS, context );
+		BoxLangComponentProxy	oComponentProxy		= new BoxLangComponentProxy( oComponent );
+		oComponentProxy.setName( className );
+
+		// Inject some helpers
+		oComponent.getVariablesScope().put( Key.newBuffer, new DynamicFunction(
+		    Key.newBuffer,
+		    ( context1, fnc ) -> new StringBuffer()
+		) );
+		oComponent.getVariablesScope().put( Key.newBuilder, new DynamicFunction(
+		    Key.newBuilder,
+		    ( context1, fnc ) -> new StringBuilder()
+		) );
+
+		// ProcessBody Delegate
+		oComponent.getVariablesScope().put( Key.processBody, new DynamicFunction(
+		    Key.processBody,
+		    ( context1, fnc ) -> {
+			    ArgumentsScope args	= context1.getArgumentsScope();
+			    Object		buffer	= args.get( "buffer" );
+
+			    return oComponentProxy.processBody(
+			        ( IBoxContext ) args.get( "context" ),
+			        ( ComponentBody ) args.get( "body" ),
+			        buffer instanceof StringBuffer ? ( StringBuffer ) buffer : new StringBuffer()
+			    );
+		    }
+		) );
+		// Get Name Delegate
+		oComponent.getVariablesScope().put( Key.getName, new DynamicFunction(
+		    Key.getName,
+		    ( context1, fnc ) -> oComponent.getName()
+		) );
+
+		/**
+		 * --------------------------------------------------------------------------
+		 * Component Registration
+		 * --------------------------------------------------------------------------
+		 */
+
+		IStruct				annotations			= oComponent.getBoxMeta().getMeta().getAsStruct( Key.annotations );
+		ComponentDescriptor	descriptor			= new ComponentDescriptor(
+		    oComponent.getName(),
+		    oComponent.getClass(),
+		    this.name.getName(),
+		    null,
+		    oComponentProxy,
+		    BooleanCaster.cast( annotations.getOrDefault( "AllowsBody", false ) ),
+		    BooleanCaster.cast( annotations.getOrDefault( "RequiresBody", false ) )
+		);
+		Key[]				componentAliases	= buildAnnotationAliases( oComponent, className, Key.boxComponent );
+		System.out.println( "Component Aliases: " + Arrays.toString( componentAliases ) );
+
+		// Register all components with their aliases
+		for ( Key thisAlias : componentAliases ) {
+			componentService.registerComponent( descriptor, thisAlias, true );
+			logger.info(
+			    "> Registered Module [{}] Component [{}] with alias [{}]",
+			    this.name.getName(),
+			    className.getName(),
+			    thisAlias.getName()
+			);
+			this.components.push( thisAlias );
+		}
+
+		return this;
+	}
+
+	/**
+	 * Register a BoxLang based BIF with the runtime
+	 *
+	 * @param targetFile The target file to register that represents the BIF on disk
+	 * @param context    The current context of execution
+	 *
+	 * @return The ModuleRecord
+	 */
+	private ModuleRecord registerBIF( File targetFile, IBoxContext context ) {
+		// System.out.println( "Processing BIF: " + targetFile.getAbsolutePath() );
+
+		// Skip directories and non CFC/BX files
+		// We are not doing recursive registration for the moment.
+		if ( targetFile.isDirectory() || !targetFile.getName().matches( "^.*\\.(cfc|bx)$" ) ) {
+			return this;
+		}
+
+		// Nice References
+		BoxRuntime		runtime			= BoxRuntime.getInstance();
+		FunctionService	functionService	= runtime.getFunctionService();
+		// Try to load the BoxLang class
+		Key				className		= Key.of( FilenameUtils.getBaseName( targetFile.getAbsolutePath() ) );
+		IClassRunnable	oBIF			= loadClassRunnable( targetFile, ModuleService.MODULE_BIFS, context );
+
+		/**
+		 * --------------------------------------------------------------------------
+		 * BIF Registration
+		 * --------------------------------------------------------------------------
+		 */
+		BIFDescriptor	bifDescriptor	= new BIFDescriptor(
+		    className,
+		    oBIF.getClass(),
+		    this.name.getName(),
+		    null,
+		    true,
+		    new BoxLangBIFProxy( oBIF )
+		);
+		Key[]			bifAliases		= buildAnnotationAliases( oBIF, className, Key.boxBif );
+		for ( Key bifAlias : bifAliases ) {
+			// Register the mapping in the runtime
+			functionService.registerGlobalFunction(
+			    bifDescriptor,
+			    bifAlias,
+			    true
+			);
+			logger.info(
+			    "> Registered Module [{}] BIF [{}] with alias [{}]",
+			    this.name.getName(),
+			    className.getName(),
+			    bifAlias.getName()
+			);
+			this.bifs.push( bifAlias );
+		}
+
+		/**
+		 * --------------------------------------------------------------------------
+		 * BIF Member Method(s) Registration
+		 * --------------------------------------------------------------------------
+		 */
+		Array bifMemberMethods = discoverMemberMethods( oBIF, className );
+		for ( Object memberMethod : bifMemberMethods ) {
+			Key			memberKey		= Key.of( ( ( IStruct ) memberMethod ).getAsString( Key._NAME ) );
+			BoxLangType	memberType		= ( BoxLangType ) ( ( IStruct ) memberMethod ).get( Key.type );
+			String		objectArgument	= ( ( IStruct ) memberMethod ).getAsString( Key.objectArgument );
+
+			// Call to register
+			functionService.registerMemberMethod(
+			    memberKey,
+			    new MemberDescriptor(
+			        memberKey,
+			        memberType,
+			        java.lang.Object.class,
+			        // Pass null if objectArgument is empty
+			        objectArgument.isEmpty() ? null : Key.of( objectArgument ),
+			        bifDescriptor
+			    )
+			);
+			logger.info(
+			    "> Registered Module [{}] MemberMethod [{}]",
+			    this.name.getName(),
+			    memberMethod
+			);
+			this.memberMethods.push( memberMethod );
+		}
+
+		return this;
+	}
+
+	/**
+	 * Discover member methods by getting the {@code BoxMember} annotation on the Class.
+	 *
+	 * @param targetBIF The target BIF to discover member methods for
+	 * @param className The class name of the BIF
+	 *
+	 * @return An array of member methods for the BIF: {@code [ { name : "", objectArgument: "", type : BoxLangType } ] }
+	 */
+	private Array discoverMemberMethods( IClassRunnable targetBIF, Key className ) {
+		// Get the BoxMember annotation
+		Object boxMembers = targetBIF.getBoxMeta().getMeta().getAsStruct( Key.annotations ).getOrDefault( Key.boxMember, null );
+
+		// System.out.println( className.getName() + " BoxMembers Found [" + boxMembers + "]" );
+
+		// Case 0: If null, then we don't have any :)
+		if ( boxMembers == null ) {
+			return new Array();
+		}
+
+		// Case 1 : This is a simple String with no value, throw an exception
+		// @BoxMember
+		if ( boxMembers instanceof String castedBoxMember && castedBoxMember.isBlank() ) {
+			throw new BoxRuntimeException( className.getName() + " BoxMember annotation is missing it's type value, which is mandatory" );
+		}
+
+		// Case 2 : This is a simple String with a value which is the type. Validate it, default it's record and return it
+		// ClassName : ArrayFoo
+		// @BoxMember "array" -> { "name": "foo", "objectArgument": null, type: BoxLangType.ARRAY }
+		if ( boxMembers instanceof String castedBoxMember && !castedBoxMember.isBlank() ) {
+			// Validate the type is valid else throw an exception
+			if ( !BoxLangType.isValid( castedBoxMember ) ) {
+				throw new BoxRuntimeException(
+				    className.getName() + " BoxMember annotation has an invalid type value [" + castedBoxMember + "]" +
+				        "Valid types are: " + Arrays.toString( BoxLangType.values() )
+				);
+			}
+			BoxLangType boxType = BoxLangType.valueOf( castedBoxMember.toUpperCase() );
+			return Array.of(
+			    Struct.of(
+			        // Default member name for class ArrayFoo with BoxType of Array is just foo()
+			        Key._NAME, className.getNameNoCase().replaceAll( boxType.getKey().getNameNoCase(), "" ),
+			        Key.objectArgument, "",
+			        Key.type, boxType
+			    )
+			);
+		}
+
+		// Case 3 : We have a struct of member methods, validate them and return them
+		// @BoxMember { "string": { "name": "append", "objectArgument": "string" } }
+		if ( boxMembers instanceof IStruct castedBoxMember ) {
+			Array result = new Array();
+
+			// Iterate over all entries and validate them
+			for ( IStruct.Entry<Key, ?> entry : castedBoxMember.entrySet() ) {
+				// Validate Type first which is the key of the entry
+				Key type = entry.getKey();
+				if ( !BoxLangType.isValid( type ) ) {
+					throw new BoxRuntimeException(
+					    className.getName() + " BoxMember annotation has an invalid type value [" + type.getName() + "]" +
+					        "Valid types are: " + Arrays.toString( BoxLangType.values() )
+					);
+				}
+
+				// Now the value of this key must be a struct with the following keys: name, objectArgument
+				// Validate the value is a struct
+				if ( ! ( entry.getValue() instanceof IStruct memberRecord ) ) {
+					throw new BoxRuntimeException(
+					    className.getName() + " BoxMember annotation value must be a struct with the following keys: [name], [objectArgument]"
+					);
+				}
+
+				// Prepare the record now
+				BoxLangType boxType = BoxLangType.valueOf( type.getNameNoCase() );
+				memberRecord.put( Key.type, boxType );
+				memberRecord.computeIfAbsent( Key._NAME, k -> className.getNameNoCase().replaceAll( type.getNameNoCase(), "" )
+				);
+				memberRecord.putIfAbsent( Key.objectArgument, "" );
+				result.push( memberRecord );
+			}
+
+			return result;
+		}
+
+		// Who knows what this is, just return an empty struct
+		return new Array();
+	}
+
+	/**
+	 * Build an array of Key aliases for the BIF/Component based on the following rules:
+	 * - If the target has any `{annotation}` annoations that have a value, use those
+	 * - If the target has any `{annotation}` annoations that have no value, use the BIF name
+	 *
+	 * @param target     The target Component/BIF to build aliases for
+	 * @param className  The class name of the target
+	 * @param annotation The annotation to look for
+	 *
+	 * @return An array of Key aliases
+	 */
+	private Key[] buildAnnotationAliases( IClassRunnable target, Key className, Key annotation ) {
+		// Get the requested annotation for the target
+		Object annotations = target.getBoxMeta().getMeta().getAsStruct( Key.annotations ).getOrDefault( annotation, "" );
+
+		// Case 1 : This is a simple String with no value, just return
+		if ( annotations instanceof String castedAnnotation && castedAnnotation.isBlank() ) {
+			return new Key[] { className };
+		}
+
+		// Case 2 : This is a simple String with a value, return the value as the alias instead of the name of the file on disk
+		if ( annotations instanceof String castedAnnotationWithValue && !castedAnnotationWithValue.isBlank() ) {
+			return new Key[] {
+			    Key.of( castedAnnotationWithValue )
+			};
+		}
+
+		// Case 3 : We have an Array of aliases, and they have values, return them alongside the class name
+		if ( annotations instanceof Array castedAliases ) {
+			// convert the values in the array to Keys
+			return castedAliases.push( className ).stream().map( Key::of ).toArray( Key[]::new );
+		}
+
+		// Default : Just return the class name
+		return new Key[] { className };
+	}
+
+	/**
+	 * Load a BoxLang class from disk and return it as a {@link IClassRunnable}
+	 *
+	 * @param targetFile      The target file to load
+	 * @param conventionsPath The conventions path to load the class from
+	 * @param context         The current context of execution
+	 *
+	 * @return The loaded BoxLang class
+	 */
+	private IClassRunnable loadClassRunnable( File targetFile, String conventionsPath, IBoxContext context ) {
+		var					oTargetObject		= ( IClassRunnable ) DynamicObject.of(
+		    RunnableLoader.getInstance().loadClass(
+		        ResolvedFilePath.of(
+		            null,
+		            null,
+		            ( this.invocationPath + "." + conventionsPath )
+		                .replaceAll( "\\.", Matcher.quoteReplacement( File.separator ) )
+		                + File.separator
+		                + FilenameUtils.getBaseName( targetFile.getAbsolutePath() ),
+		            targetFile.toPath()
+		        ),
+		        context
+		    )
+		).invokeConstructor( context )
+		    .getTargetInstance();
+
+		/**
+		 * --------------------------------------------------------------------------
+		 * DI Injections
+		 * --------------------------------------------------------------------------
+		 * Inject the following references into the BoxLang BIF
+		 * - boxRuntime : BoxLangRuntime
+		 * - log : A logger
+		 * - functionService : The BoxLang FunctionService
+		 * - interceptorService : The BoxLang InterceptorService
+		 * - moduleRecord : The ModuleRecord instance
+		 */
+
+		BoxRuntime			runtime				= BoxRuntime.getInstance();
+		FunctionService		functionService		= runtime.getFunctionService();
+		InterceptorService	interceptorService	= runtime.getInterceptorService();
+
+		oTargetObject.getVariablesScope().put( Key.moduleRecord, this );
+		oTargetObject.getVariablesScope().put( Key.boxRuntime, runtime );
+		oTargetObject.getVariablesScope().put( Key.functionService, functionService );
+		oTargetObject.getVariablesScope().put( Key.interceptorService, interceptorService );
+		oTargetObject.getVariablesScope().put( Key.log, LoggerFactory.getLogger( oTargetObject.getClass() ) );
+
+		return oTargetObject;
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/scopes/ArgumentsScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/ArgumentsScope.java
@@ -45,19 +45,44 @@ public class ArgumentsScope extends BaseScope {
 	}
 
 	/**
+	 * Create a new arguments scope with the given attributes
+	 *
+	 * @param attributes The attributes to add to the scope
+	 */
+	public ArgumentsScope( IStruct attributes ) {
+		super( ArgumentsScope.name, Struct.TYPES.LINKED );
+		putAll( attributes );
+	}
+
+	/**
 	 * --------------------------------------------------------------------------
 	 * Methods
 	 * --------------------------------------------------------------------------
 	 */
 
+	/**
+	 * Convert the arguments scope to a native array
+	 *
+	 * @return The arguments as a native array
+	 */
 	public Object[] asNativeArray() {
 		return values().toArray();
 	}
 
+	/**
+	 * Convert the arguments scope to a BoxLang array
+	 *
+	 * @return The arguments as a BoxLang array
+	 */
 	public Array asArray() {
 		return Array.of( asNativeArray() );
 	}
 
+	/**
+	 * Convert the arguments scope to a BoxLang struct
+	 *
+	 * @return The arguments as a BoxLang struct
+	 */
 	public IStruct asStruct() {
 		return this;
 	}
@@ -72,6 +97,13 @@ public class ArgumentsScope extends BaseScope {
 		return super.containsKey( key );
 	}
 
+	/**
+	 * Helper method to create an arguments scope from a map
+	 *
+	 * @param key The key to use for the scope
+	 *
+	 * @return The arguments scope key
+	 */
 	public Object get( Key key ) {
 		key = resolveKey( key );
 		return super.get( key );
@@ -140,7 +172,7 @@ public class ArgumentsScope extends BaseScope {
 
 	/**
 	 * Was this arguments scope created with an array of arguments or a struct of named arguments?
-	 * 
+	 *
 	 * @return True if positional, false if named
 	 */
 	public boolean isPositional() {
@@ -149,9 +181,9 @@ public class ArgumentsScope extends BaseScope {
 
 	/**
 	 * Set whether this arguments scope was created with an array of arguments or a struct of named arguments
-	 * 
+	 *
 	 * @param positional True if positional, false if named
-	 * 
+	 *
 	 * @return This arguments scope
 	 */
 	public ArgumentsScope setPositional( boolean positional ) {

--- a/src/main/java/ortus/boxlang/runtime/scopes/ArgumentsScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/ArgumentsScope.java
@@ -64,7 +64,11 @@ public class ArgumentsScope extends BaseScope {
 
 	@Override
 	public boolean containsKey( Key key ) {
-		key = resolveKey( key );
+		// Leave this unneccessary override as a reminder. All the other get/put methods translate between numeric and named keys, but contains key
+		// will ONLY look for real live actual keys. This is largely for CF compat as `arguments[ 1 ]` works but `structKeyExists( arguments, 1 )` returns false.
+		// It sort of makes sense if you think about it as the numeric keys only really existing when using the arguments as an array.
+		// containsKey() is what powers structKeyExists(), and when using the arguments scope as a struct, it should only return true for actual keys and ignore the "spoofed"
+		// positional numeric keys that allow it to behave as an array.
 		return super.containsKey( key );
 	}
 
@@ -106,7 +110,7 @@ public class ArgumentsScope extends BaseScope {
 	/**
 	 * Resolve a key to the actual key in the scope
 	 * Arguments allows existing items to be referenced by name OR position.
-	 * argumetns[1] is the same as arguments.first
+	 * arguments[1] is the same as arguments.first
 	 * So if we have an int key coming in, change it to the actual key in that position
 	 *
 	 * @param key The key to resolve

--- a/src/main/java/ortus/boxlang/runtime/scopes/BaseScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/BaseScope.java
@@ -110,6 +110,7 @@ public class BaseScope extends Struct implements IScope {
 	 *
 	 * @return The {@Link BoxMeta} object for this struct
 	 */
+	@Override
 	public BoxMeta getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new ScopeMeta( this, this.finalKeys );
@@ -153,9 +154,10 @@ public class BaseScope extends Struct implements IScope {
 	/**
 	 * Assign a value to a key in this scope
 	 */
+	@Override
 	public Object put( Key key, Object value ) {
 		if ( finalKeys.contains( key ) ) {
-			if ( super.get( key ) instanceof Function f ) {
+			if ( super.get( key ) instanceof Function ) {
 				throw new BoxRuntimeException( "Cannot override final function [" + key.getName() + "] in scope [" + scopeName.getName() + "]" );
 			}
 			throw new BoxRuntimeException( "Cannot reassign final key [" + key.getName() + "] in scope [" + scopeName.getName() + "]" );
@@ -166,6 +168,7 @@ public class BaseScope extends Struct implements IScope {
 	/**
 	 * Assign a value to a key in this scope if it doesn't exist
 	 */
+	@Override
 	public Object putIfAbsent( Key key, Object value ) {
 		if ( finalKeys.contains( key ) ) {
 			throw new BoxRuntimeException( "Cannot reassign final key [" + key.getName() + "] in scope [" + scopeName.getName() + "]" );
@@ -178,6 +181,7 @@ public class BaseScope extends Struct implements IScope {
 	 *
 	 * @param key The String key to remove
 	 */
+	@Override
 	public Object remove( Key key ) {
 		if ( finalKeys.contains( key ) ) {
 			throw new BoxRuntimeException( "Cannot delete final key [" + key.getName() + "] in scope [" + scopeName.getName() + "]" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -108,6 +108,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		asOptional							= Key.of( "asOptional" );
 	public static final Key		assocAttribs						= Key.of( "assocAttribs" );
 	public static final Key		asyncService						= Key.of( "asyncService" );
+	public static final Key		announce							= Key.of( "announce" );
 	public static final Key		attribute							= Key.of( "attribute" );
 	public static final Key		attributeCollection					= Key.of( "attributeCollection" );
 	public static final Key		attributes							= Key.of( "attributes" );
@@ -121,6 +122,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		binary								= Key.of( "binary" );
 	public static final Key		body								= Key.of( "body" );
 	public static final Key		boxBif								= Key.of( "BoxBif" );
+	public static final Key		boxComponent						= Key.of( "BoxComponent" );
 	public static final Key		boxCacheProvider					= Key.of( "BoxCacheProvider" );
 	public static final Key		boxlang								= Key.of( "boxlang" );
 	public static final Key		bxSessions							= Key.of( "bxSessions" );
@@ -332,6 +334,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		getAsBinary							= Key.of( "getAsBinary" );
 	public static final Key		getClass							= Key.of( "getClass" );
 	public static final Key		getFileInfo							= Key.of( "getFileInfo" );
+	public static final Key		getName								= Key.of( "getName" );
 	public static final Key		group								= Key.of( "group" );
 	public static final Key		groupCaseSensitive					= Key.of( "groupCaseSensitive" );
 	public static final Key		hasEndTag							= Key.of( "hasEndTag" );
@@ -475,6 +478,8 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		newDelimiter						= Key.of( "newDelimiter" );
 	public static final Key		newDirectory						= Key.of( "newDirectory" );
 	public static final Key		newPath								= Key.of( "newPath" );
+	public static final Key		newBuffer							= Key.of( "newBuffer" );
+	public static final Key		newBuilder							= Key.of( "newBuilder" );
 	public static final Key		noInit								= Key.of( "noInit" );
 	public static final Key		nulls								= Key.of( "null" );
 	public static final Key		number								= Key.of( "number" );
@@ -529,6 +534,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		precise								= Key.of( "precise" );
 	public static final Key		prefix								= Key.of( "prefix" );
 	public static final Key		priority							= Key.of( "priority" );
+	public static final Key		processBody							= Key.of( "processBody" );
 	public static final Key		positionals							= Key.of( "positionals" );
 	public static final Key		properties							= Key.of( "properties" );
 	public static final Key		protocol							= Key.of( "protocol" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -423,6 +423,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		listToJSON							= Key.of( "listToJSON" );
 	public static final Key		lJustify							= Key.of( "lJustify" );
 	public static final Key		loadPaths							= Key.of( "loadPaths" );
+	public static final Key		loggingService						= Key.of( "loggingService" );
 	public static final Key		local_addr							= Key.of( "local_addr" );
 	public static final Key		local_host							= Key.of( "local_host" );
 	public static final Key		locale								= Key.of( "locale" );

--- a/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
@@ -16,6 +16,7 @@ package ortus.boxlang.runtime.services;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class DatasourceService extends BaseService {
 	/**
 	 * Map of datasources registered with the service.
 	 */
-	private Map<Key, DataSource>	datasources	= new HashMap<>();
+	private Map<Key, DataSource>	datasources	= new ConcurrentHashMap<>();
 
 	/**
 	 * Map of JDBC drivers registered with the service.
@@ -246,8 +247,7 @@ public class DatasourceService extends BaseService {
 	 * @return The datasource that was registered
 	 */
 	public DataSource register( Key name, DataSource datasource ) {
-		this.datasources.put( name, datasource );
-		return datasource;
+		return this.datasources.putIfAbsent( name, datasource );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
@@ -595,14 +595,14 @@ public class ModuleService extends BaseService {
 			}
 
 			// Minor and Patch version check
-			if ( this.runtimeSemver.compareTo( minimumVersion ) < 0 ) {
-				logger.warn(
-				    "Module [{}] requires a minimum BoxLang version [{}] or later, but we are running [{}]. " +
-				        "There may be compatibility issues with newer features or bug fixes.",
-				    directoryPath.getFileName(),
-				    minimumVersion,
-				    this.runtimeSemver
-				);
+			if ( this.runtimeSemver.getMinor() != minimumVersion.getMinor() || this.runtimeSemver.getPatch() != minimumVersion.getPatch() ) {
+				// logger.trace(
+				// "Module [{}] requires a minimum BoxLang version [{}] or later, but we are running [{}]. " +
+				// "There may be compatibility issues with newer features or bug fixes.",
+				// directoryPath.getFileName(),
+				// minimumVersion,
+				// this.runtimeSemver
+				// );
 			}
 		}
 	}

--- a/src/main/java/ortus/boxlang/runtime/types/DateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/types/DateTime.java
@@ -348,44 +348,8 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	 * @param timezone The timezone to assign to the string, if an offset or zone is not provided in the value
 	 */
 	public DateTime( String dateTime, Locale locale, ZoneId timezone ) {
-		ZonedDateTime parsed = null;
-		this.formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME.withLocale( locale );
-		// try parsing if it fails then our time does not contain timezone info so we fall back to a local zoned date
-		try {
-			parsed = ZonedDateTime.parse( dateTime, LocalizationUtil.getLocaleZonedDateTimeParsers( locale ) );
-		} catch ( java.time.format.DateTimeParseException e ) {
-			// First fallback - it has a time without a zone
-			try {
-				parsed = ZonedDateTime.of( LocalDateTime.parse( dateTime, LocalizationUtil.getLocaleDateTimeParsers( locale ) ),
-				    timezone );
-				// Second fallback - it is only a date and we need to supply a time
-			} catch ( java.time.format.DateTimeParseException x ) {
-				try {
-					parsed = ZonedDateTime.of(
-					    LocalDateTime.of( LocalDate.parse( dateTime, LocalizationUtil.getLocaleDateParsers( locale ) ), LocalTime.MIN ),
-					    timezone );
-					// last fallback - this is a time only value
-				} catch ( java.time.format.DateTimeParseException z ) {
-					parsed = ZonedDateTime.of( LocalDate.MIN, LocalTime.parse( dateTime, LocalizationUtil.getLocaleTimeParsers( locale ) ),
-					    ZoneId.systemDefault() );
-				}
-			} catch ( Exception x ) {
-				throw new BoxRuntimeException(
-				    String.format(
-				        "The the date time value of [%s] could not be parsed as a valid date or datetime locale of [%s]",
-				        dateTime,
-				        locale.getDisplayName()
-				    ), x );
-			}
-		} catch ( Exception e ) {
-			throw new BoxRuntimeException(
-			    String.format(
-			        "The the date time value of [%s] could not be parsed with a locale of [%s]",
-			        dateTime,
-			        locale.getDisplayName()
-			    ), e );
-		}
-		this.wrapped = parsed;
+		this.formatter	= DateTimeFormatter.ISO_ZONED_DATE_TIME.withLocale( locale );
+		this.wrapped	= LocalizationUtil.parseFromString( dateTime, locale, timezone );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.time.Duration;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
@@ -96,6 +97,14 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	public Query( IStruct meta ) {
 		this.functionService	= BoxRuntime.getInstance().getFunctionService();
 		this.metadata			= meta == null ? new Struct( IStruct.TYPES.SORTED ) : meta;
+
+		// Set defaults for cache metadata, just in case they are not set.
+		this.metadata.putIfAbsent( Key.executionTime, 0 );
+		this.metadata.putIfAbsent( Key.cached, false );
+		this.metadata.putIfAbsent( Key.cacheKey, null );
+		this.metadata.putIfAbsent( Key.cacheProvider, null );
+		this.metadata.computeIfAbsent( Key.cacheTimeout, key -> Duration.ZERO );
+		this.metadata.computeIfAbsent( Key.cacheLastAccessTimeout, key -> Duration.ZERO );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -97,14 +97,6 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	public Query( IStruct meta ) {
 		this.functionService	= BoxRuntime.getInstance().getFunctionService();
 		this.metadata			= meta == null ? new Struct( IStruct.TYPES.SORTED ) : meta;
-
-		// Set defaults for cache metadata, just in case they are not set.
-		this.metadata.putIfAbsent( Key.executionTime, 0 );
-		this.metadata.putIfAbsent( Key.cached, false );
-		this.metadata.putIfAbsent( Key.cacheKey, null );
-		this.metadata.putIfAbsent( Key.cacheProvider, null );
-		this.metadata.computeIfAbsent( Key.cacheTimeout, key -> Duration.ZERO );
-		this.metadata.computeIfAbsent( Key.cacheLastAccessTimeout, key -> Duration.ZERO );
 	}
 
 	/**
@@ -881,6 +873,12 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	 * @return The metadata as a struct
 	 */
 	public IStruct getMetaData() {
+		this.metadata.putIfAbsent( Key.executionTime, 0 );
+		this.metadata.putIfAbsent( Key.cached, false );
+		this.metadata.putIfAbsent( Key.cacheKey, null );
+		this.metadata.putIfAbsent( Key.cacheProvider, null );
+		this.metadata.computeIfAbsent( Key.cacheTimeout, key -> Duration.ZERO );
+		this.metadata.computeIfAbsent( Key.cacheLastAccessTimeout, key -> Duration.ZERO );
 		this.metadata.computeIfAbsent( Key.recordCount, key -> data.size() );
 		this.metadata.computeIfAbsent( Key.columns, key -> this.getColumns() );
 		this.metadata.computeIfAbsent( Key.columnList, key -> this.getColumnList() );

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -205,10 +205,11 @@ public class DumpUtil {
 			if ( output.equals( "buffer" ) ) {
 				context.writeToBuffer(
 				    """
-				    	<div style="display: inline-block; padding: 8px 12px; background-color: #ff4d4d; color: white; font-weight: bold; border-radius: 5px;">
+				    	<div style="margin-top: 10px; display: inline-block; padding: 8px 12px; background-color: #ff4d4d; color: white; font-weight: bold; border-radius: 5px;">
 				    		Dump Aborted
 				    	</div>
-				    """, true );
+				    """,
+				    true );
 			}
 			context.flushBuffer( true );
 			throw new AbortException( "request", null );

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -45,7 +45,6 @@ import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.components.jdbc.Query;
 import ortus.boxlang.runtime.context.ContainerBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
-import ortus.boxlang.runtime.context.RequestBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.ArrayCaster;
 import ortus.boxlang.runtime.dynamic.casters.DateTimeCaster;
@@ -120,17 +119,29 @@ public class DumpUtil {
 	    String output,
 	    String format,
 	    Boolean showUDFs ) {
-		output = output.toLowerCase();
 
-		// Backwards compat here, could put this in the transpiler if we want
-		if ( output.equals( "browser" ) ) {
-			output = "buffer";
+		boolean isScriptContext = context.getRequestContext() instanceof ScriptingRequestBoxContext;
+
+		// Default output param
+		if ( output == null ) {
+			if ( isScriptContext ) {
+				output = "console";
+			} else {
+				output = "buffer";
+			}
+		} else {
+			output = output.toLowerCase();
+
+			// Backwards compat here, could put this in the transpiler if we want
+			if ( output.equals( "browser" ) ) {
+				output = "buffer";
+			}
 		}
 
 		// Determine the output format if not passed from the output parameter.
 		if ( format == null ) {
 			// If the output is console or the parent context is a scripting context, then use text.
-			if ( output.equals( "console" ) || context.getParentOfType( RequestBoxContext.class ) instanceof ScriptingRequestBoxContext ) {
+			if ( output.equals( "console" ) || isScriptContext ) {
 				format = "text";
 			}
 			// Otherwise, use HTML (default for buffer or filename)
@@ -160,7 +171,11 @@ public class DumpUtil {
 		switch ( output ) {
 			// SEND TO CONSOLE
 			case "console" :
-				dumpToConsole( context, target, label );
+				if ( format.equals( "html" ) ) {
+					dumpHTMLToConsole( context, target, label, top, expand, abort, output, format, showUDFs );
+				} else {
+					dumpTextToConsole( context, target, label );
+				}
 				break;
 
 			// SEND TO BUFFER (HTML or TEXT)
@@ -223,8 +238,40 @@ public class DumpUtil {
 	 * @param target  The target object
 	 * @param label   The label for the object
 	 */
-	public static void dumpToConsole( IBoxContext context, Object target, String label ) {
-		PrintStream out = context.getParentOfType( RequestBoxContext.class ).getOut();
+	public static void dumpHTMLToConsole(
+	    IBoxContext context,
+	    Object target,
+	    String label,
+	    Integer top,
+	    Boolean expand,
+	    Boolean abort,
+	    String output,
+	    String format,
+	    Boolean showUDFs ) {
+		// Push a fresh buffer to our context to capture the HTML generated
+		StringBuffer buffer = new StringBuffer();
+		context.pushBuffer( buffer );
+		try {
+			// Fire the HTML templates to fill up the buffer
+			dumpHTMLToBuffer( context, target, label, top, expand, abort, output, format, showUDFs );
+			// Dump the buffer to the console
+			context.getRequestContext().getOut().println( buffer.toString() );
+		} finally {
+			// We're done with you.
+			context.popBuffer();
+		}
+
+	}
+
+	/**
+	 * Dump the object to the console.
+	 *
+	 * @param context The context
+	 * @param target  The target object
+	 * @param label   The label for the object
+	 */
+	public static void dumpTextToConsole( IBoxContext context, Object target, String label ) {
+		PrintStream out = context.getRequestContext().getOut();
 
 		// Do we have a console label?
 		if ( label != null && !label.isEmpty() ) {

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -569,6 +569,15 @@ public final class LocalizationUtil {
 		return symbols;
 	}
 
+	/**
+	 * Parses a date string into a ZonedDateTime instance
+	 *
+	 * @param dateTime the date time string to parse
+	 * @param locale   the locale
+	 * @param timezone the timezone
+	 * 
+	 * @return
+	 */
 	public static ZonedDateTime parseFromString( String dateTime, Locale locale, ZoneId timezone ) {
 
 		Boolean	likelyHasDate			= dateTime.contains( "/" ) || dateTime.contains( "-" );

--- a/src/main/java/ortus/boxlang/runtime/util/ResolvedFilePath.java
+++ b/src/main/java/ortus/boxlang/runtime/util/ResolvedFilePath.java
@@ -105,11 +105,11 @@ public record ResolvedFilePath( String mappingName, String mappingPath, String r
 	}
 
 	/**
-	 * Get the package of the resolved path, but with a prefix appended in front
+	 * Get the package of the resolved path, but with a prefix prepended in front
 	 *
-	 * @param prefix The prefix to append to the package.
+	 * @param prefix The prefix to prepend to the package.
 	 *
-	 * @return The package of the resolved path with the prefix appended.
+	 * @return The package of the resolved path with the prefix prepended.
 	 */
 	public FQN getFQN( String prefix ) {
 		return FQN.of( prefix, relativePath != null ? Path.of( relativePath ) : absolutePath );
@@ -134,11 +134,11 @@ public record ResolvedFilePath( String mappingName, String mappingPath, String r
 	}
 
 	/**
-	 * Get the Box package of the resolved path, but with a prefix appended in front
+	 * Get the Box package of the resolved path, but with a prefix prepended in front
 	 *
-	 * @param prefix The prefix to append to the package.
+	 * @param prefix The prefix to prepend to the package.
 	 *
-	 * @return The package of the resolved path with the prefix appended.
+	 * @return The package of the resolved path with the prefix prepended.
 	 */
 	public BoxFQN getBoxFQN( String prefix ) {
 		return BoxFQN.of( prefix, relativePath != null ? Path.of( relativePath ) : absolutePath );

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -209,7 +209,7 @@
 									</tr>
 									<bx:loop collection="#thisScope#" item="dataProperty">
 										<bx:script>
-											thisData = thisScope[ dataProperty ]
+											thisData = thisScope[ dataProperty ] ?: null;
 											if( (thisData instanceOf "ortus.boxlang.runtime.types.Function") ){
 												continue;
 											}
@@ -261,8 +261,8 @@
 								</tr>
 								<bx:loop collection="#staticScope#" item="methodName">
 									<bx:script>
-										thisMethod = staticScope[ methodName ]
-										if( !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
+										thisMethod = staticScope[ methodName ] ?: null;
+										if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
 											continue;
 										}
 									</bx:script>
@@ -311,8 +311,8 @@
 										</tr>
 										<bx:loop collection="#thisScope#" item="methodName">
 											<bx:script>
-												thisMethod = thisScope[ methodName ]
-												if( !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
+												thisMethod = thisScope[ methodName ] ?: null;
+												if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
 													continue;
 												}
 											</bx:script>
@@ -362,8 +362,8 @@
 										</tr>
 										<bx:loop collection="#variablesScope#" item="methodName">
 											<bx:script>
-												thisMethod = variablesScope[ methodName ]
-												if( !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
+												thisMethod = variablesScope[ methodName ] ?: null;
+												if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
 													continue;
 												}
 												if( thisMethod.getAccess().toString() == "public" ){

--- a/src/modules/test/src/main/bx/components/HelloComponent.bx
+++ b/src/modules/test/src/main/bx/components/HelloComponent.bx
@@ -1,0 +1,60 @@
+/**
+ * This is a BoxLang only Component
+ *
+ * Annotations you can use on a component:
+ * <pre>
+ * // The alias of the Component, defaults to the name of the Class
+ * @BoxComponent 'myComponentAlias'
+ * @BoxComponent [ 'myComponentAlias', 'anotherAlias' ]
+ * @AllowsBody [boolean=false]
+ * @RequiresBody [boolean=false]
+ * </pre>
+ *
+ * The runtime injects the following into the variables	scope:
+ * - boxRuntime : BoxLangRuntime
+ * - log : A logger
+ * - functionService : The BoxLang FunctionService
+ * - interceptorService : The BoxLang InterceptorService
+ * - moduleRecord : The ModuleRecord instance
+ *
+ * The runtime also injects the following helpers into the variables scope:
+ * - newBuffer() : Create and return a new StringBuffer
+ * - newBuilder() : Create and return a new StringBuilder
+ * - processBody( context, body, [buffer] ) : Process the body of a component
+ * - getName() : Get the name of the component
+ */
+@BoxComponent 'HolaComponent'
+@AllowsBody true
+@RequiresBody false
+class{
+
+	/**
+	 * The execution of this Component
+	 *
+	 * <pre>
+	 * <bx:holaComponent>This is my output</bx:holaComponent>
+	 * </pre>
+	 *
+	 * @param context The context of the execution (IBoxContext)
+	 * @param attributes The attributes of the component that were passed in
+	 * @param body The body of the component that you can pass to `processBody(context, body, [buffer])` for execution and buffer retreival
+	 * @param executionState The execution state of the component. Each component get's one as an isolated state.
+	 *
+	 * @return A BodyResult instance or null for a default result return.
+	 */
+	function invoke( required context, Struct attributes, any body, Struct executionState ){
+		// A buffer to capture the body output
+		var	buffer		= newBuffer();
+		var	bodyResult	= processBody( context, body, buffer );
+
+		// // If there was a return statement inside our body, we early exit now
+		if ( bodyResult.isEarlyExit() ) {
+			return bodyResult;
+		}
+		// // reverse the buffer contents and place into a string
+		var newContent	= buffer.reverse().toString();
+		// // output it to the page buffer
+		context.writeToBuffer( newContent );
+	}
+
+}

--- a/src/test/java/TestCases/asm/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/asm/phase1/CoreLangTest.java
@@ -2266,26 +2266,6 @@ public class CoreLangTest {
 
 	}
 
-	@DisplayName( "CF transpile structKeyExists" )
-	@Test
-	public void testCFTranspileStructKeyExists() {
-
-		instance.executeSource(
-		    """
-		       str = {
-		    	foo : 'bar',
-		    	baz : null
-		    };
-		    result = structKeyExists( str, "foo" )
-		    result2 = structKeyExists( str, "baz" )
-		    	 """,
-		    context, BoxSourceType.CFSCRIPT );
-
-		assertThat( variables.getAsBoolean( result ) ).isTrue();
-		assertThat( variables.getAsBoolean( Key.of( "result2" ) ) ).isFalse();
-
-	}
-
 	@Test
 	public void numberKey() {
 

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -755,6 +755,26 @@ public class CoreLangTest {
 		assertThat( variables.get( Key.of( "i" ) ) ).isEqualTo( 0 );
 	}
 
+	@DisplayName( "sentinel with switch that uses break" )
+	@Test
+	public void testSentinelWithSwitchThatUsesBreak() {
+
+		instance.executeSource(
+		    """
+		    safety = 0;
+		       for( i=0; i<5; i++ ) {
+		    	safety++;
+		    	assert safety < 100;
+		       	switch( "brad" ) {
+		       		case "brad":
+		       			break;
+		       	}
+		       }
+		    """,
+		    context );
+		assertThat( variables.get( Key.of( "i" ) ) ).isEqualTo( 5 );
+	}
+
 	@DisplayName( "nested sentinel break" )
 	@Test
 	public void testNestedSentinelBreak() {

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -2381,26 +2381,6 @@ public class CoreLangTest {
 
 	}
 
-	@DisplayName( "CF transpile structKeyExists" )
-	@Test
-	public void testCFTranspileStructKeyExists() {
-
-		instance.executeSource(
-		    """
-		       str = {
-		    	foo : 'bar',
-		    	baz : null
-		    };
-		    result = structKeyExists( str, "foo" )
-		    result2 = structKeyExists( str, "baz" )
-		    	 """,
-		    context, BoxSourceType.CFSCRIPT );
-
-		assertThat( variables.getAsBoolean( result ) ).isTrue();
-		assertThat( variables.getAsBoolean( Key.of( "result2" ) ) ).isFalse();
-
-	}
-
 	@Test
 	public void numberKey() {
 
@@ -3988,6 +3968,34 @@ public class CoreLangTest {
 		    variables.firstResult4 = result4;
 		      	foo( "brad" )
 		      """, context );
+		assertThat( variables.get( Key.of( "firstResult1" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "firstResult2" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "firstResult3" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "firstResult4" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "result1" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "result2" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "result3" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "result4" ) ).toString() ).contains( "brad" );
+	}
+
+	@Test
+	public void testNumericKeysDoNotExistInNamedParamArgumentsCF() {
+		instance.executeSource(
+		    """
+		      	function foo( param ) {
+		      		variables.result1 = structKeyExists( arguments, 1 )
+		      		variables.result2 = arguments[ 1 ]
+		      		variables.result3 = structKeyExists( arguments, "param" )
+		      		variables.result4 = arguments[ "param" ]
+		      	}
+
+		      	foo( param="brad" )
+		    variables.firstResult1 = result1;
+		    variables.firstResult2 = result2;
+		    variables.firstResult3 = result3;
+		    variables.firstResult4 = result4;
+		      	foo( "brad" )
+		      """, context, BoxSourceType.CFSCRIPT );
 		assertThat( variables.get( Key.of( "firstResult1" ) ) ).isEqualTo( false );
 		assertThat( variables.get( Key.of( "firstResult2" ) ).toString() ).contains( "brad" );
 		assertThat( variables.get( Key.of( "firstResult3" ) ) ).isEqualTo( true );

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -3970,4 +3970,32 @@ public class CoreLangTest {
 		    """, context );
 	}
 
+	@Test
+	public void testNumericKeysDoNotExistInNamedParamArguments() {
+		instance.executeSource(
+		    """
+		      	function foo( param ) {
+		      		variables.result1 = structKeyExists( arguments, 1 )
+		      		variables.result2 = arguments[ 1 ]
+		      		variables.result3 = structKeyExists( arguments, "param" )
+		      		variables.result4 = arguments[ "param" ]
+		      	}
+
+		      	foo( param="brad" )
+		    variables.firstResult1 = result1;
+		    variables.firstResult2 = result2;
+		    variables.firstResult3 = result3;
+		    variables.firstResult4 = result4;
+		      	foo( "brad" )
+		      """, context );
+		assertThat( variables.get( Key.of( "firstResult1" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "firstResult2" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "firstResult3" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "firstResult4" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "result1" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "result2" ) ).toString() ).contains( "brad" );
+		assertThat( variables.get( Key.of( "result3" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "result4" ) ).toString() ).contains( "brad" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/BoxRuntimeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRuntimeTest.java
@@ -38,16 +38,10 @@ public class BoxRuntimeTest {
 
 	@DisplayName( "It can startup" )
 	@Test
-	@Disabled( "We can't shutdown the runtime singleton in the middle of an async test suite" )
 	public void testItCanStartUp() {
-		BoxRuntime runtime = BoxRuntime.getInstance( "", "" );
+		BoxRuntime runtime = BoxRuntime.getInstance( true );
 		assertThat( BoxRuntime.getInstance() ).isSameInstanceAs( runtime );
 		assertThat( runtime.getStartTime() ).isNotNull();
-
-		// Shutdown and restart to ensure we're in debug mode - just in case the runtime was already running from another test.
-		runtime.shutdown();
-		BoxRuntime runtime2 = BoxRuntime.getInstance( true );
-		assertThat( runtime2.inDebugMode() ).isTrue();
 	}
 
 	@DisplayName( "It can shutdown" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/math/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/math/LogTest.java
@@ -19,7 +19,6 @@ package ortus.boxlang.runtime.bifs.global.math;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,11 +41,6 @@ public class LogTest {
 	@BeforeAll
 	public static void setUp() {
 		instance = BoxRuntime.getInstance( true );
-	}
-
-	@AfterAll
-	public static void teardown() {
-
 	}
 
 	@BeforeEach

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/DateLenTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/DateLenTest.java
@@ -1,0 +1,82 @@
+package ortus.boxlang.runtime.bifs.global.string;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+
+public class DateLenTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+	static Key			result2	= new Key( "result2" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It returns the length of the date using len(date)" )
+	@Test
+	public void testDateLenFunction() {
+		instance.executeSource(
+		    """
+		    dt = now();
+		    result = len(dt);
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( 26 );
+	}
+
+	@DisplayName( "It returns the length of the date using date.len()" )
+	@Test
+	public void testDateLenMethod() {
+		instance.executeSource(
+		    """
+		    dt = now();
+		    result = dt.len();
+		    result2 = now().len();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( 26 );
+		assertThat( variables.get( result2 ) ).isEqualTo( 26 );
+	}
+
+	@DisplayName( "It returns the length of custom JVM date classes" )
+	@Test
+	public void testCustomDateLenFunction() {
+		instance.executeSource(
+		    """
+		      	import java.util.Date;
+		    dt = new Date();
+		    result = len(dt);
+		    actualLen = dt.toString().length();
+		      """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( variables.getAsInteger( Key.of( "actualLen" ) ) );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetSemverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetSemverTest.java
@@ -1,0 +1,84 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.system;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.semver4j.Semver;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+
+public class GetSemverTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can parse a semantic version string" )
+	@Test
+	public void testGetSemver() {
+		instance.executeSource(
+		    """
+		    result = getSemver( "1.2.3" );
+		    """,
+		    context );
+
+		Semver semver = ( Semver ) variables.get( result );
+		assertThat( semver.getMajor() ).isEqualTo( 1 );
+		assertThat( semver.getMinor() ).isEqualTo( 2 );
+		assertThat( semver.getPatch() ).isEqualTo( 3 );
+	}
+
+	@DisplayName( "It can build a semver using the semver builder" )
+	@Test
+	public void testBuildSemver() {
+		instance.executeSource(
+		    """
+		    result = getSemver().withMajor( 1 ).withMinor( 2 ).withPatch( 3 ).toSemver();
+		    """,
+		    context );
+
+		Semver semver = ( Semver ) variables.get( result );
+		assertThat( semver.getMajor() ).isEqualTo( 1 );
+		assertThat( semver.getMinor() ).isEqualTo( 2 );
+		assertThat( semver.getPatch() ).isEqualTo( 3 );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
@@ -43,12 +43,13 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 public class WriteLogTest {
 
 	static BoxRuntime				instance;
+	static String					logsDirectory;
 	static IBoxContext				context;
 	static IScope					variables;
 	static Key						result		= new Key( "result" );
+	static String					logFilePath;
 	static ByteArrayOutputStream	outContent;
 	static PrintStream				originalOut	= System.out;
-	static String					logsDirectory;
 
 	@BeforeAll
 	public static void setUp() {
@@ -56,12 +57,12 @@ public class WriteLogTest {
 		logsDirectory	= instance.getConfiguration().logsDirectory;
 		outContent		= new ByteArrayOutputStream();
 		System.setOut( new PrintStream( outContent ) );
+		logFilePath = Paths.get( logsDirectory, "/writelog.log" ).normalize().toString();
 	}
 
 	@AfterAll
 	public static void teardown() {
 		System.setOut( originalOut );
-		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			FileSystemUtil.deleteFile( logFilePath );
 		}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
@@ -48,7 +48,6 @@ public class WriteLogTest {
 	static Key						result		= new Key( "result" );
 	static ByteArrayOutputStream	outContent;
 	static PrintStream				originalOut	= System.out;
-
 	static String					logsDirectory;
 
 	@BeforeAll
@@ -62,7 +61,10 @@ public class WriteLogTest {
 	@AfterAll
 	public static void teardown() {
 		System.setOut( originalOut );
-
+		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
+		if ( FileSystemUtil.exists( logFilePath ) ) {
+			FileSystemUtil.deleteFile( logFilePath );
+		}
 	}
 
 	@BeforeEach
@@ -72,7 +74,7 @@ public class WriteLogTest {
 		outContent.reset();
 	}
 
-	@DisplayName( "It can write a default log" )
+	@DisplayName( "It can write to the default log file" )
 	@Test
 	public void testPrint() {
 		instance.executeSource(
@@ -80,45 +82,45 @@ public class WriteLogTest {
 		    writeLog( "Hello Logger!" )
 		    """,
 		    context );
+
+		// Assert we got here
+		assertTrue( StringUtils.contains( outContent.toString(), "Hello Logger!" ) );
 	}
 
-	@DisplayName( "It can write a default with a custom category" )
+	@DisplayName( "It can write a default with a compat log argument" )
 	@Test
 	public void testCategory() {
 		instance.executeSource(
 		    """
-		    writeLog( text="Hello Logger!", log="Custom" )
+		    writeLog( text="Hola Logger!", log="Custom" )
 		    """,
 		    context );
+		// Assert we got here
+		assertTrue( StringUtils.contains( outContent.toString(), "Hola Logger!" ) );
 	}
 
 	@DisplayName( "It can write a default with a custom log file" )
 	@Test
 	public void testCustomFile() {
 		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
 		instance.executeSource(
 		    """
-		    writeLog( text="Hello Logger!", log="Foo", file="foo.log" )
+		    writeLog( text="Custom Logger!", file="foo.log" )
 		    """,
 		    context );
 		assertTrue( FileSystemUtil.exists( logFilePath ) );
 		String fileContent = StringCaster.cast( FileSystemUtil.read( logFilePath ) );
-		assertTrue( StringUtils.contains( fileContent, "Hello Logger!" ) );
+		assertTrue( StringUtils.contains( fileContent, "Custom Logger!" ) );
+
 	}
 
 	@DisplayName( "It can write a default with a custom log file" )
 	@Test
 	public void testCustomFileAndLevel() {
 		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
 		instance.executeSource(
 		    """
-		    writeLog( text="Hello Error Logger!", log="Foo", file="foo.log", type="Error" );
+		    writeLog( text="Hello Error Logger!", file="foo.log", type="Error" );
 		    """,
 		    context );
 
@@ -131,6 +133,7 @@ public class WriteLogTest {
 		String fileContent = StringCaster.cast( FileSystemUtil.read( logFilePath ) );
 		assertTrue( StringUtils.contains( fileContent, "[ERROR]" ) );
 		assertTrue( StringUtils.contains( fileContent, "Hello Error Logger!" ) );
+
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
@@ -35,6 +35,7 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -63,6 +64,7 @@ public class WriteLogTest {
 	@AfterAll
 	public static void teardown() {
 		System.setOut( originalOut );
+		LoggingService.getInstance().shutdownAppenders();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			FileSystemUtil.deleteFile( logFilePath );
 		}

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -36,6 +36,7 @@ import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -66,6 +67,7 @@ public class LogTest {
 	@AfterAll
 	public static void tearDown() {
 		System.setOut( originalOut );
+		LoggingService.getInstance().shutdownAppenders();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			FileSystemUtil.deleteFile( logFilePath );
 		}

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -47,16 +47,20 @@ public class LogTest {
 	IBoxContext			context;
 	IScope				variables;
 	static Key			result	= new Key( "result" );
+	static String		logFilePath;
 
 	@BeforeAll
 	public static void setUp() {
 		instance		= BoxRuntime.getInstance( true );
 		logsDirectory	= instance.getConfiguration().logsDirectory;
-
+		logFilePath		= Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
 	}
 
 	@AfterAll
-	public static void teardown() {
+	public static void tearDown() {
+		if ( FileSystemUtil.exists( logFilePath ) ) {
+			FileSystemUtil.deleteFile( logFilePath );
+		}
 	}
 
 	@BeforeEach
@@ -70,7 +74,7 @@ public class LogTest {
 	public void testComponentScript() {
 		instance.executeSource(
 		    """
-		    log text="Hello Logger!" log="Foo" file="foo.log";
+		    log text="Hello Logger!" file="foo.log";
 		    """,
 		    context, BoxSourceType.BOXSCRIPT );
 	}
@@ -80,7 +84,7 @@ public class LogTest {
 	public void testComponentCF() {
 		instance.executeSource(
 		    """
-		    <cflog text="Hello Logger!" log="Foo" file="foo.log" />
+		    <cflog text="Hello Logger!" file="foo.log" />
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
 	}
@@ -90,7 +94,7 @@ public class LogTest {
 	public void testComponentBX() {
 		instance.executeSource(
 		    """
-		    <bx:log text="Hello Logger!" log="Foo" file="foo.log" />
+		    <bx:log text="Hello Logger!" file="foo.log" />
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
 	}
@@ -98,14 +102,10 @@ public class LogTest {
 	@DisplayName( "It tests the BIF Log with Script parsing" )
 	@Test
 	public void testComponentCustomLogScript() {
-		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
 
 		instance.executeSource(
 		    """
-		    log text="Hello Logger!" log="Foo" file="foo.log";
+		    log text="Hello Logger!" file="foo.log";
 		    """,
 		    context, BoxSourceType.BOXSCRIPT );
 
@@ -117,14 +117,9 @@ public class LogTest {
 	@DisplayName( "It tests the BIF Log with CF tag parsing" )
 	@Test
 	public void testComponentCustomLogCF() {
-		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
-
 		instance.executeSource(
 		    """
-		    <cflog text="Hello Logger!" log="Foo" file="foo.log"/>
+		    <cflog text="Hello Logger!" file="foo.log"/>
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
 
@@ -136,14 +131,9 @@ public class LogTest {
 	@DisplayName( "It tests the BIF Log with BX tag parsing" )
 	@Test
 	public void testComponentCustomLogBX() {
-		String logFilePath = Paths.get( logsDirectory, "/foo.log" ).normalize().toString();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
-
 		instance.executeSource(
 		    """
-		    <bx:log text="Hello Logger!" log="Foo" file="foo.log"/>
+		    <bx:log text="Hello Logger!"  file="foo.log"/>
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
 

--- a/src/test/java/ortus/boxlang/runtime/config/ConfigLoaderTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/ConfigLoaderTest.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -43,11 +42,6 @@ class ConfigLoaderTest {
 	@BeforeAll
 	public static void setUp() {
 		runtime = BoxRuntime.getInstance( true );
-	}
-
-	@AfterAll
-	public static void teardown() {
-
 	}
 
 	@BeforeEach

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -283,11 +283,14 @@ class DatasourceConfigTest {
 		) );
 		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", datasource.toHikariConfig().getJdbcUrl() );
 
-		// dsn key
+		// dsn key shortcut for CFConfig
 		DatasourceConfig datasource2 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(
-		    "dsn", "jdbc:postgresql://127.0.0.1:5432/foo?"
+		    "dsn", "jdbc:postgresql://{host}:{port}/{database}",
+		    "database", "foo",
+		    "host", "localhost",
+		    "port", "5432"
 		) );
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", datasource2.toHikariConfig().getJdbcUrl() );
+		assertEquals( "jdbc:postgresql://localhost:5432/foo?", datasource2.toHikariConfig().getJdbcUrl() );
 
 		// connectionString key
 		DatasourceConfig datasource3 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -300,7 +300,7 @@ class DatasourceConfigTest {
 		    "host", "localhost",
 		    "port", "5432"
 		) );
-		assertThat( datasource2.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo?" );
+		assertThat( datasource2.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo" );
 
 		// connectionString key
 		DatasourceConfig datasource3 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -44,7 +44,7 @@ class DatasourceConfigTest {
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
 
-		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo?" );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo" );
 	}
 
 	@DisplayName( "It can load config" )

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -18,7 +18,6 @@
 package ortus.boxlang.runtime.config.segments;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +44,7 @@ class DatasourceConfigTest {
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
 
-		assert hikariConfig.getJdbcUrl().equals( "jdbc:postgresql://localhost:5432/foo" );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo?" );
 	}
 
 	@DisplayName( "It can load config" )
@@ -59,11 +58,10 @@ class DatasourceConfigTest {
 		    "custom", Struct.of( "useSSL", false )
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
-
-		assertEquals( "jdbc:mysql://127.0.0.1:3306/foo?useSSL=false", hikariConfig.getJdbcUrl() );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:mysql://127.0.0.1:3306/foo?useSSL=false" );
 	}
 
-	@DisplayName( "It can load a config with placeholders" )
+	@DisplayName( "It can load a config with placeholders on a url key" )
 	@Test
 	void testItCanConstructConnectionStringWithPlaceholders() {
 		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
@@ -75,8 +73,21 @@ class DatasourceConfigTest {
 		    "custom", Struct.of( "useSSL", false )
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:mysql://localhost:3306/foo?useSSL=false" );
+	}
 
-		assertEquals( "jdbc:mysql://localhost:3306/foo?useSSL=false", hikariConfig.getJdbcUrl() );
+	@DisplayName( "It can load a config with placeholders on a dsn key" )
+	@Test
+	void testItCanConstructConnectionStringWithPlaceholdersOnDSN() {
+		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
+		    "dsn", "jdbc:mysql://{host}:{port}/{database}",
+		    "host", "localhost",
+		    "port", 3306,
+		    "database", "foo",
+		    "custom", Struct.of( "useSSL", false )
+		) );
+		HikariConfig		hikariConfig	= datasource.toHikariConfig();
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:mysql://localhost:3306/foo?useSSL=false" );
 	}
 
 	@DisplayName( "It can load config" )
@@ -89,8 +100,7 @@ class DatasourceConfigTest {
 		    "database", "foo"
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
-
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", hikariConfig.getJdbcUrl() );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 	}
 
 	@DisplayName( "It can create a unique name for the datasource" )
@@ -236,7 +246,7 @@ class DatasourceConfigTest {
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
 
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", hikariConfig.getJdbcUrl() );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 	}
 
 	@DisplayName( "It can use 'dbdriver' in place of 'driver', for CFConfig support" )
@@ -250,7 +260,7 @@ class DatasourceConfigTest {
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
 
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", hikariConfig.getJdbcUrl() );
+		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 	}
 
 	@DisplayName( "It casts numeric values correctly upon instantation" )
@@ -268,11 +278,11 @@ class DatasourceConfigTest {
 		) ).setOnTheFly();
 
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
-		assertEquals( 1, hikariConfig.getMinimumIdle() );
-		assertEquals( 11, hikariConfig.getMaximumPoolSize() );
-		assertEquals( 3000, hikariConfig.getConnectionTimeout() );
-		assertEquals( 600000, hikariConfig.getIdleTimeout() );
-		assertEquals( 1800000, hikariConfig.getMaxLifetime() );
+		assertThat( hikariConfig.getMinimumIdle() ).isEqualTo( 1 );
+		assertThat( hikariConfig.getMaximumPoolSize() ).isEqualTo( 11 );
+		assertThat( hikariConfig.getConnectionTimeout() ).isEqualTo( 3000 );
+		assertThat( hikariConfig.getIdleTimeout() ).isEqualTo( 600000 );
+		assertThat( hikariConfig.getMaxLifetime() ).isEqualTo( 1800000 );
 	}
 
 	@DisplayName( "It can skip driver in place of jdbc url" )
@@ -281,7 +291,7 @@ class DatasourceConfigTest {
 		DatasourceConfig datasource = new DatasourceConfig( Key.of( "Foo" ), Struct.of(
 		    "url", "jdbc:postgresql://127.0.0.1:5432/foo?"
 		) );
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", datasource.toHikariConfig().getJdbcUrl() );
+		assertThat( datasource.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 
 		// dsn key shortcut for CFConfig
 		DatasourceConfig datasource2 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(
@@ -290,19 +300,19 @@ class DatasourceConfigTest {
 		    "host", "localhost",
 		    "port", "5432"
 		) );
-		assertEquals( "jdbc:postgresql://localhost:5432/foo?", datasource2.toHikariConfig().getJdbcUrl() );
+		assertThat( datasource2.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo?" );
 
 		// connectionString key
 		DatasourceConfig datasource3 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(
 		    "connectionString", "jdbc:postgresql://127.0.0.1:5432/foo?"
 		) );
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", datasource3.toHikariConfig().getJdbcUrl() );
+		assertThat( datasource3.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 
 		// jdbcURL key
 		DatasourceConfig datasource4 = new DatasourceConfig( Key.of( "Foo" ), Struct.of(
 		    "jdbcURL", "jdbc:postgresql://127.0.0.1:5432/foo?"
 		) );
-		assertEquals( "jdbc:postgresql://127.0.0.1:5432/foo?", datasource4.toHikariConfig().getJdbcUrl() );
+		assertThat( datasource4.toHikariConfig().getJdbcUrl() ).isEqualTo( "jdbc:postgresql://127.0.0.1:5432/foo?" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
@@ -42,7 +42,7 @@ public class LoggingInterceptorTest {
 
 	static Logging		loggingInterceptor;
 	static String		tmpDirectory	= "src/test/resources/tmp/FileSystemStoreTest";
-	static String		testLogFile		= "LoggingInterceptorTest.txt";
+	static String		testLogFile		= "LoggingInterceptorTest.log";
 	static String		logFilePath;
 	static String		absoluteLogeFilePath;
 	static String		logDirectory;

--- a/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
@@ -59,7 +59,7 @@ public class LoggingInterceptorTest {
 	@AfterAll
 	public static void teardown() {
 		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
+			// FileSystemUtil.deleteFile( logFilePath );
 		}
 		if ( FileSystemUtil.exists( absoluteLogeFilePath ) ) {
 			FileSystemUtil.deleteFile( absoluteLogeFilePath );
@@ -68,7 +68,7 @@ public class LoggingInterceptorTest {
 
 	@DisplayName( "It can log a message" )
 	@Test
-	void testLogMessage() throws InterruptedException {
+	void testLogMessage() {
 		System.out.println( logFilePath );
 		loggingInterceptor.logMessage( Struct.of(
 		    Key.text, "Hello, World!",
@@ -81,7 +81,7 @@ public class LoggingInterceptorTest {
 
 	@DisplayName( "It can log a message to an absolute path" )
 	@Test
-	void testLogAbsolute() throws InterruptedException {
+	void testLogAbsolute() {
 		loggingInterceptor.logMessage( Struct.of(
 		    Key.text, "Hello, Absolute Path!",
 		    Key.level, "INFO",

--- a/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Struct;
@@ -58,6 +59,7 @@ public class LoggingInterceptorTest {
 
 	@AfterAll
 	public static void teardown() {
+		LoggingService.getInstance().shutdownAppenders();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			FileSystemUtil.deleteFile( logFilePath );
 		}

--- a/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
@@ -59,7 +59,7 @@ public class LoggingInterceptorTest {
 	@AfterAll
 	public static void teardown() {
 		if ( FileSystemUtil.exists( logFilePath ) ) {
-			// FileSystemUtil.deleteFile( logFilePath );
+			FileSystemUtil.deleteFile( logFilePath );
 		}
 		if ( FileSystemUtil.exists( absoluteLogeFilePath ) ) {
 			FileSystemUtil.deleteFile( absoluteLogeFilePath );

--- a/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interceptors/LoggingInterceptorTest.java
@@ -72,7 +72,7 @@ public class LoggingInterceptorTest {
 		System.out.println( logFilePath );
 		loggingInterceptor.logMessage( Struct.of(
 		    Key.text, "Hello, World!",
-		    Key.level, "INFO",
+		    Key.type, "INFO",
 		    Key.file, testLogFile,
 		    Key.log, "Test"
 		) );
@@ -84,7 +84,7 @@ public class LoggingInterceptorTest {
 	void testLogAbsolute() {
 		loggingInterceptor.logMessage( Struct.of(
 		    Key.text, "Hello, Absolute Path!",
-		    Key.level, "INFO",
+		    Key.type, "INFO",
 		    Key.file, absoluteLogeFilePath,
 		    Key.log, "Test"
 		) );

--- a/src/test/java/ortus/boxlang/runtime/jdbc/DataSourceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/DataSourceTest.java
@@ -116,17 +116,17 @@ public class DataSourceTest {
 		DataSource	myDataSource	= DataSource.fromStruct(
 		    Key.of( "mssql" ),
 		    Struct.of(
-				"host","localhost",
-				"port","1433",
-				"dbdriver","MSSQL",
-				"database","master",
-				"dsn","jdbc:sqlserver://{host}:{port}",
-				"custom","DATABASENAME=master&sendStringParametersAsUnicode=false&SelectMethod=direct&applicationName=fooey",
-				"class","com.microsoft.sqlserver.jdbc.SQLServerDriver",
-				"username","${DB_USER}",
-				"password","${DB_PASSWORD}",
-				"connectionLimit","100",
-				"connectionTimeout","20",
+		        "host", "localhost",
+		        "port", "1433",
+		        "dbdriver", "MSSQL",
+		        "database", "master",
+		        "dsn", "jdbc:sqlserver://{host}:{port}",
+		        "custom", "DATABASENAME=master&sendStringParametersAsUnicode=false&SelectMethod=direct&applicationName=fooey",
+		        "class", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+		        "username", "${DB_USER}",
+		        "password", "${DB_PASSWORD}",
+		        "connectionLimit", "100",
+		        "connectionTimeout", "20",
 		        "username", "sa",
 		        "password", "123456Password"
 		    ) );

--- a/src/test/java/ortus/boxlang/runtime/jdbc/DataSourceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/DataSourceTest.java
@@ -109,6 +109,31 @@ public class DataSourceTest {
 		assertThat( conn ).isInstanceOf( Connection.class );
 	}
 
+	@EnabledIf( "tools.JDBCTestUtils#hasMSSQLModule" )
+	@DisplayName( "It can get a MSSQL JDBC connection" )
+	@Test
+	void testMSSQLConnection() throws SQLException {
+		DataSource	myDataSource	= DataSource.fromStruct(
+		    Key.of( "mssql" ),
+		    Struct.of(
+				"host","localhost",
+				"port","1433",
+				"dbdriver","MSSQL",
+				"database","master",
+				"dsn","jdbc:sqlserver://{host}:{port}",
+				"custom","DATABASENAME=master&sendStringParametersAsUnicode=false&SelectMethod=direct&applicationName=fooey",
+				"class","com.microsoft.sqlserver.jdbc.SQLServerDriver",
+				"username","${DB_USER}",
+				"password","${DB_PASSWORD}",
+				"connectionLimit","100",
+				"connectionTimeout","20",
+		        "username", "sa",
+		        "password", "123456Password"
+		    ) );
+		Connection	conn			= myDataSource.getConnection();
+		assertThat( conn ).isInstanceOf( Connection.class );
+	}
+
 	@DisplayName( "It can get a JDBC connection regardless of key casing" )
 	@Test
 	void testDerbyConnectionFunnyKeyCasing() throws SQLException {

--- a/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordTest.java
+++ b/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +42,7 @@ import ortus.boxlang.runtime.loader.resolvers.JavaResolver;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.services.ComponentService;
 import ortus.boxlang.runtime.services.FunctionService;
 import ortus.boxlang.runtime.services.ModuleService;
 import ortus.boxlang.runtime.types.IStruct;
@@ -215,6 +217,12 @@ class ModuleRecordTest {
 		assertThat( functionService.hasGlobalFunction( Key.of( "moduleHelloWorld" ) ) ).isTrue();
 		assertThat( functionService.hasGlobalFunction( Key.of( "moduleNow" ) ) ).isTrue();
 
+		// It should register components
+		ComponentService componentService = runtime.getComponentService();
+		assertThat( moduleRecord.components.size() ).isEqualTo( 1 );
+		System.out.println( Arrays.toString( componentService.getComponentNames() ) );
+		assertThat( componentService.hasComponent( Key.of( "HolaComponent" ) ) ).isTrue();
+
 		// Register a class loader
 		Class<?> clazz = moduleRecord.findModuleClass( "HelloWorld", false, context );
 		assertThat( clazz ).isNotNull();
@@ -241,6 +249,13 @@ class ModuleRecordTest {
 
 			//result4 = hola();
 		    """, context );
+		// @formatter:on
+
+		// Test the component
+		// @formatter:off
+		runtime.executeSource("""
+				<bx:HolaComponent>Hello</bx:HolaComponent>
+		    """, context, BoxSourceType.BOXTEMPLATE );
 		// @formatter:on
 
 		IScope variables = context.getScopeNearby( VariablesScope.name );

--- a/src/test/java/ortus/boxlang/runtime/services/ModuleServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/ModuleServiceTest.java
@@ -19,16 +19,17 @@ package ortus.boxlang.runtime.services;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 class ModuleServiceTest {
 
@@ -39,11 +40,6 @@ class ModuleServiceTest {
 	public static void setupBeforeAll() {
 		runtime	= BoxRuntime.getInstance( true );
 		service	= runtime.getModuleService();
-	}
-
-	@AfterAll
-	public static void tearDownAfterAll() {
-
 	}
 
 	@DisplayName( "Test it can get an instance of the service" )
@@ -86,6 +82,26 @@ class ModuleServiceTest {
 		var count = service.getModulePaths().size();
 		assertDoesNotThrow( () -> service.addModulePath( "" ) );
 		assertThat( service.getModulePaths().size() ).isEqualTo( count );
+	}
+
+	@DisplayName( "Test it can allow a modules version against the runtime version" )
+	@Test
+	void testItCanAllowModuleVersionAgainstRuntimeVersion() {
+		assertDoesNotThrow( () -> service.verifyModuleAndBoxLangVersion( "1.0.0", Paths.get( "" ) ) );
+		assertDoesNotThrow( () -> service.verifyModuleAndBoxLangVersion( "1.1.0", Paths.get( "" ) ) );
+		assertDoesNotThrow( () -> service.verifyModuleAndBoxLangVersion( "1.0.1", Paths.get( "" ) ) );
+	}
+
+	@DisplayName( "Test it can disallow a modules version against the runtime version due to < major version issue" )
+	@Test
+	void testItCanDisallowModuleVersionAgainstRuntimeVersionDueToMajorVersionIssue() {
+		assertThrows( BoxRuntimeException.class, () -> service.verifyModuleAndBoxLangVersion( "2.0.0", Paths.get( "" ) ) );
+	}
+
+	@DisplayName( "Test it can still allow a modules version against the runtime version due to > major version issue" )
+	@Test
+	void testItCanStillAllowModuleVersionAgainstRuntimeVersionDueToMajorVersionIssue() {
+		assertDoesNotThrow( () -> service.verifyModuleAndBoxLangVersion( "0.0.0", Paths.get( "" ) ) );
 	}
 
 }


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta23

### Improvement

[BL-769](https://ortussolutions.atlassian.net/browse/BL-769) dump default to console output when in scripting context

[BL-770](https://ortussolutions.atlassian.net/browse/BL-770) avoid date parsing in len\(\) BIF

### Bug

[BL-761](https://ortussolutions.atlassian.net/browse/BL-761) Error when using abort in cfdump tag

[BL-763](https://ortussolutions.atlassian.net/browse/BL-763) whitespace management handle no content-type response header set yet

[BL-765](https://ortussolutions.atlassian.net/browse/BL-765) Difference of behaviour for handing arguments passed by position vs named

[BL-772](https://ortussolutions.atlassian.net/browse/BL-772) dsn key for jdbc drivers was not being used correctly as per cfconfig and replacements and producing invalid jdbc urls

[BL-774](https://ortussolutions.atlassian.net/browse/BL-774) Improve DateTimeCaster/DateTime instantiation performance with Strings

[BL-775](https://ortussolutions.atlassian.net/browse/BL-775) onSessionStart\(\) can cause endless recursion

[BL-776](https://ortussolutions.atlassian.net/browse/BL-776) debugmode flag in boxlang.json doesn't seem to be getting used

[BL-778](https://ortussolutions.atlassian.net/browse/BL-778) reconfigure debug mode doesn't work in a servlet

[BL-779](https://ortussolutions.atlassian.net/browse/BL-779) Logging interceptor is recreating appenders and loggers and discarding them on each log message, this is inefficient and a bottleneck under stress

[BL-780](https://ortussolutions.atlassian.net/browse/BL-780) writelog and log components where missing the \`application\` boolean argument

### New Feature

[BL-750](https://ortussolutions.atlassian.net/browse/BL-750) Component in BX for modules

[BL-768](https://ortussolutions.atlassian.net/browse/BL-768) ModuleService check the "boxlang" version to make sure the module is compatible or not

[BL-771](https://ortussolutions.atlassian.net/browse/BL-771) Generic JDBC Driver add a default URL delimiter, since some DBs are different

[BL-777](https://ortussolutions.atlassian.net/browse/BL-777) new getSemver\(\) bif to build or parse semvers and return a Semver object

### Story

[BL-116](https://ortussolutions.atlassian.net/browse/BL-116) Implement unfinished query options

[BL-769]: https://ortussolutions.atlassian.net/browse/BL-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-770]: https://ortussolutions.atlassian.net/browse/BL-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-761]: https://ortussolutions.atlassian.net/browse/BL-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-763]: https://ortussolutions.atlassian.net/browse/BL-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-765]: https://ortussolutions.atlassian.net/browse/BL-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-772]: https://ortussolutions.atlassian.net/browse/BL-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-774]: https://ortussolutions.atlassian.net/browse/BL-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-775]: https://ortussolutions.atlassian.net/browse/BL-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-776]: https://ortussolutions.atlassian.net/browse/BL-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ