### PR TITLE
version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,9 +167,9 @@ project.ext.bumpVersion = {
 	if( patch ){
 		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${newPathVersion}"
 	} else if( minor ){
-		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.${versionParts[ 2 ]}"
+		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.0"
 	} else if( major ){
-		newVersion = "${newPathVersion}.${versionParts[ 1 ]}.${versionParts[ 2 ]}"
+		newVersion = "${newPathVersion}.0.0"
 	} else if( beta ){
 		// Get's the -betaX version.
 		def betaString = currentVersion.split( '-' )[ 1 ]

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,8 @@ project.ext.bumpVersion = {
 	boolean minor = false,
 	boolean patch = false,
 	boolean beta = false,
-	boolean rc = false ->
+	boolean rc = false,
+	property = "version" ->
 
 	def propertiesFile = file( './gradle.properties' );
 	def properties = new Properties();
@@ -158,14 +159,9 @@ project.ext.bumpVersion = {
 	properties.load( propertiesFile.newDataInputStream() )
 	def versionTarget = major ? 0 : minor ? 1 : beta ? 2 : 3
 
-	def currentVersion = properties.getProperty( 'version' )
-	// 1.1.0 -> -> [ 1, 1, 0 ]
-	// 1.0.0-beta1 -> [ 1, 0, 0-beta1 ]
-	// 1.0.0-rc.1 -> [ 1, 0, 0-rc, 1 ]
+	def currentVersion = properties.getProperty( property )
 	def versionParts = currentVersion.split( '\\.' )
-	if( !beta ){
-		def newPathVersion = versionParts[ versionTarget ].toInteger() + 1
-	}
+	def newPathVersion = versionParts[ versionTarget ].toInteger() + 1
 	def newVersion = '';
 
 	if( patch ){
@@ -184,7 +180,7 @@ project.ext.bumpVersion = {
 		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${versionParts[ 2 ]}.${newPathVersion}"
 	}
 
-	properties.setProperty( 'version', newVersion )
+	properties.setProperty( property, newVersion )
 	properties.store( propertiesFile.newWriter(), null )
 
 	println "Bumped version from ${currentVersion} to ${newVersion}"

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New Features
+
+- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
+- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not
+
+### Improvements
+
+- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
+- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
+- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
+- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
+- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
+- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
+- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
+- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
+- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal
+
+### Bugs
+
+- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
+- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
+- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
+- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
+- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
+- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
+- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
+- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
+- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
+- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds
+
 ## [1.0.1] - 2025-05-01
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Detection on `boxlang file` execution with invalid paths was not working properly.
+
 ## [1.0.0] - 2025-04-30
 
 [Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0...HEAD

--- a/changelog.md
+++ b/changelog.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-05-01
+
 ### Fixed
 
 - Detection on `boxlang file` execution with invalid paths was not working properly.
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.1...HEAD
+
+[1.0.1]: https://github.com/ortus-boxlang/BoxLang/compare/v1.0.0...v1.0.1
 
 [1.0.0]: https://github.com/ortus-boxlang/BoxLang/compare/aa8064a2aecbc79fbff9b31c56e0c5c6be71063f...v1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Tue Feb 18 09:03:33 UTC 2025
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.1.0
+version=1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Tue Feb 18 09:03:33 UTC 2025
+#Thu May 01 01:47:33 UTC 2025
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.0.1
+version=1.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Thu May 01 01:47:33 UTC 2025
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.1.1
+version=1.1.0

--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -300,10 +300,6 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		        true )
 		);
 
-		if ( returnContext == ReturnValueContext.VALUE || returnContext == ReturnValueContext.VALUE_OR_NULL ) {
-			nodes.add( new InsnNode( Opcodes.ACONST_NULL ) );
-		}
-
 		if ( !function.getModifiers().contains( BoxMethodDeclarationModifier.STATIC )
 		    && !function.getModifiers().contains( BoxMethodDeclarationModifier.ABSTRACT ) ) {
 			transpiler.addUDFRegistration( function.getName(), nodes );
@@ -311,9 +307,15 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 
 		if ( function.getModifiers().contains( BoxMethodDeclarationModifier.STATIC ) ) {
 			return nodes;
-		} else {
-			return new ArrayList<>();
 		}
+
+		ArrayList<AbstractInsnNode> blankResult = new ArrayList<>();
+
+		if ( returnContext == ReturnValueContext.VALUE || returnContext == ReturnValueContext.VALUE_OR_NULL ) {
+			blankResult.add( new InsnNode( Opcodes.ACONST_NULL ) );
+		}
+
+		return blankResult;
 	}
 
 	private boolean shouldDefaultOutput( BoxFunctionDeclaration function ) {

--- a/src/main/java/ortus/boxlang/compiler/ast/BoxExpressionError.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/BoxExpressionError.java
@@ -22,7 +22,7 @@ public class BoxExpressionError extends BoxExpression {
 	 */
 	@Override
 	public void accept( VoidBoxVisitor v ) {
-
+		v.visit( this );
 	}
 
 	/**
@@ -35,6 +35,6 @@ public class BoxExpressionError extends BoxExpression {
 	 */
 	@Override
 	public BoxNode accept( ReplacingBoxVisitor v ) {
-		return this;
+		return v.visit( this );
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/BoxStatementError.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/BoxStatementError.java
@@ -22,7 +22,7 @@ public class BoxStatementError extends BoxStatement {
 	 */
 	@Override
 	public void accept( VoidBoxVisitor v ) {
-
+		v.visit( this );
 	}
 
 	/**
@@ -35,6 +35,6 @@ public class BoxStatementError extends BoxStatement {
 	 */
 	@Override
 	public BoxNode accept( ReplacingBoxVisitor v ) {
-		return null;
+		return v.visit( this );
 	}
 }

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/PrettyPrintBoxVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/PrettyPrintBoxVisitor.java
@@ -18,9 +18,11 @@ import java.util.Stack;
 
 import ortus.boxlang.compiler.ast.BoxClass;
 import ortus.boxlang.compiler.ast.BoxExpression;
+import ortus.boxlang.compiler.ast.BoxExpressionError;
 import ortus.boxlang.compiler.ast.BoxInterface;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
+import ortus.boxlang.compiler.ast.BoxStatementError;
 import ortus.boxlang.compiler.ast.BoxStaticInitializer;
 import ortus.boxlang.compiler.ast.BoxTemplate;
 import ortus.boxlang.compiler.ast.comment.BoxDocComment;
@@ -1755,6 +1757,23 @@ public class PrettyPrintBoxVisitor extends VoidBoxVisitor {
 			}
 			print( ")" );
 		}
+		printPostComments( node );
+	}
+
+	/**
+	 * An invalid AST (containing error nodes) probably should not be printed out as it may be missing code.
+	 * If an error node is printed, it should be printed as the original source text.
+	 * This may or may not duplicate comments depending on whether or not the associated comments were inside the error node boundaries or not
+	 */
+	public void visit( BoxStatementError node ) {
+		printPreComments( node );
+		print( node.getSourceText() );
+		printPostComments( node );
+	}
+
+	public void visit( BoxExpressionError node ) {
+		printPreComments( node );
+		print( node.getSourceText() );
 		printPostComments( node );
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/ReplacingBoxVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/ReplacingBoxVisitor.java
@@ -18,10 +18,12 @@ import java.util.List;
 
 import ortus.boxlang.compiler.ast.BoxClass;
 import ortus.boxlang.compiler.ast.BoxExpression;
+import ortus.boxlang.compiler.ast.BoxExpressionError;
 import ortus.boxlang.compiler.ast.BoxInterface;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
 import ortus.boxlang.compiler.ast.BoxStatement;
+import ortus.boxlang.compiler.ast.BoxStatementError;
 import ortus.boxlang.compiler.ast.BoxStaticInitializer;
 import ortus.boxlang.compiler.ast.BoxTemplate;
 import ortus.boxlang.compiler.ast.comment.BoxDocComment;
@@ -1043,6 +1045,14 @@ public abstract class ReplacingBoxVisitor {
 			}
 		}
 		handleStatements( node.getBody(), node );
+		return node;
+	}
+
+	public BoxNode visit( BoxStatementError node ) {
+		return node;
+	}
+
+	public BoxNode visit( BoxExpressionError node ) {
 		return node;
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/VoidBoxVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/VoidBoxVisitor.java
@@ -15,9 +15,11 @@
 package ortus.boxlang.compiler.ast.visitor;
 
 import ortus.boxlang.compiler.ast.BoxClass;
+import ortus.boxlang.compiler.ast.BoxExpressionError;
 import ortus.boxlang.compiler.ast.BoxInterface;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
+import ortus.boxlang.compiler.ast.BoxStatementError;
 import ortus.boxlang.compiler.ast.BoxStaticInitializer;
 import ortus.boxlang.compiler.ast.BoxTemplate;
 import ortus.boxlang.compiler.ast.comment.BoxDocComment;
@@ -394,6 +396,14 @@ public abstract class VoidBoxVisitor {
 	}
 
 	public void visit( BoxFunctionalMemberAccess node ) {
+		visitChildren( node );
+	}
+
+	public void visit( BoxStatementError node ) {
+		visitChildren( node );
+	}
+
+	public void visit( BoxExpressionError node ) {
 		visitChildren( node );
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/toolchain/CFVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/toolchain/CFVisitor.java
@@ -27,7 +27,6 @@ import ortus.boxlang.compiler.ast.expression.BoxClosure;
 import ortus.boxlang.compiler.ast.expression.BoxDotAccess;
 import ortus.boxlang.compiler.ast.expression.BoxFQN;
 import ortus.boxlang.compiler.ast.expression.BoxIdentifier;
-import ortus.boxlang.compiler.ast.expression.BoxNull;
 import ortus.boxlang.compiler.ast.expression.BoxStringLiteral;
 import ortus.boxlang.compiler.ast.expression.BoxUnaryOperation;
 import ortus.boxlang.compiler.ast.expression.BoxUnaryOperator;
@@ -187,7 +186,8 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 		var					pos			= tools.getPositionStartingAt( ctx, tools.getFirstToken() );
 		var					src			= tools.getSourceText( ctx );
 
-		List<BoxStatement>	statements	= ctx.functionOrStatement().stream().map( stmt -> stmt.accept( this ) ).map( obj -> ( BoxStatement ) obj )
+		List<BoxStatement>	statements	= ctx.functionOrStatement().stream()
+		    .map( stmt -> tools.toStatementOrError( () -> ( BoxStatement ) stmt.accept( this ), stmt ) )
 		    .collect( Collectors.toList() );
 		return new BoxScript( statements, pos, src );
 	}
@@ -294,7 +294,7 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 
 		processIfNotNull( ctx.importStatement(), stmt -> imports.add( ( BoxImport ) stmt.accept( this ) ) );
 		processIfNotNull( ctx.postAnnotation(), annotation -> postAnnotations.add( ( BoxAnnotation ) annotation.accept( this ) ) );
-		processIfNotNull( ctx.function(), stmt -> body.add( ( BoxStatement ) stmt.accept( this ) ) );
+		processIfNotNull( ctx.function(), stmt -> body.add( tools.toStatementOrError( () -> ( BoxStatement ) stmt.accept( this ), stmt ) ) );
 
 		return new BoxInterface( imports, body, preAnnotations, postAnnotations, documentation, tools.getPosition( ctx ), tools.getSourceText( ctx ) );
 	}
@@ -332,7 +332,7 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 		var				pos			= tools.getPosition( ctx );
 		var				src			= tools.getSourceText( ctx );
 		BoxExpression	condition	= ctx.expression().accept( expressionVisitor );
-		BoxStatement	body		= ( BoxStatement ) ctx.statementOrBlock().accept( this );
+		BoxStatement	body		= tools.toStatementOrError( () -> ( BoxStatement ) ctx.statementOrBlock().accept( this ), ctx.statementOrBlock() );
 		String			label		= Optional.ofNullable( ctx.preFix() ).map( preFix -> preFix.identifier().getText() ).orElse( null );
 		return new BoxDo( label, condition, body, pos, src );
 	}
@@ -341,7 +341,7 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 	public BoxNode visitFor( ForContext ctx ) {
 		var					pos			= tools.getPosition( ctx );
 		var					src			= tools.getSourceText( ctx );
-		BoxStatement		body		= ( BoxStatement ) ctx.statementOrBlock().accept( this );
+		BoxStatement		body		= tools.toStatementOrError( () -> ( BoxStatement ) ctx.statementOrBlock().accept( this ), ctx.statementOrBlock() );
 		String				label		= Optional.ofNullable( ctx.preFix() ).map( preFix -> preFix.identifier().getText() ).orElse( null );
 		List<BoxExpression>	expressions	= Optional.ofNullable( ctx.expression() ).orElse( Collections.emptyList() ).stream()
 		    .map( expression -> expression.accept( expressionVisitor ) ).toList();
@@ -368,8 +368,9 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 		var				pos			= tools.getPosition( ctx );
 		var				src			= tools.getSourceText( ctx );
 		BoxExpression	condition	= ctx.expression().accept( expressionVisitor );
-		BoxStatement	thenBody	= ( BoxStatement ) ctx.ifStmt.accept( this );
-		BoxStatement	elseBody	= Optional.ofNullable( ctx.elseStmt ).map( stmt -> ( BoxStatement ) stmt.accept( this ) ).orElse( null );
+		BoxStatement	thenBody	= tools.toStatementOrError( () -> ( BoxStatement ) ctx.ifStmt.accept( this ), ctx.ifStmt );
+		BoxStatement	elseBody	= Optional.ofNullable( ctx.elseStmt )
+		    .map( stmt -> tools.toStatementOrError( () -> ( BoxStatement ) stmt.accept( this ), stmt ) ).orElse( null );
 		return new BoxIfElse( condition, thenBody, elseBody, pos, src );
 	}
 
@@ -395,7 +396,8 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 		// Produce body from iterating ctx.statement() and calling accept(this) on each one,
 		// or assign null to body if there are no ctx.statement()
 		List<BoxStatement>	body		= Optional.ofNullable( ctx.statementOrBlock() )
-		    .map( statements -> statements.stream().map( statement -> ( BoxStatement ) statement.accept( this ) ).collect( Collectors.toList() ) )
+		    .map( statements -> statements.stream().map( statement -> tools.toStatementOrError( () -> ( BoxStatement ) statement.accept( this ), statement ) )
+		        .collect( Collectors.toList() ) )
 		    .orElse( List.of() );
 
 		return new BoxSwitchCase( condition, null, body, pos, src );
@@ -432,7 +434,7 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 		var				src			= tools.getSourceText( ctx );
 
 		BoxExpression	condition	= ctx.expression().accept( expressionVisitor );
-		BoxStatement	body		= ( BoxStatement ) ctx.statementOrBlock().accept( this );
+		BoxStatement	body		= tools.toStatementOrError( () -> ( BoxStatement ) ctx.statementOrBlock().accept( this ), ctx.statementOrBlock() );
 		String			label		= Optional.ofNullable( ctx.preFix() ).map( preFix -> preFix.identifier().getText() ).orElse( null );
 		return new BoxWhile( label, condition, body, pos, src );
 	}
@@ -945,13 +947,13 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 
 	private List<BoxStatement> buildClassBody( ClassBodyContext ctx ) {
 		List<BoxStatement> body = new ArrayList<>();
-		processIfNotNull( ctx.classBodyStatement(), stmt -> body.add( ( BoxStatement ) stmt.accept( this ) ) );
+		processIfNotNull( ctx.classBodyStatement(), stmt -> body.add( tools.toStatementOrError( () -> ( BoxStatement ) stmt.accept( this ), stmt ) ) );
 		return body;
 	}
 
 	private List<BoxStatement> buildStaticBody( NormalStatementBlockContext ctx ) {
 		List<BoxStatement> body = new ArrayList<>();
-		processIfNotNull( ctx.statement(), stmt -> body.add( ( BoxStatement ) stmt.accept( this ) ) );
+		processIfNotNull( ctx.statement(), stmt -> body.add( tools.toStatementOrError( () -> ( BoxStatement ) stmt.accept( this ), stmt ) ) );
 		return body;
 	}
 
@@ -1055,13 +1057,17 @@ public class CFVisitor extends CFGrammarBaseVisitor<BoxNode> {
 
 	private List<BoxStatement> buildStatementBlock( StatementBlockContext statementBlock ) {
 		return Optional.ofNullable( statementBlock ).map( StatementBlockContext::statement ).orElse( Collections.emptyList() ).stream()
-		    .map( statement -> statement.accept( this ) ).filter( boxNode -> ! ( boxNode instanceof BoxNull ) ).map( boxNode -> ( BoxStatement ) boxNode )
+		    .map( statement -> tools.toStatementOrError( () -> ( BoxStatement ) statement.accept( this ), statement ) )
+		    // How would a BoxNull ever be at the top level of a statement block?
+		    // .filter( boxNode -> ! ( boxNode instanceof BoxNull ) ).map( boxNode -> ( BoxStatement ) boxNode )
 		    .collect( Collectors.toList() );
 	}
 
 	private List<BoxStatement> buildStatementBlock( NormalStatementBlockContext statementBlock ) {
 		return Optional.ofNullable( statementBlock ).map( NormalStatementBlockContext::statement ).orElse( Collections.emptyList() ).stream()
-		    .map( statement -> statement.accept( this ) ).filter( boxNode -> ! ( boxNode instanceof BoxNull ) ).map( boxNode -> ( BoxStatement ) boxNode )
+		    .map( statement -> tools.toStatementOrError( () -> ( BoxStatement ) statement.accept( this ), statement ) )
+		    // How would a BoxNull ever be at the top level of a statement block?
+		    // .filter( boxNode -> ! ( boxNode instanceof BoxNull ) ).map( boxNode -> ( BoxStatement ) boxNode )
 		    .collect( Collectors.toList() );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -456,7 +456,7 @@ public class BoxRunner {
 			// Mutually exclusive with template
 			if ( currentArgument.equalsIgnoreCase( "--bx-code" ) ) {
 				if ( argsList.isEmpty() ) {
-					throw new BoxRuntimeException( "Missing inline code to execute with -c flag." );
+					throw new BoxRuntimeException( "Missing inline code to execute with --bx-code flag." );
 				}
 				code = argsList.remove( 0 );
 				break;

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -41,8 +42,10 @@ import org.slf4j.Logger;
 import ortus.boxlang.compiler.ClassInfo;
 import ortus.boxlang.compiler.IBoxpiler;
 import ortus.boxlang.compiler.asmboxpiler.ASMBoxpiler;
+import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler;
 import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
 import ortus.boxlang.runtime.application.BaseApplicationListener;
 import ortus.boxlang.runtime.config.CLIOptions;
@@ -1669,6 +1672,59 @@ public class BoxRuntime implements java.io.Closeable {
 	public void printSourceAST( String source ) {
 		ParsingResult result = this.boxpiler.parseOrFail( source, BoxSourceType.BOXSCRIPT, false );
 		System.out.println( result.getRoot().toJSON() );
+	}
+
+	/**
+	 * Parse a script file
+	 * This is a passthrough to the Boxpiler parse method
+	 *
+	 * @param file source file to parse
+	 *
+	 * @return a ParsingResult containing the AST with a BoxScript as root and the list of errors (if any)
+	 *
+	 * @throws IOException
+	 *
+	 * @see BoxScript
+	 * @see ParsingResult
+	 */
+	public ParsingResult parse( File file ) {
+		return new Parser().parse( file );
+	}
+
+	/**
+	 * Parse a script string
+	 * This is a passthrough to the Boxpiler parse method
+	 *
+	 * @param code       source of the expression to parse
+	 * @param sourceType the type of source to parse. Available options are: BOXSCRIPT, BOXTEMPLATE, CFSCRIPT, CFTEMPLATE
+	 *
+	 * @return a ParsingResult containing the AST with a BoxExpr as root and the list of errors (if any)
+	 *
+	 * @throws IOException
+	 *
+	 * @see ParsingResult
+	 * @see BoxExpression
+	 */
+	public ParsingResult parse( String code, BoxSourceType sourceType ) throws IOException {
+		return new Parser().parse( code, sourceType );
+	}
+
+	/**
+	 * Parse a script string expression
+	 * This is a passthrough to the Boxpiler parse method
+	 * Defaults to BoxScript source type. If you want to parse another type, use the other method
+	 *
+	 * @param code source of the expression to parse
+	 *
+	 * @return a ParsingResult containing the AST with a BoxExpr as root and the list of errors (if any)
+	 *
+	 * @throws IOException
+	 *
+	 * @see ParsingResult
+	 * @see BoxExpression
+	 */
+	public ParsingResult parse( String code ) throws IOException {
+		return new Parser().parse( code, BoxSourceType.BOXSCRIPT );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -498,25 +498,25 @@ public class Application {
 				BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
 				timeoutDuration = Duration.ofMinutes( timeoutMinutes.longValue() );
 			} else if ( sessionTimeout instanceof String && StringCaster.cast( sessionTimeout ).contains( "." ) ) {
-				BigDecimal castDecimal = BigDecimalCaster.cast( sessionTimeout );
-				BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
+				BigDecimal	castDecimal		= BigDecimalCaster.cast( sessionTimeout );
+				BigDecimal	timeoutMinutes	= castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
 				timeoutDuration = Duration.ofMinutes( timeoutMinutes.longValue() );
 			} else {
 				timeoutDuration = Duration.ofDays( LongCaster.cast( sessionTimeout ) );
 			}
 		}
 		// Dumb Java! It needs a final variable to use in the lambda
-		final Duration	finalTimeoutDuration	= timeoutDuration;
+		final Duration finalTimeoutDuration = timeoutDuration;
 		// Make sure our created duration is represented in the application metadata
 		context.getParentOfType( RequestBoxContext.class )
 		    .getApplicationListener()
-			.getSettings()
+		    .getSettings()
 		    .put( Key.sessionTimeout, finalTimeoutDuration );
 
 		// logger.debug( "**** getOrCreateSession {} Timeout {} ", ID, timeoutDuration );
 
 		// Get or create the session
-		Session			targetSession			= ( Session ) this.sessionsCache.getOrSet(
+		Session targetSession = ( Session ) this.sessionsCache.getOrSet(
 		    cacheKey,
 		    () -> new Session( ID, this, finalTimeoutDuration ),
 		    timeoutDuration,

--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -587,12 +587,21 @@ public class Application {
 	public boolean isExpired() {
 		Object		appTimeout	= this.startingListener.getSettings().get( Key.applicationTimeout );
 		Duration	appDuration	= null;
-		// Duration is the default, but if not, we will use the number as seconds
+		// Duration is the default, but if not, we will use the number as minutes
 		// Which is what the cache providers expect
 		if ( appTimeout instanceof Duration castedTimeout ) {
 			appDuration = castedTimeout;
 		} else {
-			appDuration = Duration.ofMinutes( LongCaster.cast( appTimeout ) );
+			if ( appTimeout instanceof BigDecimal castDecimal ) {
+				BigDecimal timeoutSeconds = castDecimal.multiply( BigDecimalCaster.cast( 60 ) );
+				appDuration = Duration.ofSeconds( timeoutSeconds.longValue() );
+			} else if ( appTimeout instanceof String && StringCaster.cast( appTimeout ).contains( "." ) ) {
+				BigDecimal	castDecimal		= BigDecimalCaster.cast( appTimeout );
+				BigDecimal	timeoutSeconds	= castDecimal.multiply( BigDecimalCaster.cast( 60 ) );
+				appDuration = Duration.ofSeconds( timeoutSeconds.longValue() );
+			} else {
+				appDuration = Duration.ofMinutes( LongCaster.cast( appTimeout ) );
+			}
 		}
 
 		// If the duration is zero, then it never expires

--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -497,12 +497,21 @@ public class Application {
 			if ( sessionTimeout instanceof BigDecimal castDecimal ) {
 				BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
 				timeoutDuration = Duration.ofMinutes( timeoutMinutes.longValue() );
+			} else if ( sessionTimeout instanceof String && StringCaster.cast( sessionTimeout ).contains( "." ) ) {
+				BigDecimal castDecimal = BigDecimalCaster.cast( sessionTimeout );
+				BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
+				timeoutDuration = Duration.ofMinutes( timeoutMinutes.longValue() );
 			} else {
 				timeoutDuration = Duration.ofDays( LongCaster.cast( sessionTimeout ) );
 			}
 		}
 		// Dumb Java! It needs a final variable to use in the lambda
 		final Duration	finalTimeoutDuration	= timeoutDuration;
+		// Make sure our created duration is represented in the application metadata
+		context.getParentOfType( RequestBoxContext.class )
+		    .getApplicationListener()
+			.getSettings()
+		    .put( Key.sessionTimeout, finalTimeoutDuration );
 
 		// logger.debug( "**** getOrCreateSession {} Timeout {} ", ID, timeoutDuration );
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/io/FileExists.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/io/FileExists.java
@@ -56,15 +56,18 @@ public class FileExists extends BIF {
 		String	filePath		= arguments.getAsString( Key.source );
 		Boolean	allowRealPath	= arguments.getAsBoolean( Key.allowRealPath );
 		try {
+			Path finalPath;
 			if ( !allowRealPath && Path.of( filePath ).isAbsolute() ) {
 				throw new BoxRuntimeException(
 				    "The file or path argument [" + filePath + "] is an absolute path. This is disallowed when the allowRealPath argument is set to false."
 				);
 			} else if ( !FileSystemUtil.exists( filePath ) ) {
-				filePath = FileSystemUtil.expandPath( context, filePath ).toString();
+				finalPath = FileSystemUtil.expandPath( context, filePath ).absolutePath();
+			} else {
+				finalPath = Path.of( filePath );
 			}
 
-			return ( Boolean ) FileSystemUtil.exists( filePath ) && !Files.isDirectory( Path.of( filePath ) );
+			return ( Boolean ) finalPath.toFile().exists() && !Files.isDirectory( finalPath );
 		} catch ( java.nio.file.InvalidPathException e ) {
 			// We ignore invalid paths
 			return false;

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/LCase.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/LCase.java
@@ -48,7 +48,13 @@ public class LCase extends BIF {
 	 * 
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		return arguments.getAsString( Key.string ).toLowerCase();
+		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
+		return input.toLowerCase();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/Left.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/Left.java
@@ -50,8 +50,13 @@ public class Left extends BIF {
 	 * @argument.count The number of characters to retrieve.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	input	= arguments.getAsString( Key.string );
-		int		count	= arguments.getAsInteger( Key.count );
+		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
+		int count = arguments.getAsInteger( Key.count );
 
 		// Check if count is zero
 		if ( count == 0 ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/Mid.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/Mid.java
@@ -52,9 +52,14 @@ public class Mid extends BIF {
 	 * @argument.count The number of characters to retrieve.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	input	= arguments.getAsString( Key.string );
-		int		start	= arguments.getAsInteger( Key.start );
-		int		count	= arguments.getAsInteger( Key.count );
+		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
+		int	start	= arguments.getAsInteger( Key.start );
+		int	count	= arguments.getAsInteger( Key.count );
 
 		// Check if start and count are within valid bounds
 		if ( start < 1 ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReReplace.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReReplace.java
@@ -146,7 +146,14 @@ public class ReReplace extends BIF {
 							}
 						}
 
-						replacement.replace( i, i + 2, group );
+						if ( group != null ) {
+							replacement.replace( i, i + 2, group );
+							i += group.length() - 2;
+						} else {
+							// Skip replacement if group is null
+							replacement.delete( i, i + 2 );
+							i -= 2;
+						}
 						i += ( group != null ? group.length() : 0 ) - 2;
 					}
 				}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReReplace.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/ReReplace.java
@@ -154,7 +154,6 @@ public class ReReplace extends BIF {
 							replacement.delete( i, i + 2 );
 							i -= 2;
 						}
-						i += ( group != null ? group.length() : 0 ) - 2;
 					}
 				}
 			}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/Right.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/Right.java
@@ -50,8 +50,13 @@ public class Right extends BIF {
 	 * @argument.count The number of characters to retrieve.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	input	= arguments.getAsString( Key.string );
-		int		count	= arguments.getAsInteger( Key.count );
+		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
+		int count = arguments.getAsInteger( Key.count );
 
 		// Check if count is zero
 		if ( count == 0 ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/Trim.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/Trim.java
@@ -47,6 +47,11 @@ public class Trim extends BIF {
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
 		return input.trim();
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/UCase.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/UCase.java
@@ -48,7 +48,13 @@ public class UCase extends BIF {
 	 * 
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		return arguments.getAsString( Key.string ).toUpperCase();
+		String input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return "";
+		}
+
+		return input.toUpperCase();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/Val.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/Val.java
@@ -47,7 +47,12 @@ public class Val extends BIF {
 	 * @argument.string The string to parse
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		var		input		= arguments.getAsString( Key.string );
+		var input = arguments.getAsString( Key.string );
+
+		if ( input == null ) {
+			return 0;
+		}
+
 		var		result		= new StringBuilder();
 		boolean	foundDot	= false;
 		// Loop over each character in the string

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpan.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpan.java
@@ -17,12 +17,15 @@
  */
 package ortus.boxlang.runtime.bifs.global.temporal;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.dynamic.casters.BigDecimalCaster;
+import ortus.boxlang.runtime.dynamic.casters.LongCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 
@@ -36,11 +39,11 @@ public class CreateTimeSpan extends BIF {
 	public CreateTimeSpan() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "long", Key.days ),
-		    new Argument( true, "long", Key.hours ),
-		    new Argument( true, "long", Key.minutes ),
-		    new Argument( true, "long", Key.seconds ),
-		    new Argument( false, "long", Key.milliseconds, 0l )
+				new Argument(true, "numeric", Key.days),
+				new Argument(true, "numeric", Key.hours),
+				new Argument(true, "numeric", Key.minutes),
+				new Argument(true, "numeric", Key.seconds),
+				new Argument(false, "numeric", Key.milliseconds, 0l)
 		};
 	}
 
@@ -60,12 +63,35 @@ public class CreateTimeSpan extends BIF {
 	 *
 	 * @argument.milliseconds The number of milliseconds in the timespan
 	 */
-	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		return Duration.ofDays( arguments.getAsLong( Key.days ) )
-		    .plusHours( arguments.getAsLong( Key.hours ) )
-		    .plusMinutes( arguments.getAsLong( Key.minutes ) )
-		    .plusSeconds( arguments.getAsLong( Key.seconds ) )
-		    .plusMillis( arguments.getAsLong( Key.milliseconds ) );
+	public Object _invoke(IBoxContext context, ArgumentsScope arguments) {
+		// Check to see if any of the inbound arguments are decimals. If so, demote them
+		// for assignment
+		if (arguments.get(Key.days) instanceof BigDecimal castDecimal) {
+			BigDecimal timeoutMinutes = castDecimal.multiply(BigDecimalCaster.cast(1440));
+			arguments.put(Key.days, 0l);
+			arguments.put(Key.minutes, timeoutMinutes.longValue());
+		}
+		if (arguments.get(Key.hours) instanceof BigDecimal castDecimal) {
+			BigDecimal timeoutMinutes = castDecimal.multiply(BigDecimalCaster.cast(60));
+			arguments.put(Key.hours, 0l);
+			arguments.put(Key.minutes, timeoutMinutes.longValue());
+		}
+		if (arguments.get(Key.minutes) instanceof BigDecimal castDecimal) {
+			BigDecimal timeoutSeconds = castDecimal.multiply(BigDecimalCaster.cast(60));
+			arguments.put(Key.minutes, 0l);
+			arguments.put(Key.seconds, timeoutSeconds.longValue());
+		}
+		if (arguments.get(Key.seconds) instanceof BigDecimal castDecimal) {
+			BigDecimal timeoutMilliseconds = castDecimal.multiply(BigDecimalCaster.cast(1000));
+			arguments.put(Key.seconds, 0l);
+			arguments.put(Key.milliseconds, timeoutMilliseconds.longValue());
+		}
+
+		return Duration.ofDays(LongCaster.cast(arguments.get(Key.days)))
+				.plusHours(LongCaster.cast(arguments.get(Key.hours)))
+				.plusMinutes(LongCaster.cast(arguments.get(Key.minutes)))
+				.plusSeconds(LongCaster.cast(arguments.get(Key.seconds)))
+				.plusMillis(LongCaster.cast(arguments.get(Key.milliseconds)));
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpan.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpan.java
@@ -39,11 +39,11 @@ public class CreateTimeSpan extends BIF {
 	public CreateTimeSpan() {
 		super();
 		declaredArguments = new Argument[] {
-				new Argument(true, "numeric", Key.days),
-				new Argument(true, "numeric", Key.hours),
-				new Argument(true, "numeric", Key.minutes),
-				new Argument(true, "numeric", Key.seconds),
-				new Argument(false, "numeric", Key.milliseconds, 0l)
+		    new Argument( true, "numeric", Key.days ),
+		    new Argument( true, "numeric", Key.hours ),
+		    new Argument( true, "numeric", Key.minutes ),
+		    new Argument( true, "numeric", Key.seconds ),
+		    new Argument( false, "numeric", Key.milliseconds, 0l )
 		};
 	}
 
@@ -63,35 +63,35 @@ public class CreateTimeSpan extends BIF {
 	 *
 	 * @argument.milliseconds The number of milliseconds in the timespan
 	 */
-	public Object _invoke(IBoxContext context, ArgumentsScope arguments) {
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		// Check to see if any of the inbound arguments are decimals. If so, demote them
 		// for assignment
-		if (arguments.get(Key.days) instanceof BigDecimal castDecimal) {
-			BigDecimal timeoutMinutes = castDecimal.multiply(BigDecimalCaster.cast(1440));
-			arguments.put(Key.days, 0l);
-			arguments.put(Key.minutes, timeoutMinutes.longValue());
+		if ( arguments.get( Key.days ) instanceof BigDecimal castDecimal ) {
+			BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 1440 ) );
+			arguments.put( Key.days, 0l );
+			arguments.put( Key.minutes, timeoutMinutes.longValue() );
 		}
-		if (arguments.get(Key.hours) instanceof BigDecimal castDecimal) {
-			BigDecimal timeoutMinutes = castDecimal.multiply(BigDecimalCaster.cast(60));
-			arguments.put(Key.hours, 0l);
-			arguments.put(Key.minutes, timeoutMinutes.longValue());
+		if ( arguments.get( Key.hours ) instanceof BigDecimal castDecimal ) {
+			BigDecimal timeoutMinutes = castDecimal.multiply( BigDecimalCaster.cast( 60 ) );
+			arguments.put( Key.hours, 0l );
+			arguments.put( Key.minutes, timeoutMinutes.longValue() );
 		}
-		if (arguments.get(Key.minutes) instanceof BigDecimal castDecimal) {
-			BigDecimal timeoutSeconds = castDecimal.multiply(BigDecimalCaster.cast(60));
-			arguments.put(Key.minutes, 0l);
-			arguments.put(Key.seconds, timeoutSeconds.longValue());
+		if ( arguments.get( Key.minutes ) instanceof BigDecimal castDecimal ) {
+			BigDecimal timeoutSeconds = castDecimal.multiply( BigDecimalCaster.cast( 60 ) );
+			arguments.put( Key.minutes, 0l );
+			arguments.put( Key.seconds, timeoutSeconds.longValue() );
 		}
-		if (arguments.get(Key.seconds) instanceof BigDecimal castDecimal) {
-			BigDecimal timeoutMilliseconds = castDecimal.multiply(BigDecimalCaster.cast(1000));
-			arguments.put(Key.seconds, 0l);
-			arguments.put(Key.milliseconds, timeoutMilliseconds.longValue());
+		if ( arguments.get( Key.seconds ) instanceof BigDecimal castDecimal ) {
+			BigDecimal timeoutMilliseconds = castDecimal.multiply( BigDecimalCaster.cast( 1000 ) );
+			arguments.put( Key.seconds, 0l );
+			arguments.put( Key.milliseconds, timeoutMilliseconds.longValue() );
 		}
 
-		return Duration.ofDays(LongCaster.cast(arguments.get(Key.days)))
-				.plusHours(LongCaster.cast(arguments.get(Key.hours)))
-				.plusMinutes(LongCaster.cast(arguments.get(Key.minutes)))
-				.plusSeconds(LongCaster.cast(arguments.get(Key.seconds)))
-				.plusMillis(LongCaster.cast(arguments.get(Key.milliseconds)));
+		return Duration.ofDays( LongCaster.cast( arguments.get( Key.days ) ) )
+		    .plusHours( LongCaster.cast( arguments.get( Key.hours ) ) )
+		    .plusMinutes( LongCaster.cast( arguments.get( Key.minutes ) ) )
+		    .plusSeconds( LongCaster.cast( arguments.get( Key.seconds ) ) )
+		    .plusMillis( LongCaster.cast( arguments.get( Key.milliseconds ) ) );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -619,6 +619,9 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 		if ( properties.containsKey( Key.leakDetectionThreshold ) ) {
 			result.setLeakDetectionThreshold( LongCaster.cast( properties.get( Key.leakDetectionThreshold ), false ) * 1000 );
 		}
+		if ( properties.containsKey( Key.initializationFailTimeout ) ) {
+			result.setInitializationFailTimeout( LongCaster.cast( properties.getOrDefault( Key.initializationFailTimeout, 1 ) ) );
+		}
 
 		// ADD NON-RESERVED PROPERTIES
 		// as Hikari properties

--- a/src/main/java/ortus/boxlang/runtime/config/segments/SecurityConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/SecurityConfig.java
@@ -38,6 +38,11 @@ import ortus.boxlang.runtime.types.Struct;
 public class SecurityConfig implements IConfigSegment {
 
 	/**
+	 * A flag indicating whether the server system scope should be populated.
+	 */
+	public boolean				populateServerSystemScope			= true;
+
+	/**
 	 * A list of disallowed imports for the runtime
 	 * These are a list of regular expressions that are used to match against the import statements in the code
 	 * Ex: "disallowedImports": ["java\\.lang\\.(ProcessBuilder|Reflect", "java\\.io\\.(File|FileWriter)"]
@@ -151,9 +156,9 @@ public class SecurityConfig implements IConfigSegment {
 
 	/**
 	 * Determines whether a file operation is allowed or not based on the file extension.
-	 * 
+	 *
 	 * @param file
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isFileOperationAllowed( String file ) {
@@ -163,9 +168,9 @@ public class SecurityConfig implements IConfigSegment {
 
 	/**
 	 * Determines whether a file extension is allowed or not.
-	 * 
+	 *
 	 * @param extension
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isExtensionAllowed( String extension ) {
@@ -203,7 +208,8 @@ public class SecurityConfig implements IConfigSegment {
 		    Key.disallowedImports, this.disallowedImports,
 		    Key.disallowedBIFs, this.disallowedBIFs,
 		    Key.disallowedComponents, this.disallowedComponents,
-		    Key.disallowedFileOperationExtensions, Array.fromList( this.disallowedFileOperationExtensions )
+		    Key.disallowedFileOperationExtensions, Array.fromList( this.disallowedFileOperationExtensions ),
+		    Key.populateServerSystemScope, this.populateServerSystemScope
 		);
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/ArrayCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/ArrayCaster.java
@@ -23,6 +23,7 @@ import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.QueryColumn;
+import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 
 /**
@@ -102,6 +103,9 @@ public class ArrayCaster implements IBoxCaster {
 			}
 			case QueryColumn col -> {
 				return col.getColumnDataAsArray();
+			}
+			case XML xml -> {
+				return xml.getSiblingsOfSameName();
 			}
 			default -> {
 			}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/CollectionCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/CollectionCaster.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
@@ -100,6 +101,14 @@ public class CollectionCaster implements IBoxCaster {
 		if ( object.getClass().isArray() ) {
 			Object[] array = ( Object[] ) object;
 			return Arrays.asList( array );
+		}
+
+		// A class just uses the public this scope as the collection
+		if ( object instanceof IClassRunnable icr ) {
+			return icr.getThisScope().keySet()
+			    .stream()
+			    .map( k -> k.getName() )
+			    .collect( Collectors.toList() );
 		}
 
 		CastAttempt<String> stringAttempt = StringCaster.attempt( object );

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
@@ -203,6 +203,9 @@ public class GenericCaster implements IBoxCaster {
 			    || type.equals( "modifiablestruct" ) ) {
 				// Any Box Class is also considered of type "component" or "class" or "struct" or "structloose" or "modifiablestruct"
 				return object;
+			} else if ( type.equals( "collection" ) ) {
+				// Need a special case for collections, since we'll never hit the generic check below
+				return CollectionCaster.cast( object, fail );
 			} else if ( fail ) {
 				throw new BoxCastException( String.format( "Could not cast object [%s] to type [%s]", object.getClass().getSimpleName(), type ) );
 			} else {

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorEntry.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorEntry.java
@@ -1,0 +1,54 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.events;
+
+import ortus.boxlang.runtime.interop.DynamicObject;
+
+/**
+ * This represents the interceptor object and it's invoker to avoid runtime lookups
+ * when invoking the interceptor.
+ */
+public class InterceptorEntry {
+
+	public final DynamicObject		interceptor;
+	public final InterceptorInvoker	invoker;
+
+	/**
+	 * Constructor
+	 *
+	 * @param interceptor The interceptor object
+	 * @param invoker     The interceptor invoker
+	 */
+	InterceptorEntry( DynamicObject interceptor, InterceptorInvoker invoker ) {
+		this.interceptor	= interceptor;
+		this.invoker		= invoker;
+	}
+
+	/**
+	 * Equals method. Verifies if the incoming object is the same as this interceptor.
+	 * This is used to verify if the interceptor is already registered in the interceptor state
+	 *
+	 * @param obj The object to compare
+	 *
+	 * @return true if the object is the same as this interceptor
+	 */
+	public boolean equals( DynamicObject obj ) {
+		return this.interceptor.equals( obj );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorInvoker.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorInvoker.java
@@ -1,0 +1,37 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.events;
+
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.types.IStruct;
+
+@FunctionalInterface
+interface InterceptorInvoker {
+
+	/**
+	 * Invokes the interceptor with the given data and context.
+	 * This is done in order to avoid runtime lookups/instance checks when invoking the interceptor.
+	 *
+	 * @param data     The data to be passed to the interceptor.
+	 * @param context  The context in which the interceptor is invoked.
+	 * @param observer The observer that is being invoked.
+	 *
+	 * @return The result of the interceptor invocation, which can be null or boolean
+	 */
+	Object invoke( IStruct data, IBoxContext context, Object observer );
+}

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorInvoker.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorInvoker.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime.events;
 
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.IStruct;
 
 @FunctionalInterface
@@ -33,5 +34,5 @@ interface InterceptorInvoker {
 	 *
 	 * @return The result of the interceptor invocation, which can be null or boolean
 	 */
-	Object invoke( IStruct data, IBoxContext context, Object observer );
+	Object invoke( IStruct data, IBoxContext context, DynamicObject observer );
 }

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
@@ -52,6 +52,13 @@ public class InterceptorPool {
 
 	/**
 	 * --------------------------------------------------------------------------
+	 * Constants
+	 * --------------------------------------------------------------------------
+	 */
+	private static final IStruct				EMPTY_STRUCT		= new Struct();
+
+	/**
+	 * --------------------------------------------------------------------------
 	 * Private Properties
 	 * --------------------------------------------------------------------------
 	 */
@@ -365,7 +372,7 @@ public class InterceptorPool {
 	 */
 	public InterceptorPool register( IInterceptor interceptor ) {
 		// No properties
-		return register( interceptor, new Struct() );
+		return register( interceptor, EMPTY_STRUCT );
 	}
 
 	/**
@@ -549,7 +556,7 @@ public class InterceptorPool {
 	 * @param state The state key to announce
 	 */
 	public void announce( Key state ) {
-		announce( state, new Struct() );
+		announce( state, EMPTY_STRUCT );
 	}
 
 	/**
@@ -558,7 +565,7 @@ public class InterceptorPool {
 	 * @param state The state key to announce
 	 */
 	public void announce( BoxEvent state ) {
-		announce( state.key(), new Struct() );
+		announce( state.key(), EMPTY_STRUCT );
 	}
 
 	/**
@@ -627,7 +634,7 @@ public class InterceptorPool {
 	 * @return A CompletableFuture of the data or null if the state does not exist
 	 */
 	public CompletableFuture<IStruct> announceAsync( Key state ) {
-		return announceAsync( state, new Struct() );
+		return announceAsync( state, EMPTY_STRUCT );
 	}
 
 	/**
@@ -638,7 +645,7 @@ public class InterceptorPool {
 	 * @return A CompletableFuture of the data or null if the state does not exist
 	 */
 	public CompletableFuture<IStruct> announceAsync( BoxEvent state ) {
-		return announceAsync( state.key(), new Struct() );
+		return announceAsync( state.key(), EMPTY_STRUCT );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorState.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorState.java
@@ -97,7 +97,7 @@ public class InterceptorState {
 
 		// This is a BoxLang class
 		if ( interceptor instanceof IReferenceable ) {
-			invoker = ( data, context, target ) -> ( ( IReferenceable ) target ).dereferenceAndInvoke(
+			invoker = ( data, context, target ) -> ( ( IReferenceable ) target.unWrap() ).dereferenceAndInvoke(
 			    context,
 			    getName(),
 			    new Object[] { data, context },
@@ -106,11 +106,11 @@ public class InterceptorState {
 		}
 		// Java Interceptor Lambdas
 		else if ( interceptor instanceof IInterceptorLambda ) {
-			invoker = ( data, context, target ) -> ( ( IInterceptorLambda ) target ).intercept( data );
+			invoker = ( data, context, target ) -> ( ( IInterceptorLambda ) target.unWrap() ).intercept( data );
 		}
 		// Anything else is a Java class
 		else {
-			invoker = ( data, context, target ) -> ( ( DynamicObject ) target ).invoke( context, getName().getName(), new Object[] { data } );
+			invoker = ( data, context, target ) -> target.invoke( context, getName().getName(), new Object[] { data, context } );
 		}
 
 		// Register the interceptor entry set
@@ -178,7 +178,7 @@ public class InterceptorState {
 		// Process the state
 		for ( InterceptorEntry entry : this.observers ) {
 			// Run baby run!
-			Object stopChain = entry.invoker.invoke( data, context, entry.interceptor.unWrap() );
+			Object stopChain = entry.invoker.invoke( data, context, entry.interceptor );
 			// If the observer returns true, we short circuit the rest of the observers
 			if ( Boolean.TRUE.equals( stopChain ) ) {
 				break;

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorState.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorState.java
@@ -17,12 +17,11 @@
  */
 package ortus.boxlang.runtime.events;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.IReferenceable;
-import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
@@ -37,14 +36,14 @@ import ortus.boxlang.runtime.types.IStruct;
 public class InterceptorState {
 
 	/**
-	 * The state name (e.g. "preProcess", "postProcess", "onRuntimeStartup" etc.)
+	 * The interception state we represent (e.g. "preProcess", "postProcess", "onRuntimeStartup" etc.)
 	 */
-	private Key					name;
+	private Key								name;
 
 	/**
 	 * The observers for this state
 	 */
-	private List<DynamicObject>	observers	= new ArrayList<>();
+	private final List<InterceptorEntry>	observers	= new CopyOnWriteArrayList<>();
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -88,12 +87,34 @@ public class InterceptorState {
 	/**
 	 * Register an observer for this state
 	 *
-	 * @param observer The observer
+	 * @param observer The observer to register
 	 *
 	 * @return The same state
 	 */
 	public InterceptorState register( DynamicObject observer ) {
-		this.observers.add( observer );
+		InterceptorInvoker	invoker;
+		Object				interceptor	= observer.unWrap();
+
+		// This is a BoxLang class
+		if ( interceptor instanceof IReferenceable ) {
+			invoker = ( data, context, target ) -> ( ( IReferenceable ) target ).dereferenceAndInvoke(
+			    context,
+			    getName(),
+			    new Object[] { data, context },
+			    false
+			);
+		}
+		// Java Interceptor Lambdas
+		else if ( interceptor instanceof IInterceptorLambda ) {
+			invoker = ( data, context, target ) -> ( ( IInterceptorLambda ) target ).intercept( data );
+		}
+		// Anything else is a Java class
+		else {
+			invoker = ( data, context, target ) -> ( ( DynamicObject ) target ).invoke( context, getName().getName(), new Object[] { data } );
+		}
+
+		// Register the interceptor entry set
+		this.observers.add( new InterceptorEntry( observer, invoker ) );
 		return this;
 	}
 
@@ -105,7 +126,13 @@ public class InterceptorState {
 	 * @return The same state
 	 */
 	public InterceptorState unregister( DynamicObject observer ) {
-		this.observers.remove( observer );
+		// Iterate and remove the interceptor if found, by calling the equals method
+		for ( InterceptorEntry entry : this.observers ) {
+			if ( entry.equals( observer ) ) {
+				this.observers.remove( entry );
+				break;
+			}
+		}
 		return this;
 	}
 
@@ -117,7 +144,13 @@ public class InterceptorState {
 	 * @return True if the observer is registered, false otherwise
 	 */
 	public Boolean exists( DynamicObject observer ) {
-		return this.observers.contains( observer );
+		// Iterate and check if the interceptor is registered
+		for ( InterceptorEntry entry : this.observers ) {
+			if ( entry.equals( observer ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -143,31 +176,11 @@ public class InterceptorState {
 		}
 
 		// Process the state
-		Object[] args = new Object[] { data };
-		for ( DynamicObject observer : this.observers ) {
-			Object	stopChain;
-			// Get the actual instance from the dynamic object
-			Object	unwrappedObject	= observer.unWrap();
-
-			// Do we have a BoxLang class or Java Class
-			if ( unwrappedObject instanceof IReferenceable castedObserver ) {
-				// Dereference and Invoke the BoxLang class
-				stopChain = castedObserver.dereferenceAndInvoke(
-				    context,
-				    getName(),
-				    args,
-				    false
-				);
-			} else if ( unwrappedObject instanceof IInterceptorLambda castedLambda ) {
-				// Invoke the Java lambda
-				stopChain = castedLambda.intercept( data );
-			} else {
-				// Announce to the Java observer via Indy
-				stopChain = observer.invoke( context, getName().getName(), args );
-			}
-
+		for ( InterceptorEntry entry : this.observers ) {
+			// Run baby run!
+			Object stopChain = entry.invoker.invoke( data, context, entry.interceptor.unWrap() );
 			// If the observer returns true, we short circuit the rest of the observers
-			if ( stopChain != null && BooleanCaster.cast( stopChain ) ) {
+			if ( Boolean.TRUE.equals( stopChain ) ) {
 				break;
 			}
 		}

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
@@ -1462,7 +1462,7 @@ public class DynamicInteropService {
 	 *
 	 * @return A unique set of callable methods
 	 */
-	public static Set<Executable> getMethods( Class<?> targetClass, Boolean callable ) {
+	public static Set<Executable> getMethods( Class<?> targetClass, boolean callable ) {
 		Set<Method> allMethods = new HashSet<>();
 
 		// Collect all the methods from the class and it's super classes
@@ -1471,12 +1471,9 @@ public class DynamicInteropService {
 
 		var methodStream = allMethods.stream();
 		// If callable, filter out the private methods
-		if ( Boolean.TRUE.equals( callable ) ) {
+		if ( callable ) {
 			methodStream = methodStream.filter( method -> Modifier.isPublic( method.getModifiers() ) );
 		}
-
-		// Filter out bridge methods
-		methodStream = methodStream.filter( method -> !method.isBridge() );
 
 		return methodStream.collect( Collectors.toSet() );
 	}

--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -41,7 +41,6 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.CacheService;
 import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.types.Array;
-import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.QueryColumnType;
@@ -743,11 +742,6 @@ public class PendingQuery {
 					}
 				} else {
 					Object value = param.toSQLType( context );
-					// If there are other transformations, move this into a helper method
-					if ( value instanceof DateTime dt ) {
-						// convert to java.util.Date for SQL
-						value = dt.toDate();
-					}
 					emitValueToSQL( SQLWithParamValues, value, param.getType() );
 					if ( scaleOrLength == null ) {
 						preparedStatement.setObject( parameterIndex, value, param.getSqlTypeAsInt() );

--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -41,6 +41,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.CacheService;
 import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.QueryColumnType;
@@ -742,6 +743,11 @@ public class PendingQuery {
 					}
 				} else {
 					Object value = param.toSQLType( context );
+					// If there are other transformations, move this into a helper method
+					if ( value instanceof DateTime dt ) {
+						// convert to java.util.Date for SQL
+						value = dt.toDate();
+					}
 					emitValueToSQL( SQLWithParamValues, value, param.getType() );
 					if ( scaleOrLength == null ) {
 						preparedStatement.setObject( parameterIndex, value, param.getSqlTypeAsInt() );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -582,6 +582,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		posInCode							= Key.of( "posInCode" );
 	public static final Key		position							= Key.of( "position" );
 	public static final Key		position1							= Key.of( "position1" );
+	public static final Key		populateServerSystemScope			= Key.of( "populateServerSystemScope" );
 	public static final Key		position2							= Key.of( "position2" );
 	public static final Key		positionals							= Key.of( "positionals" );
 	public static final Key		precise								= Key.of( "precise" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -902,6 +902,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		metricRegistry						= Key.of( "metricRegistry" );
 	public static final Key		minimumIdle							= Key.of( "minimumIdle" );
 	public static final Key		poolName							= Key.of( "poolName" );
+	public static final Key		initializationFailTimeout			= Key.of( "initializationFailTimeout" );
 
 	// Transaction events
 	public static final Key		onTransactionBegin					= Key.of( "onTransactionBegin" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/ServerScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/ServerScope.java
@@ -188,17 +188,12 @@ public class ServerScope extends BaseScope {
 		    "version", System.getProperty( "java.version", "" )
 		) );
 
-		IStruct	env		= UnmodifiableStruct.fromMap( System.getenv() );
-		IStruct	props	= UnmodifiableStruct.fromMap( System.getProperties() );
-
 		/**
 		 * JAVA SYSTEM PROPERTIES AND ENVIRONMENT
 		 */
 		put( Key.system, UnmodifiableStruct.of(
-		    // TODO: create wrapper struct that gives live view of env vars, not just a copy
-		    "environment", env,
-		    // TODO: create wrapper struct that gives live view of system properties, not just a copy
-		    "properties", props
+		    "environment", Struct.fromMap( System.getenv() ),
+		    "properties", Struct.fromMap( System.getProperties() )
 		) );
 
 	}

--- a/src/main/java/ortus/boxlang/runtime/scopes/ServerScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/ServerScope.java
@@ -191,10 +191,18 @@ public class ServerScope extends BaseScope {
 		/**
 		 * JAVA SYSTEM PROPERTIES AND ENVIRONMENT
 		 */
-		put( Key.system, UnmodifiableStruct.of(
-		    "environment", Struct.fromMap( System.getenv() ),
-		    "properties", Struct.fromMap( System.getProperties() )
-		) );
+		if ( runtime.getConfiguration().security.populateServerSystemScope ) {
+			// Add the security config to the server scope
+			put( Key.system, UnmodifiableStruct.of(
+			    "environment", Struct.fromMap( System.getenv() ),
+			    "properties", Struct.fromMap( System.getProperties() )
+			) );
+		} else {
+			put( Key.system, UnmodifiableStruct.of(
+			    "environment", Struct.EMPTY,
+			    "properties", Struct.EMPTY
+			) );
+		}
 
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
@@ -345,7 +345,7 @@ public class DatasourceService extends BaseService {
 	}
 
 	/**
-	 * Get an array of all registered datasources names
+	 * Get an array of all registered datasource names
 	 */
 	public String[] getNames() {
 		return this.datasources.keySet()

--- a/src/main/java/ortus/boxlang/runtime/types/QueryColumnType.java
+++ b/src/main/java/ortus/boxlang/runtime/types/QueryColumnType.java
@@ -283,8 +283,8 @@ public enum QueryColumnType {
 			case QueryColumnType.BINARY -> value; // @TODO: Will this work?
 			case QueryColumnType.BIT -> BooleanCaster.cast( value );
 			case QueryColumnType.BOOLEAN -> BooleanCaster.cast( value );
-			case QueryColumnType.TIME -> DateTimeCaster.cast( value, context );
-			case QueryColumnType.DATE -> DateTimeCaster.cast( value, context );
+			case QueryColumnType.TIME -> DateTimeCaster.cast( value, context ).toDate();
+			case QueryColumnType.DATE -> DateTimeCaster.cast( value, context ).toDate();
 			case QueryColumnType.TIMESTAMP -> new java.sql.Timestamp( DateTimeCaster.cast( value, context ).toEpochMillis() );
 			case QueryColumnType.OBJECT -> value;
 			case QueryColumnType.OTHER -> value;

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -585,7 +586,20 @@ public class XML implements Serializable, IStruct {
 		String		ourName		= node.getNodeName();
 		Array		siblings	= new Array();
 		// Get sibling nodes (including ourself)
-		NodeList	children	= node.getParentNode().getChildNodes();
+		NodeList	children	= Optional.ofNullable( node.getParentNode() )
+		    .map( p -> p.getChildNodes() )
+		    .orElseGet( () -> new NodeList() {
+
+									    @Override
+									    public Node item( int index ) {
+										    return null;
+									    }
+
+									    @Override
+									    public int getLength() {
+										    return 0;
+									    }
+								    } );
 		for ( int i = 0; i < children.getLength(); i++ ) {
 			Node child = children.item( i );
 			if ( child.getNodeType() == Node.ELEMENT_NODE && child.getNodeName().equalsIgnoreCase( ourName ) ) {

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -573,7 +573,26 @@ public class XML implements Serializable, IStruct {
 			}
 		}
 		throw new KeyNotFoundException(
-		    "Index [" + index + "] out of bounds for child [" + ourName + "] XML nodes.  There were only " + currMatch + " children." );
+		    "Index [" + ( index + 1 ) + "] out of bounds for child [" + ourName + "] XML nodes.  There were only " + ( currMatch + 1 ) + " children." );
+	}
+
+	/**
+	 * Get the sibling of this XML node having the same name
+	 *
+	 * @return The siblings of this XML node having the same name
+	 */
+	public Array getSiblingsOfSameName() {
+		String		ourName		= node.getNodeName();
+		Array		siblings	= new Array();
+		// Get sibling nodes (including ourself)
+		NodeList	children	= node.getParentNode().getChildNodes();
+		for ( int i = 0; i < children.getLength(); i++ ) {
+			Node child = children.item( i );
+			if ( child.getNodeType() == Node.ELEMENT_NODE && child.getNodeName().equalsIgnoreCase( ourName ) ) {
+				siblings.add( new XML( child ) );
+			}
+		}
+		return siblings;
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/util/DuplicationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DuplicationUtil.java
@@ -154,9 +154,7 @@ public class DuplicationUtil {
 				            return deep && val instanceof IStruct ? duplicateStruct( StructCaster.cast( val ), deep )
 				                : val instanceof Array ? duplicateArray( ArrayCaster.cast( val ), deep ) : val;
 			            },
-			            ( v1, v2 ) -> {
-				            throw new BoxRuntimeException( "An exception occurred while duplicating the linked HashMap" );
-			            },
+			            ( existingValue, newValue ) -> existingValue, // Keep the existing value in case of a conflict,
 			            LinkedHashMap<Key, Object>::new
 			        )
 			    )
@@ -171,9 +169,7 @@ public class DuplicationUtil {
 				            Object val = entry.getValue();
 				            return processStructAssignment( val, deep );
 			            },
-			            ( v1, v2 ) -> {
-				            throw new BoxRuntimeException( "An exception occurred while duplicating the linked HashMap" );
-			            },
+			            ( existingValue, newValue ) -> existingValue, // Keep the existing value in case of a conflict,
 			            ConcurrentSkipListMap<Key, Object>::new
 			        )
 			    )
@@ -184,9 +180,8 @@ public class DuplicationUtil {
 			    entries.collect(
 			        Collectors.toConcurrentMap(
 			            Entry::getKey,
-			            entry -> {
-				            return processStructAssignment( entry.getValue(), deep );
-			            }
+			            entry -> processStructAssignment( entry.getValue(), deep ),
+			            ( existingValue, newValue ) -> existingValue // Keep the existing value in case of a conflict
 			        )
 			    )
 			);

--- a/src/main/java/ortus/boxlang/runtime/util/FileSystemUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/FileSystemUtil.java
@@ -1139,7 +1139,10 @@ public final class FileSystemUtil {
 			mappingDirectory = Path.of( mappingDirectory ).normalize().toString().replace( "\\", "/" );
 			if ( File.separator.equals( "/" ) ? finalPath.startsWith( mappingDirectory )
 			    : StringUtils.startsWithIgnoreCase( finalPath, mappingDirectory ) ) {
-				String contractedPath = finalPath.replace( mappingDirectory, "" );
+
+				// strip the dir from the path
+				String contractedPath = finalPath.substring( mappingDirectory.length() );
+
 				if ( !contractedPath.startsWith( "/" ) ) {
 					contractedPath = "/" + contractedPath;
 				}

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -410,6 +410,9 @@
 		// A list of Component names that will be disallowed from execution
 		// Ex: "disallowedComponents": [ "execute", "http" ]
 		"disallowedComponents": [],
+		// This is a boolean flag that determines if the server.system scope will be populated with the
+		// Java system properties and environment variables. By default this is set to true.
+		"populateServerSystemScope": true,
 		// An explicit whitelist of file extensions that are allowed to be uploaded - overrides any values in the disallowedWriteExtensions
 		"allowedFileOperationExtensions": [],
 		// The list of file extensions that are not allowed to be uploaded. Also enforced by file relocation operations ( e.g. copy/move )

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -146,7 +146,7 @@
 					</th>
 					<td>
 						<div class="bx-onoff">
-							<bx:if sortedProperties.isEmpty()>
+							<bx:if stuctIsEmpty(sortedProperties)>
 								<p><em>None</em></p>
 							<bx:else>
 								<table class="bx-table-default">
@@ -195,7 +195,7 @@
 					</th>
 					<td>
 						<div class="bx-onoff">
-							<bx:if thisScope.isEmpty()>
+							<bx:if stuctIsEmpty(thisScope)>
 								<p><em>None</em></p>
 							<bx:else>
 								<table class="bx-table-default">
@@ -301,7 +301,7 @@
 						</th>
 						<td>
 							<div class="bx-onoff">
-								<bx:if thisScope.isEmpty()>
+								<bx:if stuctIsEmpty(thisScope)>
 									<p><em>None</em></p>
 								<bx:else>
 									<table class="bx-table-default">
@@ -356,7 +356,7 @@
 						</th>
 						<td>
 							<div class="bx-onoff">
-								<bx:if variablesScope.isEmpty()>
+								<bx:if stuctIsEmpty(variablesScope)>
 									<p><em>None</em></p>
 								<bx:else>
 									<table class="bx-table-default">

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -146,7 +146,7 @@
 					</th>
 					<td>
 						<div class="bx-onoff">
-							<bx:if stuctIsEmpty(sortedProperties)>
+							<bx:if structIsEmpty(sortedProperties)>
 								<p><em>None</em></p>
 							<bx:else>
 								<table class="bx-table-default">
@@ -195,7 +195,7 @@
 					</th>
 					<td>
 						<div class="bx-onoff">
-							<bx:if stuctIsEmpty(thisScope)>
+							<bx:if structIsEmpty(thisScope)>
 								<p><em>None</em></p>
 							<bx:else>
 								<table class="bx-table-default">
@@ -301,7 +301,7 @@
 						</th>
 						<td>
 							<div class="bx-onoff">
-								<bx:if stuctIsEmpty(thisScope)>
+								<bx:if structIsEmpty(thisScope)>
 									<p><em>None</em></p>
 								<bx:else>
 									<table class="bx-table-default">
@@ -356,7 +356,7 @@
 						</th>
 						<td>
 							<div class="bx-onoff">
-								<bx:if stuctIsEmpty(variablesScope)>
+								<bx:if structIsEmpty(variablesScope)>
 									<p><em>None</em></p>
 								<bx:else>
 									<table class="bx-table-default">

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -5443,13 +5443,27 @@ public class CoreLangTest {
 	}
 
 	@Test
-	public void testClearsdfANTLRCache() {
+	public void testElvisInLambda() {
 		instance.executeSource(
 		    """
 		    	myVar = "Brad";
 		    ( (a)->println( myVar ?: a ) )( "Luis" )
 		    		  """,
 		    context, BoxSourceType.BOXSCRIPT );
+	}
+
+	@Test
+	public void testErrorNodes() throws Exception {
+		var result = new Parser().parse( """
+		                                 <bx:script>
+		                                 person="Bob"
+		                                 </bx:script>
+
+		                                 <bx:if
+		                                 	  """, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( result.getIssues().size() ).isGreaterThan( 0 );
+		assertThat( result.getRoot() ).isNotNull();
 	}
 
 }

--- a/src/test/java/TestCases/phase3/ApplicationTest.java
+++ b/src/test/java/TestCases/phase3/ApplicationTest.java
@@ -20,6 +20,7 @@ package TestCases.phase3;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -424,6 +425,27 @@ public class ApplicationTest {
 		assertThat( schedulers ).hasSize( 1 );
 		assertThat( ( IScheduler ) variables.get( Key.of( "scheduler" ) ) ).isNotNull();
 		assertThat( variables.getAsBoolean( Key.of( "started" ) ) ).isTrue();
+	}
+
+
+
+	@DisplayName( "Use a decimal value as fractional days for session timeout" )
+	@Test
+	public void testFractionalSessionTimeout() {
+
+		// @formatter:off
+		instance.executeSource(
+		    
+		    """
+		        bx:application name="myAppsdfsdf21" sessionmanagement="true" sessionTimeout=".5";
+				result = GetApplicationMetadata();
+			""", context );
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+		assertThat( variables.getAsStruct( result ).get( "name" ) ).isEqualTo( "myAppsdfsdf21" );
+		assertThat( variables.getAsStruct( result ).get( "sessionmanagement" ).toString() ).isEqualTo( "true" );
+		assertThat( variables.getAsStruct( result ).get( "sessiontimeout" ) ).isEqualTo( Duration.ofMinutes( 720l ) );
 	}
 
 }

--- a/src/test/java/TestCases/phase3/ApplicationTest.java
+++ b/src/test/java/TestCases/phase3/ApplicationTest.java
@@ -438,6 +438,7 @@ public class ApplicationTest {
 		        bx:application name="myAppsdfsdf21" sessionmanagement="true" sessionTimeout=".5";
 				result = GetApplicationMetadata();
 			""", context );
+			
 		// @formatter:on
 
 		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );

--- a/src/test/java/TestCases/phase3/ApplicationTest.java
+++ b/src/test/java/TestCases/phase3/ApplicationTest.java
@@ -427,8 +427,6 @@ public class ApplicationTest {
 		assertThat( variables.getAsBoolean( Key.of( "started" ) ) ).isTrue();
 	}
 
-
-
 	@DisplayName( "Use a decimal value as fractional days for session timeout" )
 	@Test
 	public void testFractionalSessionTimeout() {

--- a/src/test/java/TestCases/phase3/ClassTest.java
+++ b/src/test/java/TestCases/phase3/ClassTest.java
@@ -1486,6 +1486,17 @@ public class ClassTest {
 	}
 
 	@Test
+	public void testRelativeSelfInstantiationx() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+		        include template="src/test/java/TestCases/phase3/scriptIncludeASMIssue.cfm";
+				                                      
+		    """, context );
+		// @formatter:on
+	}
+
+	@Test
 	public void testAbstractClass() {
 		Throwable t = assertThrows( AbstractClassException.class, () -> instance.executeSource(
 		    """

--- a/src/test/java/TestCases/phase3/scriptIncludeASMIssue.cfm
+++ b/src/test/java/TestCases/phase3/scriptIncludeASMIssue.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+    
+    
+    try {
+        
+    } catch (any cfcatch) {
+
+    }
+    
+    function initINI() {
+        
+    }
+    
+    </cfscript>

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/io/FileExistsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/io/FileExistsTest.java
@@ -133,4 +133,18 @@ public class FileExistsTest {
 		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( false );
 	}
 
+	@DisplayName( "It detects relative paths" )
+	@Test
+	public void testdetectsRelativePaths() throws IOException {
+		instance.executeSource(
+		    """
+		    bx:application mappings={
+		    	"/" : expandPath( "/src/test/java/ortus/boxlang/runtime/bifs/" )
+		     };
+		       result = fileExists( "global/io/FileExistsTest.java" )
+		       """,
+		    context );
+		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( true );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -445,6 +445,31 @@ public class QueryExecuteTest extends BaseJDBCTest {
 		assertEquals( "Developer", michael.get( "role" ) );
 	}
 
+	// See: https://github.com/brettwooldridge/HikariCP/issues/1197
+	// See: https://ortussolutions.atlassian.net/browse/BL-1376
+	@Disabled( "Not currently supported, leaving test for further development." )
+	@DisplayName( "It can provide username/password at query time" )
+	@Test
+	public void testDatasourceUsernamePasswordAtQueryTime() {
+		instance.executeSource(
+		    """
+		    ds = {
+		        "host":"127.0.0.1",
+		        "port":"3309",
+		        "driver":"mysql",
+		        "database":"myDB",
+		        "custom":"allowMultiQueries=true",
+		        "initializationFailTimeout": 0,
+		        "minimumIdle" : 0
+		    };
+		    queryExecute( "SELECT 1", [], { "datasource": ds, "username": "root", "password": "123456Password", } );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( Query.class );
+		Query query = variables.getAsQuery( result );
+		assertEquals( 1, query.size() );
+	}
+
 	@DisplayName( "It throws an exception if the specified datasource is not registered" )
 	@Test
 	public void testMissingNamedDataSource() {

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/LCaseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/LCaseTest.java
@@ -61,10 +61,12 @@ public class LCaseTest {
 	public void testItUppercasesBIF() {
 		instance.executeSource(
 		    """
-		    result = lcase( 'BRAD' );
-		    """,
+		       result = lcase( 'BRAD' );
+		    result2 = lcase( null );
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "brad" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It uppercases as BIF and casting" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/LeftTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/LeftTest.java
@@ -59,10 +59,12 @@ public class LeftTest {
 	public void testItExtractsLeftmostCharacters() {
 		instance.executeSource(
 		    """
-		    result = left("abcdef", 3);
-		    """,
+		       result = left("abcdef", 3);
+		    result2 = left(null, 2);
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "abc" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It extracts leftmost characters as member" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/MidTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/MidTest.java
@@ -57,10 +57,12 @@ public class MidTest {
 	public void testItExtractsSubstring() {
 		instance.executeSource(
 		    """
-		    result = mid("abcdef", 2, 3);
-		    """,
+		       result = mid("abcdef", 2, 3);
+		    result2 = mid(null, 2, 3);
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "bcd" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It extracts a substring as member" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/ReReplaceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/ReReplaceTest.java
@@ -202,4 +202,17 @@ public class ReReplaceTest {
 		assertThat( variables.get( result ) ).isEqualTo( "" );
 	}
 
+	@DisplayName( "handles optional capture group" )
+	@Test
+	public void testOptionalCaptureGroup() {
+		instance.executeSource(
+		    """
+		    localeRegex = "(_[a-z]{2})(_[A-Z]{2})?$"
+		    bundlename = "page-types.accessDenied_de"
+		    result = ReReplace( bundleName, ("^.*?" & localeRegex ), "\\1\\2" )
+		       """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "_de" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/RightTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/RightTest.java
@@ -59,10 +59,12 @@ public class RightTest {
 	public void testItExtractsRightmostCharacters() {
 		instance.executeSource(
 		    """
-		    result = right("abcdef", 3);
-		    """,
+		       result = right("abcdef", 3);
+		    result2 = right(null, 1)
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "def" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It extracts rightmost characters as member" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/TrimTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/TrimTest.java
@@ -58,10 +58,12 @@ public class TrimTest {
 	public void testItTrimsWhitespace() {
 		instance.executeSource(
 		    """
-		    result = trim('  Grant  ');
-		    """,
+		       result = trim('  Grant  ');
+		    result2 = trim(null);
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "Grant" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It trims whitespace from the beginning and end of a string as member" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/UCaseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/UCaseTest.java
@@ -61,10 +61,12 @@ public class UCaseTest {
 	public void testItUppercasesBIF() {
 		instance.executeSource(
 		    """
-		    result = ucase( 'brad' );
-		    """,
+		       result = ucase( 'brad' );
+		    result2 = ucase( null );
+		       """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( "BRAD" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( "" );
 	}
 
 	@DisplayName( "It uppercases as BIF and casting" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/string/ValTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/string/ValTest.java
@@ -57,16 +57,17 @@ public class ValTest {
 	public void testItExtractsNumber() {
 		instance.executeSource(
 		    """
-		    result = val("abcdef");
-		    result2 = val("abcdef");
-		    result3 = val("abc123");
-		    result4 = val("123abcdef");
-		    result5 = val("123");
-		    result6 = val(".123");
-		    result7 = val("123.456");
-		    result8 = val(".");
-		    result9 = val(".sdf");
-		      """,
+		       result = val("abcdef");
+		       result2 = val("abcdef");
+		       result3 = val("abc123");
+		       result4 = val("123abcdef");
+		       result5 = val("123");
+		       result6 = val(".123");
+		       result7 = val("123.456");
+		       result8 = val(".");
+		       result9 = val(".sdf");
+		    result10 = val(null);
+		         """,
 		    context );
 		assertThat( variables.get( result ) ).isEqualTo( 0 );
 		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( 0 );
@@ -77,6 +78,7 @@ public class ValTest {
 		assertThat( variables.get( Key.of( "result7" ) ) ).isEqualTo( 123.456 );
 		assertThat( variables.get( Key.of( "result8" ) ) ).isEqualTo( 0 );
 		assertThat( variables.get( Key.of( "result9" ) ) ).isEqualTo( 0 );
+		assertThat( variables.get( Key.of( "result10" ) ) ).isEqualTo( 0 );
 	}
 
 	@DisplayName( "It extracts number from string Member" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpanTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTimeSpanTest.java
@@ -115,4 +115,37 @@ public class CreateTimeSpanTest {
 		);
 	}
 
+	@DisplayName( "It tests the BIF CreateTimeSpan with fractional values" )
+	@Test
+	public void testCreateTimeSpanDecimals() {
+		instance.executeSource(
+		    """
+		    result = createTimespan( .5, 0, 0, 0 );
+		    """,
+		    context );
+
+		assertEquals( Duration.ofMinutes( 720l ), variables.get( Key.of( "result" ) ) );
+		instance.executeSource(
+		    """
+		    result = createTimespan( 0, .5, 0, 0 );
+		    """,
+		    context );
+
+		assertEquals( Duration.ofMinutes( 30l ), variables.get( Key.of( "result" ) ) );
+		instance.executeSource(
+		    """
+		    result = createTimespan( 0, 0, .5, 0 );
+		    """,
+		    context );
+
+		assertEquals( Duration.ofSeconds( 30l ), variables.get( Key.of( "result" ) ) );
+		instance.executeSource(
+		    """
+		    result = createTimespan( 0, 0, 0, .5 );
+		    """,
+		    context );
+
+		assertEquals( Duration.ofMillis( 500l ), variables.get( Key.of( "result" ) ) );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/ClassWithIsEmpty.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/system/ClassWithIsEmpty.bx
@@ -1,0 +1,5 @@
+class {
+	public function isEmpty() {
+		return 'UDF Empty Data';
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
@@ -187,8 +187,22 @@ public class DumpTest {
 				<cfdump var="#myXML#" format="html">
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
-		// @formatter:on
+		// @formatter:onp
 		assertThat( baos.toString() ).contains( "xml" );
+	}
+
+	@DisplayName( "It can dump an isEmpty method " )
+	@Test
+	public void testCanDumpisEmptyMethod() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+				cfc = new src.test.java.ortus.boxlang.runtime.components.system.ClassWithIsEmpty();
+				dump( var = cfc, format = "html" );
+		    """,
+		    context );
+ 		assertThat( baos.toString() ).contains( "<strong>isEmpty</strong>" );
+		// @formatter:on
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/LoopMeAsCollection.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LoopMeAsCollection.bx
@@ -1,0 +1,6 @@
+class {
+	this.foo = "bar";
+
+	function baz() {
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
@@ -569,4 +569,18 @@ public class LoopTest {
 		assertThat( variables.getAsBoolean( Key.of( "XMLAttributesExists" ) ) ).isTrue();
 	}
 
+	@Test
+	public void testLoopOverClass() {
+		instance.executeSource(
+		    """
+		    o = new src.test.java.ortus.boxlang.runtime.components.system.LoopMeAsCollection();
+		    result = [];
+		    bx:loop collection="#o#" item="key" {
+		    	result.append( key );
+		    }
+		         """,
+		    context );
+		assertThat( variables.getAsArray( Key.of( "result" ) ) ).contains( "foo" );
+		assertThat( variables.getAsArray( Key.of( "result" ) ) ).contains( "baz" );
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/components/xml/XMLTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/xml/XMLTest.java
@@ -150,4 +150,35 @@ public class XMLTest {
 		assertThat( xml.toString() ).contains( "</root>" );
 	}
 
+	@DisplayName( "array len on node" )
+	@Test
+	public void testArrayLenOnNode() {
+		instance.executeSource(
+		    """
+		       ```
+		       	<bx:xml variable="testxml">
+		       	<root>
+		    <element>brad</element>
+		    <element>luis</element>
+		    <element>jon</element>
+		       	</root>
+		       	</bx:xml>
+
+		       	```
+		       	tabs = XmlSearch( testxml, "/root" );
+		       	result = arraylen(tabs[1].element);
+		     result2 = "";
+		     try {
+		     	tabs[1].element[4]
+		     } catch (e) {
+		     	result2 = e.message;
+		     }
+		         		""",
+		    context, BoxSourceType.BOXSCRIPT );
+		assertThat( variables.get( result ) ).isEqualTo( 3 );
+		assertThat( variables.getAsString( Key.of( "result2" ) ) ).contains( "Index [4] out of bounds" );
+		assertThat( variables.getAsString( Key.of( "result2" ) ) ).contains( "There were only 3 children" );
+
+	}
+
 }


### PR DESCRIPTION
### New Features

- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not

### Improvements

- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal

### Bugs

- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds

[BL-1365]: https://ortussolutions.atlassian.net/browse/BL-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1388]: https://ortussolutions.atlassian.net/browse/BL-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1333]: https://ortussolutions.atlassian.net/browse/BL-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1351]: https://ortussolutions.atlassian.net/browse/BL-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1358]: https://ortussolutions.atlassian.net/browse/BL-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1363]: https://ortussolutions.atlassian.net/browse/BL-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1375]: https://ortussolutions.atlassian.net/browse/BL-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1381]: https://ortussolutions.atlassian.net/browse/BL-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1382]: https://ortussolutions.atlassian.net/browse/BL-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ