### PR TITLE
JDBC - Allow setting transaction datasource from child transaction

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -98,15 +98,12 @@ public class ChildTransaction implements ITransaction {
 	}
 
 	/**
-	 * No-op for setting the datasource on a nested transaction.
+	 * Set the datasource on the parent transaction.
 	 * <p>
-	 * The datasource is set on the parent transaction, and all child transactions inherit the datasource from their parent.
-	 * <p>
-	 * Will log a warning if called; otherwise no action taken.
+	 * Calls the same method on the parent transaction, allowing the child transaction to inherit the datasource. The parent transaction will ignore the datasource if it has already been set.
 	 */
 	public ChildTransaction setDataSource( DataSource datasource ) {
-		logger.warn(
-		    "Cannot set datasource on a nested transaction. No action required; this nested transaction will use the datasource defined by the parent" );
+		this.parent.setDataSource( datasource );
 		return this;
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
@@ -657,4 +657,29 @@ public class TransactionTest extends BaseJDBCTest {
 		        .orElse( null )
 		);
 	}
+
+	@DisplayName( "Nested transactions: Can set transaction datasource / execute query from child transaction" )
+	@Test
+	public void testNestedTransactionDatasource() {
+		getInstance().executeSource(
+		    """
+		        transaction{
+		            transaction{
+		                queryExecute( "INSERT INTO developers ( id, name, role ) VALUES ( 22, 'Brad Wood', 'Developer' )", {} );
+		            }
+		        }
+		        variables.result = queryExecute( "SELECT * FROM developers", {} );
+		    """,
+		    getContext() );
+		Query theResult = getVariables().getAsQuery( result );
+
+		// This row from the inner transaction should exist
+		assertNotNull(
+		    theResult
+		        .stream()
+		        .filter( row -> row.getAsString( Key._NAME ).equals( "Brad Wood" ) )
+		        .findFirst()
+		        .orElse( null )
+		);
+	}
 }


### PR DESCRIPTION
Fixes BL-1568.

# Description

Fixes instances of queries executing in a child transaction before any query has executed in the outer transaction to set the transaction datasource.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1568

## Type of change

- [X] Bug Fix