### PR TITLE
BL-1570, BL-1571 - Redux

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTime.java
@@ -87,7 +87,7 @@ public class ParseDateTime extends BIF {
 			CastAttempt<DateTime> attempt = DateTimeCaster.attempt( StringCaster.cast( dateRef ), context );
 			if ( attempt.wasSuccessful() ) {
 				// If the dateRef can be cast to a DateTime, we can return it directly
-				return attempt.get().setTimezone( timezone );
+				return attempt.get();
 			} else {
 				return new DateTime( StringCaster.cast( dateRef ), timezone );
 			}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCaster.java
@@ -231,12 +231,8 @@ public class DateTimeCaster implements IBoxCaster {
 
 		// Now let's go to Apache commons lang for its date parsing
 		try {
-			return new DateTime(
-			    DateUtils.parseDateStrictly( targetString, LocalizationUtil.parseLocaleFromContext( context, new ArgumentsScope() ),
-			        DateTime.COMMON_DATETIME_PATTERNS ),
-			    timezone
-			);
-		} catch ( java.text.ParseException e ) {
+			return LocalizationUtil.parseFromCommonPatterns( targetString );
+		} catch ( java.time.format.DateTimeParseException e ) {
 			try {
 				return new DateTime( targetString, timezone );
 			} catch ( Throwable e2 ) {

--- a/src/main/java/ortus/boxlang/runtime/types/DateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/types/DateTime.java
@@ -27,6 +27,7 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.chrono.Chronology;
@@ -151,81 +152,6 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	);
 
 	/**
-	 * A primitive array of common US-prioritized DateTime format patterns, which is used for fast casting by commons lang DateUtils
-	 */
-	public static final String[]			COMMON_DATETIME_PATTERNS					= {
-
-	    // Localized Date/Time formats
-	    "EEE, dd MMM yyyy HH:mm:ss zzz", // Full DateTime (e.g., Tue, 02 Apr 2024 21:01:00 CEST) - Similar to FULL_FULL
-	    "dd MMM yyyy HH:mm:ss",         // Long DateTime (e.g., 02 Apr 2024 21:01:00) - Similar to LONG_LONG
-	    "dd-MMM-yyyy HH:mm:ss",         // Medium DateTime (e.g., 02-Apr-2024 21:01:00) - Might need adjustment based on locale
-	    "MM/dd/yyyy HH:mm:ss",         // Short DateTime (e.g., 02/04/2024 21:01:00) - Might need adjustment based on locale
-	    "MM/dd/yyyy hh:mm:ss a",         // Short DateTime (e.g., 02/04/2024 04:01:00 PM) - Might need adjustment based on locale
-	    "MM/dd/yyyy hh:mm a",         // Short DateTime (e.g., 02/04/2024 04:01:00 PM) - Might need adjustment based on locale
-	    "dd.MM.yyyy HH:mm:ss",         // Short DateTime (e.g., 02.04.2024 21:01:00) - Might need adjustment based on locale
-	    "LLLL dd yyyy HH:mm:ss", 	  // Long month DateTime (e.g., April 02 2024 21:01:00) - Might need adjustment based on locale
-	    "LLLL dd',' yyyy HH:mm:ss", 	  // Long month DateTime (e.g., April 02, 2024 21:01:00) - Might need adjustment based on locale
-	    "LLLL dd yyyy hh:mm a", 	  // Long month DateTime with AM/PM (e.g., April 02 2024 05:01 AM) - Might need adjustment based on locale
-	    "LLLL dd',' yyyy hh:mm a", 	  // Long month DateTime with AM/PM (e.g., April 02, 2024 05:01 AM) - Might need adjustment based on locale
-	    "MMM dd yyyy HH:mm:ss", 	  // Med DateTime (e.g., Apr 02 2024 21:01:00) - Might need adjustment based on locale
-	    "MMM dd',' yyyy HH:mm:ss", 	  // Med DateTime (e.g., Apr 02, 2024 21:01:00) - Might need adjustment based on locale
-	    "MMM dd yyyy hh:mm a", 	       // Med DateTime No Seconds and AM/PM (e.g., Apr 02 2024 10:01 AM) - Might need adjustment based on locale
-	    "MMM dd',' yyyy hh:mm a", 	    // Med DateTime No Seconds and AM/PM (e.g., Apr 02, 2024 10:01 AM) - Might need adjustment based on locale
-	    "MMM dd yyyy HH:mm", 	       // Med DateTime No Seconds (e.g., Apr 02 2024 21:01) - Might need adjustment based on locale
-	    "MMM dd',' yyyy HH:mm", 	       // Med DateTime No Seconds (e.g., Apr 02 2024 21:01) - Might need adjustment based on locale
-
-	    // java.util.Date toString default format
-	    "EEE MMM dd HH:mm:ss zzz yyyy", // Default DateTime (e.g., Tue Apr 02 21:01:00 CET 2024) - Similar to DEFAULT
-
-	    // ISO formats
-	    "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",  // Date-time with milliseconds and offset
-	    "yyyy-MM-dd'T'HH:mm:ss.SSS",     // Date-time with milliseconds
-	    "yyyy-MM-dd'T'HH:mm:ssZ",        // Date-time with offset (Z)
-	    "yyyy-MM-dd'T'HH:mm:ssX",        // Date-time with offset (X)
-	    "yyyy-MM-dd'T'HH:mm:ss",         // Date-time
-
-	    // ODBC formats
-	    "yyyyMMddHHmmss",                // ODBCDateTime - Potential ODBC format
-
-	    // US Localized Date formats - Month First
-	    "MMM dd yyyy",                   // Long Date (e.g., Apr 02 2024)
-	    "MMM-dd-yyyy",                   // Medium Date (e.g., Apr-02-2024) - Might need adjustment based on locale
-	    "MMM/dd/yyyy",                   // Medium Date (e.g., Apr/02/2024) - Might need adjustment based on locale
-	    "MMM.dd.yyyy",                   // Medium Date (e.g., Apr.02.2024) - Might need adjustment based on locale
-
-	    // US Localized Date formats - Month First (Short)
-	    "MM dd yyyy",                   // Short Date (e.g., 04 02 2024) - Might need adjustment based on locale
-	    "MM-dd-yyyy",                   // Short Date (e.g., 04-02-2024) - Might need adjustment based on locale
-	    "MM/dd/yyyy",                   // Short Date (e.g., 04/02/2024) - Might need adjustment based on locale
-	    "MM.dd.yyyy",                   // Short Date (e.g., 04.02.2024) - Might need adjustment based on locale
-
-	    // Localized Date formats
-	    "EEE, dd MMM yyyy",            // Full Date (e.g., Tue, 02 Apr 2024) - Similar to FULL
-	    "dd MMM yyyy",                   // Long Date (e.g., 02 Apr 2024) - Similar to LONG
-	    "dd-MMM-yy",                     // Medium Date with a two-digit year (e.g., 02-Apr-24) - Might need adjustment based on locale
-	    "dd-MMM-yyyy",                   // Medium Date (e.g., 02-Apr-2024) - Might need adjustment based on locale
-	    "dd/MMM/yyyy",                   // Medium Date (e.g., 02-Apr-2024) - Might need adjustment based on locale
-	    "dd.MMM.yyyy",                   // Medium Date (e.g., 02.Apr.2024) - Might need adjustment based on locale
-	    "MMM dd, yyyy",                  // Med Date (e.g., Apr 02, 2024) - Might need adjustment based on locale
-	    "MMMM dd yyyy",                  // Long month Date (e.g., April 02 2024) - Might need adjustment based on locale
-	    "MMMM dd, yyyy",                 // Long month Date (e.g., April 02, 2024) - Might need adjustment based on locale
-
-	    // European Day-First Formats
-	    "dd MM yyyy",                   // Short Date (e.g., 02.04.2024) - Might need adjustment based on locale
-	    "dd-MM-yyyy",                   // Short Date (e.g., 02-04-2024) - Might need adjustment based on locale
-	    "dd/MM/yyyy",                   // Short Date (e.g., 02/04/2024) - Might need adjustment based on locale
-	    "dd.MM.yyyy",                   // Short Date (e.g., 02.04.2024) - Might need adjustment based on locale
-
-	    // ISO format
-	    "yyyy-MM-dd",                   // ISODate (e.g., 2024-04-02)
-	    "yyyy/MM/dd",                   // ISODate (e.g., 2024/04/02)
-	    "yyyy.MM.dd",                   // ISODate (e.g., 2024.04.02)
-
-	    // ODBC format
-	    "yyyyMMdd"                     // ODBCDate - Potential ODBC format
-	};
-
-	/**
 	 * The format we use to represent the date time
 	 * which defaults to the ODBC format: {ts '''yyyy-MM-dd HH:mm:ss'''}
 	 */
@@ -336,6 +262,10 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	 */
 	public DateTime( LocalDateTime dateTime ) {
 		this( dateTime, ZoneId.systemDefault() );
+	}
+
+	public DateTime( OffsetDateTime dateTime ) {
+		this( dateTime.toZonedDateTime() );
 	}
 
 	/**
@@ -729,8 +659,7 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	 */
 	@BoxMemberExpose
 	public String toISOString() {
-		this.formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-		return toString();
+		return this.wrapped.format( DateTimeFormatter.ISO_OFFSET_DATE_TIME );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/DateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/types/DateTime.java
@@ -264,6 +264,12 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 		this( dateTime, ZoneId.systemDefault() );
 	}
 
+	/**
+	 * Constructor to create DateTime from an OffsetDateTime object
+	 * This will convert the OffsetDateTime to a ZonedDateTime
+	 *
+	 * @param dateTime An OffsetDateTime object
+	 */
 	public DateTime( OffsetDateTime dateTime ) {
 		this( dateTime.toZonedDateTime() );
 	}

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -674,7 +674,9 @@ public final class LocalizationUtil {
 	 * {@link LocalTime}, or {@link Instant}. If successful, it wraps the parsed result in a {@link DateTime}.
 	 *
 	 * @param dateTime the date-time string to parse
+	 * 
 	 * @return a {@link DateTime} object representing the parsed date-time
+	 * 
 	 * @throws BoxRuntimeException if the input string cannot be parsed into a supported {@link TemporalAccessor}
 	 */
 	public static DateTime parseFromCommonPatterns( String dateTime ) {

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -824,6 +824,15 @@ public final class LocalizationUtil {
 		return new DateTimeFormatterBuilder().parseLenient();
 	}
 
+	/**
+	 * Returns a DateTimeFormatter that can parse common date-time patterns.
+	 * <p>
+	 * This method constructs a lenient DateTimeFormatter that supports a predefined
+	 * set of common date-time patterns. It is useful for parsing date-time strings
+	 * that match any of these patterns.
+	 *
+	 * @return a DateTimeFormatter configured with common date-time patterns
+	 */
 	public static DateTimeFormatter getCommonPatternDateTimeParsers() {
 		DateTimeFormatterBuilder builder = newLenientDateTimeFormatterBuilder();
 		Stream.of( COMMON_DATETIME_PATTERNS )

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -667,6 +667,16 @@ public final class LocalizationUtil {
 		return symbols;
 	}
 
+	/**
+	 * Parses a date-time string using common patterns and returns a {@link DateTime} object.
+	 * The method attempts to parse the input string into various {@link TemporalAccessor} types,
+	 * such as {@link OffsetDateTime}, {@link ZonedDateTime}, {@link LocalDateTime}, {@link LocalDate},
+	 * {@link LocalTime}, or {@link Instant}. If successful, it wraps the parsed result in a {@link DateTime}.
+	 *
+	 * @param dateTime the date-time string to parse
+	 * @return a {@link DateTime} object representing the parsed date-time
+	 * @throws BoxRuntimeException if the input string cannot be parsed into a supported {@link TemporalAccessor}
+	 */
 	public static DateTime parseFromCommonPatterns( String dateTime ) {
 		TemporalAccessor date = getCommonPatternDateTimeParsers().parseBest( dateTime, OffsetDateTime::from, ZonedDateTime::from, LocalDateTime::from,
 		    LocalDate::from, LocalTime::from );

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -26,7 +26,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
 import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
@@ -60,12 +63,88 @@ public final class LocalizationUtil {
 	/**
 	 * The runtime logger
 	 */
-	private static final BoxLangLogger				logger			= BoxRuntime.getInstance().getLoggingService().getRuntimeLogger();
+	private static final BoxLangLogger				logger						= BoxRuntime.getInstance().getLoggingService().getRuntimeLogger();
+
+	/**
+	 * A primitive array of common US-prioritized DateTime format patterns, which is used for fast casting by commons lang DateUtils
+	 */
+	public static final String[]					COMMON_DATETIME_PATTERNS	= {
+
+	    // Localized Date/Time formats - the order in which these are presented is very specific
+	    "EEE, d MMM yyyy HH:mm:ss zzz", // Full DateTime (e.g., Tue, 02 Apr 2024 21:01:00 CEST) - Similar to FULL_FULL
+	    "dd MMM yyyy HH:mm:ss",         // Long DateTime (e.g., 02 Apr 2024 21:01:00) - Similar to LONG_LONG
+	    "dd-MMM-yyyy HH:mm:ss",         // Medium DateTime (e.g., 02-Apr-2024 21:01:00) - Might need adjustment based on locale
+	    "MM/dd/yyyy hh:mm:ss a",         // Short DateTime (e.g., 02/04/2024 04:01:00 PM) - Might need adjustment based on locale
+	    "MM/dd/yyyy HH:mm:ss",         // Short DateTime (e.g., 02/04/2024 21:01:00) - Might need adjustment based on locale
+	    "MM/dd/yyyy hh:mm a",         // Short DateTime (e.g., 02/04/2024 04:01:00 PM) - Might need adjustment based on locale
+	    "dd.MM.yyyy HH:mm:ss",         // Short DateTime (e.g., 02.04.2024 21:01:00) - Might need adjustment based on locale
+	    "LLLL dd yyyy HH:mm:ss", 	  // Long month DateTime (e.g., April 02 2024 21:01:00) - Might need adjustment based on locale
+	    "LLLL dd',' yyyy HH:mm:ss", 	  // Long month DateTime (e.g., April 02, 2024 21:01:00) - Might need adjustment based on locale
+	    "LLLL dd yyyy hh:mm a", 	  // Long month DateTime with AM/PM (e.g., April 02 2024 05:01 AM) - Might need adjustment based on locale
+	    "LLLL dd',' yyyy hh:mm a", 	  // Long month DateTime with AM/PM (e.g., April 02, 2024 05:01 AM) - Might need adjustment based on locale
+	    "MMM dd yyyy HH:mm:ss", 	  // Med DateTime (e.g., Apr 02 2024 21:01:00) - Might need adjustment based on locale
+	    "MMM dd',' yyyy HH:mm:ss", 	  // Med DateTime (e.g., Apr 02, 2024 21:01:00) - Might need adjustment based on locale
+	    "MMM dd yyyy hh:mm a", 	       // Med DateTime No Seconds and AM/PM (e.g., Apr 02 2024 10:01 AM) - Might need adjustment based on locale
+	    "MMM dd',' yyyy hh:mm a", 	    // Med DateTime No Seconds and AM/PM (e.g., Apr 02, 2024 10:01 AM) - Might need adjustment based on locale
+	    "MMM dd yyyy HH:mm", 	       // Med DateTime No Seconds (e.g., Apr 02 2024 21:01) - Might need adjustment based on locale
+	    "MMM dd',' yyyy HH:mm", 	       // Med DateTime No Seconds (e.g., Apr 02 2024 21:01) - Might need adjustment based on locale
+
+	    // java.util.Date toString default format
+	    "EEE MMM dd HH:mm:ss zzz yyyy", // Default DateTime (e.g., Tue Apr 02 21:01:00 CET 2024) - Similar to DEFAULT
+
+	    // ISO formats
+	    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX",  // Date-time with fractional microseconds and offset
+	    "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",  // Date-time with milliseconds and offset
+	    "yyyy-MM-dd'T'HH:mm:ss.SSS",     // Date-time with milliseconds
+	    "yyyy-MM-dd'T'HH:mm:ssZ",        // Date-time with offset (Z)
+	    "yyyy-MM-dd'T'HH:mm:ssX",        // Date-time with offset (X)
+	    "yyyy-MM-dd'T'HH:mm:ss",         // Date-time
+
+	    // ODBC formats
+	    "yyyyMMddHHmmss",                // ODBCDateTime - Potential ODBC format
+
+	    // US Localized Date formats - Month First
+	    "MMM dd yyyy",                   // Long Date (e.g., Apr 02 2024)
+	    "MMM-dd-yyyy",                   // Medium Date (e.g., Apr-02-2024) - Might need adjustment based on locale
+	    "MMM/dd/yyyy",                   // Medium Date (e.g., Apr/02/2024) - Might need adjustment based on locale
+	    "MMM.dd.yyyy",                   // Medium Date (e.g., Apr.02.2024) - Might need adjustment based on locale
+
+	    // US Localized Date formats - Month First (Short)
+	    "MM dd yyyy",                   // Short Date (e.g., 04 02 2024) - Might need adjustment based on locale
+	    "MM-dd-yyyy",                   // Short Date (e.g., 04-02-2024) - Might need adjustment based on locale
+	    "MM/dd/yyyy",                   // Short Date (e.g., 04/02/2024) - Might need adjustment based on locale
+	    "MM.dd.yyyy",                   // Short Date (e.g., 04.02.2024) - Might need adjustment based on locale
+
+	    // Localized Date formats
+	    "EEE, dd MMM yyyy",            // Full Date (e.g., Tue, 02 Apr 2024) - Similar to FULL
+	    "dd MMM yyyy",                   // Long Date (e.g., 02 Apr 2024) - Similar to LONG
+	    "dd-MMM-yy",                     // Medium Date with a two-digit year (e.g., 02-Apr-24) - Might need adjustment based on locale
+	    "dd-MMM-yyyy",                   // Medium Date (e.g., 02-Apr-2024) - Might need adjustment based on locale
+	    "dd/MMM/yyyy",                   // Medium Date (e.g., 02-Apr-2024) - Might need adjustment based on locale
+	    "dd.MMM.yyyy",                   // Medium Date (e.g., 02.Apr.2024) - Might need adjustment based on locale
+	    "MMM dd, yyyy",                  // Med Date (e.g., Apr 02, 2024) - Might need adjustment based on locale
+	    "MMMM dd yyyy",                  // Long month Date (e.g., April 02 2024) - Might need adjustment based on locale
+	    "MMMM dd, yyyy",                 // Long month Date (e.g., April 02, 2024) - Might need adjustment based on locale
+
+	    // European Day-First Formats
+	    "dd MM yyyy",                   // Short Date (e.g., 02.04.2024) - Might need adjustment based on locale
+	    "dd-MM-yyyy",                   // Short Date (e.g., 02-04-2024) - Might need adjustment based on locale
+	    "dd/MM/yyyy",                   // Short Date (e.g., 02/04/2024) - Might need adjustment based on locale
+	    "dd.MM.yyyy",                   // Short Date (e.g., 02.04.2024) - Might need adjustment based on locale
+
+	    // ISO format
+	    "yyyy-MM-dd",                   // ISODate (e.g., 2024-04-02)
+	    "yyyy/MM/dd",                   // ISODate (e.g., 2024/04/02)
+	    "yyyy.MM.dd",                   // ISODate (e.g., 2024.04.02)
+
+	    // ODBC format
+	    "yyyyMMdd"                     // ODBCDate - Potential ODBC format
+	};
 
 	/**
 	 * A struct of common locale constants
 	 */
-	public static final LinkedHashMap<Key, Locale>	COMMON_LOCALES	= new LinkedHashMap<Key, Locale>();
+	public static final LinkedHashMap<Key, Locale>	COMMON_LOCALES				= new LinkedHashMap<Key, Locale>();
 	static {
 		COMMON_LOCALES.put( Key.of( "Canada" ), Locale.CANADA );
 		COMMON_LOCALES.put( Key.of( "Canadian" ), Locale.CANADA );
@@ -588,6 +667,31 @@ public final class LocalizationUtil {
 		return symbols;
 	}
 
+	public static DateTime parseFromCommonPatterns( String dateTime ) {
+		TemporalAccessor date = getCommonPatternDateTimeParsers().parseBest( dateTime, OffsetDateTime::from, ZonedDateTime::from, LocalDateTime::from,
+		    LocalDate::from, LocalTime::from );
+		if ( date instanceof ZonedDateTime castZonedDateTime ) {
+			return new DateTime( castZonedDateTime );
+		} else if ( date instanceof LocalDateTime castLocalDateTime ) {
+			return new DateTime( castLocalDateTime );
+		} else if ( date instanceof LocalDate castLocalDate ) {
+			return new DateTime( castLocalDate );
+		} else if ( date instanceof LocalTime castLocalTime ) {
+			return new DateTime( castLocalTime );
+		} else if ( date instanceof Instant castInstant ) {
+			return new DateTime( castInstant );
+		} else if ( date instanceof OffsetDateTime castOffsetDateTime ) {
+			return new DateTime( castOffsetDateTime );
+		} else {
+			throw new BoxRuntimeException(
+			    String.format(
+			        "The TemporalAccessor instanceof [%s] does not have a valid DateTime constructor",
+			        date.getClass().getName()
+			    )
+			);
+		}
+	}
+
 	/**
 	 * Parses a date string into a ZonedDateTime instance
 	 *
@@ -708,6 +812,22 @@ public final class LocalizationUtil {
 	 */
 	public static DateTimeFormatterBuilder newLenientDateTimeFormatterBuilder() {
 		return new DateTimeFormatterBuilder().parseLenient();
+	}
+
+	public static DateTimeFormatter getCommonPatternDateTimeParsers() {
+		DateTimeFormatterBuilder builder = newLenientDateTimeFormatterBuilder();
+		Stream.of( COMMON_DATETIME_PATTERNS )
+		    .forEach( pattern -> {
+			    builder.appendOptional(
+			        new DateTimeFormatterBuilder()
+			            .parseCaseInsensitive()
+			            .appendPattern( pattern )
+			            .toFormatter()
+			    );
+		    } );
+
+		return builder.toFormatter();
+
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToScriptTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/conversion/ToScriptTest.java
@@ -92,11 +92,12 @@ public class ToScriptTest {
 		    """
 		    setTimezone( "UTC" );
 		    myDate = parseDateTime( "2024-03-07T16:35:43.362397-06:00" );
+			println( "parsed date: " & myDate.toISOString() );
 		    result = toScript( myDate, "myVar" )
 		    """,
 		    context );
 		// @formatter:on
-		assertThat( variables.get( result ) ).isEqualTo( "myVar = new Date('2024-03-07T16:35:43.362397Z');" );
+		assertThat( variables.get( result ) ).isEqualTo( "myVar = new Date('2024-03-07T16:35:43.362397-06:00');" );
 	}
 
 	@Test

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateTimeFormatTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateTimeFormatTest.java
@@ -489,8 +489,9 @@ public class DateTimeFormatTest {
 		DateTime dateRef = DateTimeCaster.cast( "2025-01-01T12:00:00.000Z" );
 		instance.executeSource(
 		    """
-		    result = "2025-01-01T12:00:00.000Z".DateTimeFormat( format="long", locale="en-US" );
-		    """,
+		    setTimeZone( "Z" );
+		       result = "2025-01-01T12:00:00.000Z".DateTimeFormat( format="long", locale="en-US" );
+		       """,
 		    context );
 		String				result		= variables.getAsString( Key.of( "result" ) );
 		DateTimeFormatter	formatter	= ( DateTimeFormatter ) DateTime.COMMON_FORMATTERS.get( "longDateTime" );
@@ -609,8 +610,9 @@ public class DateTimeFormatTest {
 		DateTime dateRef = DateTimeCaster.cast( "2025-01-01T12:00:00.000Z" );
 		instance.executeSource(
 		    """
-		    result = "2025-01-01T12:00:00.000Z".timeFormat( format="long", locale="en-US" );
-		    """,
+		    setTimeZone( "Z" );
+		       result = "2025-01-01T12:00:00.000Z".timeFormat( format="long", locale="en-US" );
+		       """,
 		    context );
 		String				result		= variables.getAsString( Key.of( "result" ) );
 		DateTimeFormatter	formatter	= ( DateTimeFormatter ) DateTime.COMMON_FORMATTERS.get( "longTime" );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTimeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/ParseDateTimeTest.java
@@ -77,7 +77,7 @@ public class ParseDateTimeTest {
 		assertThat( IntegerCaster.cast( result.format( "H" ) ) ).isEqualTo( 0 );
 		assertThat( IntegerCaster.cast( result.format( "m" ) ) ).isEqualTo( 0 );
 		assertThat( IntegerCaster.cast( result.format( "s" ) ) ).isEqualTo( 1 );
-		assertThat( IntegerCaster.cast( result.format( "n" ) ) ).isEqualTo( 1000000 );
+		assertThat( IntegerCaster.cast( result.format( "n" ) ) ).isEqualTo( 100000 );
 	}
 
 	@DisplayName( "It tests the BIF ParseDateTime with a full ISO without offset" )
@@ -97,7 +97,7 @@ public class ParseDateTimeTest {
 		assertThat( IntegerCaster.cast( result.format( "H" ) ) ).isEqualTo( 0 );
 		assertThat( IntegerCaster.cast( result.format( "m" ) ) ).isEqualTo( 0 );
 		assertThat( IntegerCaster.cast( result.format( "s" ) ) ).isEqualTo( 1 );
-		assertThat( IntegerCaster.cast( result.format( "n" ) ) ).isEqualTo( 1000000 );
+		assertThat( IntegerCaster.cast( result.format( "n" ) ) ).isEqualTo( 100000 );
 	}
 
 	@DisplayName( "It tests the BIF ParseDateTime with a full ISO without offset an no T" )

--- a/src/test/java/ortus/boxlang/runtime/types/DateTimeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/types/DateTimeTest.java
@@ -189,11 +189,11 @@ public class DateTimeTest {
 	@Test
 	void testEquality() {
 		java.util.Date	epoch		= new java.util.Date( 0 );
-		DateTime		dateTime1	= DateTimeCaster.cast( epoch );
+		DateTime		dateTime1	= new DateTime( epoch, ZoneId.of( "UTC" ) );
 		DateTime		dateTime2	= DateTimeCaster.cast( "1970-01-01T00:00:00Z" );
 		assertThat( dateTime1.isEqual( dateTime2 ) ).isTrue();
 		assertThat( dateTime1.equals( dateTime2 ) ).isTrue();
-		assertThat( dateTime1.compareTo( dateTime2 ) ).isEqualTo( 0 );
+		assertThat( dateTime1.toISOString() ).isEqualTo( dateTime2.toISOString() );
 		// @formatter:off
 		instance.executeSource(
 		"""


### PR DESCRIPTION
Remove DateUtil from mix as it was incorrectly mutating zone info and incorrectly parsing microseconds

# Description

This PR revisits the mentioned issues.  It removes the use of Commons `DateUtils` as there were several problems with using that class:

* `DateUtils` does not understand nor is a aware of context time zones
* `DateUtils` underlying parser is `SimpleDateFormat` - whose underlying object is `java.util.Date`
* `java.util.Date` does not retain timezone information
* Because of the above, a date/time string containing zone info would be converted to the system timezone by DateUtils, but then the context timezone would be re-applied to the same instant - causing a mutation in the actual timestamp.
* `java.util.Date` precision is only to the millisecond and microseconds were being incorrectly rounded.

We now pass these common formats through [the `DateTimeFormatter.parseBest` method](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/time/format/DateTimeFormatter.html#parseBest(java.lang.CharSequence,java.time.temporal.TemporalQuery...)), which allows us to retain microsecond precision, while also retaining Zone information on applicable strings.

This should also fix several regressions in `bx-compat-cfml` caused by the original commits for these issues.

## Jira Issues

BL-1570
BL-1571

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
