### PR TITLE
JDBC - Stop scaring developers about connection leaks ...

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -159,7 +159,7 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 	    // additional monitoring information
 	    "registerMbeans", true,
 	    // Leak detection threshold in seconds
-	    "leakDetectionThreshold", 3 );
+	    "leakDetectionThreshold", 30 );
 
 	// List of keys to NOT set dynamically. All keys not in this list will use
 	// `addDataSourceProperty` to set the property and pass it to the JDBC driver.


### PR DESCRIPTION
...just because their query took 3+ seconds to execute.

There is no benefit here. If someone wants to debug connection leaks they can tweak the leak detection threshold in their config. Otherwise this is just harmful noise.