### PR TITLE
Patch BL-1569 - Savepoint name too long

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -141,7 +141,7 @@ public class ChildTransaction implements ITransaction {
 	 * The transaction will be rolled back to the last committed point, and will ignore any set savepoints.
 	 */
 	public ChildTransaction rollback() {
-		return rollback( Key.nulls );
+		return rollback( ChildTransaction.BEGIN );
 	}
 
 	/**
@@ -150,11 +150,9 @@ public class ChildTransaction implements ITransaction {
 	 * @param savepoint The name of the savepoint to rollback to or NULL for no savepoint.
 	 */
 	public ChildTransaction rollback( Key savepoint ) {
-		if ( savepoint == Key.nulls ) {
-			savepoint = ChildTransaction.BEGIN;
-		}
-		logger.debug( "Rolling back child transaction to savepoint {}", this.savepointPrefix + savepoint );
-		this.parent.rollback( Key.of( this.savepointPrefix + savepoint.getNameNoCase() ) );
+		Key savepointKey = savepoint.getNameNoCase().startsWith( "child_" ) ? savepoint : Key.of( this.savepointPrefix + savepoint.getNameNoCase() );
+		logger.debug( "Rolling back child transaction to savepoint {}", savepointKey );
+		this.parent.rollback( savepointKey );
 		return this;
 	}
 
@@ -164,7 +162,8 @@ public class ChildTransaction implements ITransaction {
 	 * @param savepoint The name of the savepoint
 	 */
 	public ChildTransaction setSavepoint( Key savepoint ) {
-		this.parent.setSavepoint( Key.of( this.savepointPrefix + savepoint.getNameNoCase() ) );
+		Key savepointKey = savepoint.getNameNoCase().startsWith( "child_" ) ? savepoint : Key.of( this.savepointPrefix + savepoint.getNameNoCase() );
+		this.parent.setSavepoint( savepointKey );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -1,6 +1,9 @@
 package ortus.boxlang.runtime.jdbc;
 
 import java.sql.Connection;
+import java.sql.Savepoint;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.text.RandomStringGenerator;
 
@@ -26,11 +29,16 @@ public class ChildTransaction implements ITransaction {
 	/**
 	 * Logger
 	 */
-	private static final BoxLangLogger	logger	= BoxRuntime.getInstance().getLoggingService().DATASOURCE_LOGGER;
+	private static final BoxLangLogger	logger		= BoxRuntime.getInstance().getLoggingService().DATASOURCE_LOGGER;
 	/**
 	 * The parent transaction.
 	 */
 	private ITransaction				parent;
+
+	/**
+	 * The underlying JDBC connection.
+	 */
+	private Connection					connection;
 
 	/**
 	 * The prefix for savepoints created in this transaction.
@@ -45,9 +53,18 @@ public class ChildTransaction implements ITransaction {
 	 * Key constants used for savepoints demarcating the start and end of a child (nested) transaction.
 	 * --------------------------------------------------------------------------
 	 */
-	private static final Key			BEGIN	= Key.of( "BEGIN" );
-	private static final Key			END		= Key.of( "END" );
-	private static final Key			COMMIT	= Key.of( "COMMIT" );
+	private static final Key			BEGIN		= Key.of( "BEGIN" );
+	private static final Key			END			= Key.of( "END" );
+	private static final Key			COMMIT		= Key.of( "COMMIT" );
+
+	/**
+	 * Stores the savepoints used in this transaction, referenced from <code>transactionSetSavepoint( "mySavepoint" )</code> and
+	 * <code>transactionRollback( "mySavepoint" )</code>.
+	 *
+	 * Each savepoint name uses a Key to avoid case sensitivity issues with the lookup, and each JDBC savepoint is created with the name in UPPERCASE for
+	 * the same reason.
+	 */
+	private Map<Key, Savepoint>			savepoints	= new HashMap<>();
 
 	/**
 	 * Construct a nested transaction, attaching the given @param parent transaction.
@@ -61,7 +78,7 @@ public class ChildTransaction implements ITransaction {
 		    .filteredBy( Character::isLetterOrDigit )
 		    .build();
 
-		this.savepointPrefix = "CHILD_" + generator.generate( 12 ) + "_";
+		this.savepointPrefix = ( "CHILD_" + generator.generate( 12 ) + "_" ).toUpperCase();
 	}
 
 	/**
@@ -94,7 +111,14 @@ public class ChildTransaction implements ITransaction {
 	 * Get (creating if none found) the connection associated with the parent transaction.
 	 */
 	public Connection getConnection() {
-		return this.parent.getConnection();
+		if ( this.connection == null ) {
+			this.connection = this.parent.getConnection();
+			// now that we've obtained a connection, we can "begin" the child transaction.
+			if ( !this.savepoints.containsKey( generateSavepointKey( ChildTransaction.BEGIN ) ) ) {
+				begin();
+			}
+		}
+		return this.connection;
 	}
 
 	/**
@@ -150,7 +174,7 @@ public class ChildTransaction implements ITransaction {
 	 * @param savepoint The name of the savepoint to rollback to or NULL for no savepoint.
 	 */
 	public ChildTransaction rollback( Key savepoint ) {
-		Key savepointKey = savepoint.getNameNoCase().startsWith( "child_" ) ? savepoint : Key.of( this.savepointPrefix + savepoint.getNameNoCase() );
+		Key savepointKey = generateSavepointKey( savepoint );
 		logger.debug( "Rolling back child transaction to savepoint {}", savepointKey );
 		this.parent.rollback( savepointKey );
 		return this;
@@ -161,10 +185,27 @@ public class ChildTransaction implements ITransaction {
 	 *
 	 * @param savepoint The name of the savepoint
 	 */
-	public ChildTransaction setSavepoint( Key savepoint ) {
-		Key savepointKey = savepoint.getNameNoCase().startsWith( "child_" ) ? savepoint : Key.of( this.savepointPrefix + savepoint.getNameNoCase() );
-		this.parent.setSavepoint( savepointKey );
-		return this;
+	public Savepoint setSavepoint( Key savepoint ) {
+		Key			savepointKey	= generateSavepointKey( savepoint );
+		Savepoint	jdbcSavepoint	= this.parent.setSavepoint( savepointKey );
+		if ( jdbcSavepoint != null ) {
+			this.savepoints.put( savepointKey, jdbcSavepoint );
+		}
+		return jdbcSavepoint;
+	}
+
+	/**
+	 * Get the savepoints used in this transaction.
+	 * <p>
+	 * This method returns a map of savepoint names to their associated savepoint objects, allowing you to manage and rollback to specific points in the transaction.
+	 * 
+	 * @see #setSavepoint(Key)
+	 * @see #rollback(Key)
+	 * 
+	 * @return A map of savepoint Keys to JDBC savepoint objects.
+	 */
+	public Map<Key, Savepoint> getSavepoints() {
+		return this.savepoints;
 	}
 
 	/**
@@ -183,5 +224,9 @@ public class ChildTransaction implements ITransaction {
 	 */
 	public ITransaction getParent() {
 		return this.parent;
+	}
+
+	private Key generateSavepointKey( Key savepoint ) {
+		return savepoint.getNameNoCase().startsWith( "child_" ) ? savepoint : Key.of( this.savepointPrefix + savepoint.getName().toUpperCase() );
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -155,7 +155,9 @@ public class ChildTransaction implements ITransaction {
 	 * Commit the transaction
 	 */
 	public ChildTransaction commit() {
-		setSavepoint( ChildTransaction.COMMIT );
+		if ( !this.savepoints.containsKey( generateSavepointKey( ChildTransaction.COMMIT ) ) ) {
+			setSavepoint( ChildTransaction.COMMIT );
+		}
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ChildTransaction.java
@@ -100,9 +100,12 @@ public class ChildTransaction implements ITransaction {
 	/**
 	 * Set the datasource on the parent transaction.
 	 * <p>
-	 * Calls the same method on the parent transaction, allowing the child transaction to inherit the datasource. The parent transaction will ignore the datasource if it has already been set.
+	 * Calls the same method on the parent transaction, allowing the child transaction to inherit the datasource. Will no-op if the parent transaction already has a datasource set.
 	 */
 	public ChildTransaction setDataSource( DataSource datasource ) {
+		if ( this.parent.getDataSource() != null ) {
+			return this;
+		}
 		this.parent.setDataSource( datasource );
 		return this;
 	}

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ITransaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ITransaction.java
@@ -15,6 +15,8 @@
 package ortus.boxlang.runtime.jdbc;
 
 import java.sql.Connection;
+import java.sql.Savepoint;
+import java.util.Map;
 
 import ortus.boxlang.runtime.scopes.Key;
 
@@ -96,9 +98,21 @@ public interface ITransaction {
 	 *
 	 * @param savepoint The name of the savepoint
 	 * 
-	 * @return The transaction object for chainability.
+	 * @return The created JDBC savepoint object or NULL if the savepoint could not be created.
 	 */
-	public ITransaction setSavepoint( Key savepoint );
+	public Savepoint setSavepoint( Key savepoint );
+
+	/**
+	 * Get the savepoints used in this transaction.
+	 * <p>
+	 * This method returns a map of savepoint names to their associated savepoint objects, allowing you to manage and rollback to specific points in the transaction.
+	 * 
+	 * @see #setSavepoint(Key)
+	 * @see #rollback(Key)
+	 * 
+	 * @return A map of savepoint Keys to JDBC savepoint objects.
+	 */
+	public Map<Key, Savepoint> getSavepoints();
 
 	/**
 	 * Shutdown the transaction by re-enabling auto commit mode and closing the connection to the database (i.e. releasing it back to the connection pool

--- a/src/main/java/ortus/boxlang/runtime/jdbc/Transaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/Transaction.java
@@ -217,7 +217,7 @@ public class Transaction implements ITransaction {
 	 * The transaction will be rolled back to the last committed point, and will ignore any set savepoints.
 	 */
 	public Transaction rollback() {
-		return rollback( Key.nulls );
+		return rollback( null );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/jdbc/Transaction.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/Transaction.java
@@ -277,7 +277,7 @@ public class Transaction implements ITransaction {
 		if ( this.connection != null ) {
 			try {
 				logger.debug( "Setting transaction savepoint: {}", savepoint.getNameNoCase() );
-				savepoints.put( savepoint, this.connection.setSavepoint( savepoint.getNameNoCase() ) );
+				this.savepoints.put( savepoint, this.connection.setSavepoint( savepoint.getNameNoCase() ) );
 			} catch ( SQLException e ) {
 				throw new DatabaseException( "Failed to set savepoint: " + e.getMessage(), e );
 			}

--- a/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
@@ -658,6 +658,37 @@ public class TransactionTest extends BaseJDBCTest {
 		);
 	}
 
+	// @Disabled( "Fails due to savepoint not existing. More testing to do here." )
+	@DisplayName( "Nested transactions: Won't throw 'savepoint name too long' on 4+ level transaction savepoints" )
+	@Test
+	public void testHighlyNestedSavepoints() {
+		getInstance().executeSource(
+		    """
+		    transaction{
+		    	transaction{
+		    		transaction{
+		    			transaction{
+		    				queryExecute( "INSERT INTO developers ( id, name, role ) VALUES ( 22, 'Brad Wood', 'Developer' )", {} );
+		    				transactionCommit();
+		    			}
+		    		}
+		    	}
+		    }
+		          variables.result = queryExecute( "SELECT * FROM developers", {} );
+		      """,
+		    getContext() );
+		Query theResult = getVariables().getAsQuery( result );
+
+		// This row from the inner transaction should exist
+		assertNotNull(
+		    theResult
+		        .stream()
+		        .filter( row -> row.getAsString( Key._NAME ).equals( "Brad Wood" ) )
+		        .findFirst()
+		        .orElse( null )
+		);
+	}
+
 	@DisplayName( "Nested transactions: Can set transaction datasource / execute query from child transaction" )
 	@Test
 	public void testNestedTransactionDatasource() {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/TransactionTest.java
@@ -674,8 +674,8 @@ public class TransactionTest extends BaseJDBCTest {
 		    		}
 		    	}
 		    }
-		          variables.result = queryExecute( "SELECT * FROM developers", {} );
-		      """,
+		    variables.result = queryExecute( "SELECT * FROM developers", {} );
+		    """,
 		    getContext() );
 		Query theResult = getVariables().getAsQuery( result );
 


### PR DESCRIPTION
# Description

This is a partial fix for BL-1569, which is an error thrown when JDBC transactions are nested multiple times and the generated savepoint names are much too long:

```
[2025-07-08T12:06:39,313] [pool-7-thread-9] [ERROR] [DATASOURCE] Encountered generic exception while processing transaction; rolling back ortus.boxlang.runtime.types.exceptions.DatabaseException: Failed to set savepoint: The identifier that starts with 'child_kgjbbbp8sbgn_child_aliner3zamee_child_nfxw7vocuof9_commit' is too long. Maximum length is 32.
```

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1569

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [X] Improvement
