### PR TITLE
BL-1127 - Add datasource config load event interception point

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/config/Configuration.java
+++ b/src/main/java/ortus/boxlang/runtime/config/Configuration.java
@@ -49,6 +49,7 @@ import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.KeyCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
+import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
@@ -637,8 +638,14 @@ public class Configuration implements IConfigSegment {
 				    .entrySet()
 				    .forEach( entry -> {
 					    if ( entry.getValue() instanceof IStruct castedStruct ) {
-						    DatasourceConfig datasourceConfig = new DatasourceConfig( entry.getKey() )
-						        .process( new Struct( castedStruct ) );
+						    IStruct eventData = Struct.of(
+						        Key._name, entry.getKey(),
+						        Key.datasource, new Struct( castedStruct )
+						    );
+						    BoxRuntime.getInstance().announce( BoxEvent.ON_DATASOURCE_CONFIG_LOAD, eventData );
+
+						    DatasourceConfig datasourceConfig = new DatasourceConfig( eventData.getAsKey( Key._name ) )
+						        .process( eventData.getAsStruct( Key.datasource ) );
 						    this.datasources.put( datasourceConfig.name, datasourceConfig );
 					    } else {
 						    logger.warn(
@@ -951,9 +958,9 @@ public class Configuration implements IConfigSegment {
 		this.executors.entrySet()
 		    .forEach( entry -> executorsCopy.put( entry.getKey(), ( ( ExecutorConfig ) entry.getValue() ).toStruct() ) );
 
-		IStruct datsourcesCopy = new Struct();
+		IStruct datasourcesCopy = new Struct();
 		this.datasources.entrySet()
-		    .forEach( entry -> datsourcesCopy.put( entry.getKey(), ( ( DatasourceConfig ) entry.getValue() ).asStruct() ) );
+		    .forEach( entry -> datasourcesCopy.put( entry.getKey(), ( ( DatasourceConfig ) entry.getValue() ).asStruct() ) );
 
 		IStruct modulesCopy = new Struct();
 		this.modules.entrySet()
@@ -970,7 +977,7 @@ public class Configuration implements IConfigSegment {
 		    Key.clearClassFilesOnStartup, this.clearClassFilesOnStartup,
 		    Key.customComponentsDirectory, Array.copyFromList( this.customComponentsDirectory ),
 		    Key.classPaths, Array.copyFromList( this.classPaths ),
-		    Key.datasources, datsourcesCopy,
+		    Key.datasources, datasourcesCopy,
 		    Key.debugMode, this.debugMode,
 		    Key.classResolverCache, this.classResolverCache,
 		    Key.defaultDatasource, this.defaultDatasource,

--- a/src/main/java/ortus/boxlang/runtime/config/Configuration.java
+++ b/src/main/java/ortus/boxlang/runtime/config/Configuration.java
@@ -646,12 +646,12 @@ public class Configuration implements IConfigSegment {
 					    if ( entry.getValue() instanceof IStruct castedStruct ) {
 						    IStruct eventData = Struct.of(
 						        Key._name, entry.getKey(),
-						        Key.datasource, new Struct( castedStruct )
+						        Key.properties, new Struct( castedStruct )
 						    );
 						    BoxRuntime.getInstance().announce( BoxEvent.ON_DATASOURCE_CONFIG_LOAD, eventData );
 
 						    DatasourceConfig datasourceConfig = new DatasourceConfig( eventData.getAsKey( Key._name ) )
-						        .process( eventData.getAsStruct( Key.datasource ) );
+						        .process( eventData.getAsStruct( Key.properties ) );
 						    this.datasources.put( datasourceConfig.name, datasourceConfig );
 					    } else {
 						    logger.warn(

--- a/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
+++ b/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
@@ -148,6 +148,7 @@ public enum BoxEvent {
 	/**
 	 * Datasource Service Events
 	 */
+	ON_DATASOURCE_CONFIG_LOAD( "onDatasourceConfigLoad" ),
 	ON_DATASOURCE_SERVCE_STARTUP( "onDatasourceServiceStartup" ),
 	ON_DATASOURCE_SERVICE_SHUTDOWN( "onDatasourceServiceShutdown" ),
 	ON_DATASOURCE_STARTUP( "onDatasourceStartup" ),

--- a/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
+++ b/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
@@ -149,7 +149,7 @@ public enum BoxEvent {
 	 * Datasource Service Events
 	 */
 	ON_DATASOURCE_CONFIG_LOAD( "onDatasourceConfigLoad" ),
-	ON_DATASOURCE_SERVCE_STARTUP( "onDatasourceServiceStartup" ),
+	ON_DATASOURCE_SERVICE_STARTUP( "onDatasourceServiceStartup" ),
 	ON_DATASOURCE_SERVICE_SHUTDOWN( "onDatasourceServiceShutdown" ),
 	ON_DATASOURCE_STARTUP( "onDatasourceStartup" ),
 

--- a/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/DatasourceService.java
@@ -102,7 +102,7 @@ public class DatasourceService extends BaseService {
 
 		// Announce it
 		announce(
-		    BoxEvent.ON_DATASOURCE_SERVCE_STARTUP,
+		    BoxEvent.ON_DATASOURCE_SERVICE_STARTUP,
 		    Struct.of( "DatasourceService", this )
 		);
 


### PR DESCRIPTION
Allows the compat module to intercept and override incoming datasource configurations for lucee password encryption support.

# Description

Adds interception point to datasource configuration load.

Implemented via https://github.com/ortus-boxlang/bx-compat-cfml/pull/40

## Jira Issues

[BL-1127](https://ortussolutions.atlassian.net/browse/BL-1127)

## Type of change

- [X] New Feature

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


[BL-1127]: https://ortussolutions.atlassian.net/browse/BL-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ