### PR TITLE
BL-1525

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -1164,7 +1164,8 @@ public class BoxRuntime implements java.io.Closeable {
 			// Load the template
 			BoxTemplate targetTemplate = RunnableLoader.getInstance().loadTemplateRelative(
 			    context,
-			    templatePath );
+			    templatePath,
+			    false );
 			executeTemplate( targetTemplate, templatePath, context );
 		}
 	}

--- a/src/main/java/ortus/boxlang/runtime/application/ApplicationDefaultListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/ApplicationDefaultListener.java
@@ -45,7 +45,7 @@ public class ApplicationDefaultListener extends BaseApplicationListener {
 	public void onRequest( IBoxContext context, Object[] args ) {
 		super.onRequest( context, args );
 		// Then include the requested template
-		context.includeTemplate( ( String ) args[ 0 ] );
+		context.includeTemplate( ( String ) args[ 0 ], true );
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/application/ApplicationTemplateListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/ApplicationTemplateListener.java
@@ -56,7 +56,7 @@ public class ApplicationTemplateListener extends BaseApplicationListener {
 	public void onRequest( IBoxContext context, Object[] args ) {
 		super.onRequest( context, args );
 		// Then include the requested template
-		context.includeTemplate( ( String ) args[ 0 ] );
+		context.includeTemplate( ( String ) args[ 0 ], true );
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/components/system/Component.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Component.java
@@ -92,7 +92,7 @@ public class Component extends ortus.boxlang.runtime.components.Component {
 			String	templateName		= templateFileName.substring( 0, templateFileName.lastIndexOf( '.' ) );
 			tagName = Key.of( templateName );
 			executionState.put( Key.customTagName, tagName );
-			bTemplate = RunnableLoader.getInstance().loadTemplateRelative( context, template );
+			bTemplate = RunnableLoader.getInstance().loadTemplateRelative( context, template, false );
 		} else if ( name != null && !name.isEmpty() ) {
 			tagName = Key.of( name );
 			executionState.put( Key.customTagName, tagName );
@@ -236,6 +236,7 @@ public class Component extends ortus.boxlang.runtime.components.Component {
 		        .stream()
 		        .map( entry -> ResolvedFilePath.of(
 		            entry.getKey().getName(),
+		            // Mapping.toString() returns the path
 		            entry.getValue().toString(),
 		            entry.getValue().toString(),
 		            entry.getValue().toString() )

--- a/src/main/java/ortus/boxlang/runtime/components/system/Include.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Include.java
@@ -22,10 +22,10 @@ import java.util.Set;
 import ortus.boxlang.runtime.components.Attribute;
 import ortus.boxlang.runtime.components.BoxComponent;
 import ortus.boxlang.runtime.components.Component;
-import ortus.boxlang.runtime.validation.Validator;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.validation.Validator;
 
 @BoxComponent
 public class Include extends Component {
@@ -39,7 +39,8 @@ public class Include extends Component {
 	public Include() {
 		super();
 		declaredAttributes = new Attribute[] {
-		    new Attribute( Key.template, "string", Set.of( Validator.REQUIRED, Validator.NON_EMPTY ) )
+		    new Attribute( Key.template, "string", Set.of( Validator.REQUIRED, Validator.NON_EMPTY ) ),
+		    new Attribute( Key.externalOnly, "boolean", false )
 		};
 	}
 
@@ -53,7 +54,7 @@ public class Include extends Component {
 	 *
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {
-		context.includeTemplate( attributes.getAsString( Key.template ) );
+		context.includeTemplate( attributes.getAsString( Key.template ), attributes.getAsBoolean( Key.externalOnly ) );
 		return DEFAULT_RETURN;
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/config/Configuration.java
+++ b/src/main/java/ortus/boxlang/runtime/config/Configuration.java
@@ -61,6 +61,7 @@ import ortus.boxlang.runtime.types.util.DateTimeHelper;
 import ortus.boxlang.runtime.util.DataNavigator;
 import ortus.boxlang.runtime.util.DataNavigator.Navigator;
 import ortus.boxlang.runtime.util.LocalizationUtil;
+import ortus.boxlang.runtime.util.Mapping;
 
 /**
  * The BoxLang configuration object representing the core configuration.
@@ -463,9 +464,14 @@ public class Configuration implements IConfigSegment {
 		// Process mappings
 		if ( config.containsKey( Key.mappings ) ) {
 			if ( config.get( Key.mappings ) instanceof IStruct castedMap ) {
-				castedMap.entrySet().forEach( entry -> this.mappings.put(
-				    entry.getKey(),
-				    PlaceholderHelper.resolve( entry.getValue() ) ) );
+				castedMap.entrySet().forEach( entry -> {
+					// Server-level mappings default to being external
+					registerMapping(
+					    entry.getKey(),
+					    PlaceholderHelper.resolveAll( entry.getValue() ),
+					    true
+					);
+				} );
 			} else {
 				logger.warn( "The [mappings] configuration is not a JSON Object, ignoring it." );
 			}
@@ -747,83 +753,93 @@ public class Configuration implements IConfigSegment {
 	}
 
 	/**
-	 * Register a mapping in the runtime configuration
+	 * Register a mapping in the runtime configuration.
+	 * The mapping will default to not being external
 	 *
-	 * @param mapping The mapping to register: {@code /myMapping}, please note the
-	 *                leading slash
-	 * @param path    The absolute path to the directory to map to the mapping
+	 * @param name            The mapping to register: {@code /myMapping}, please note the
+	 *                        leading slash
+	 * @param data            The absolute path to the directory to map to the mapping
+	 * @param defaultExternal If this mapping defaults to being external
 	 *
 	 * @throws BoxRuntimeException If the path does not exist
 	 *
 	 * @return The runtime configuration
 	 */
-	public Configuration registerMapping( String mapping, String path ) {
-		return this.registerMapping( Key.of( mapping ), path );
+	public Configuration registerMapping( String name, Object data, boolean defaultExternal ) {
+		return this.registerMapping( Key.of( name ), data, defaultExternal );
 	}
 
 	/**
 	 * Register a mapping in the runtime configuration
 	 *
-	 * @param mapping The mapping to register: {@code /myMapping}, please note the
-	 *                leading slash
-	 * @param path    The absolute path to the directory to map to the mapping
+	 * @param name The mapping to register: {@code /myMapping}, please note the
+	 *             leading slash
+	 * @param data The absolute path to the directory to map to the mapping
 	 *
 	 * @throws BoxRuntimeException If the path does not exist
 	 *
 	 * @return The runtime configuration
 	 */
-	public Configuration registerMapping( Key mapping, String path ) {
-		// Check if mapping has a leading slash else add it
-		if ( !mapping.getName().startsWith( "/" ) ) {
-			mapping = Key.of( "/" + mapping.getName() );
-		}
+	public Configuration registerMapping( String name, Object data ) {
+		return this.registerMapping( Key.of( name ), data );
+	}
 
-		// Convert the path to a Java Path
-		Path pathObj = Path.of( path ).toAbsolutePath();
+	/**
+	 * Register a mapping in the runtime configuration
+	 * The mapping will default to not being external
+	 *
+	 * @param name The mapping to register: {@code /myMapping}, please note the
+	 *             leading slash
+	 * @param data The absolute path to the directory to map to the mapping
+	 *
+	 * @throws BoxRuntimeException If the path does not exist
+	 *
+	 * @return The runtime configuration
+	 */
+	public Configuration registerMapping( Key name, Object data ) {
+		return registerMapping( name, data, false );
+	}
 
-		// Verify it exists else throw an exception
-		if ( !pathObj.toFile().exists() ) {
-			throw new BoxRuntimeException(
-			    String.format( "The path [%s] does not exist.", pathObj ) );
-		}
-
-		// Now we can add it
-		this.mappings.put( mapping, pathObj.toString() );
-
+	/**
+	 * Register a mapping in the runtime configuration
+	 *
+	 * @param name            The mapping to register: {@code /myMapping}, please note the
+	 *                        leading slash
+	 * @param data            The absolute path to the directory to map to the mapping
+	 * @param defaultExternal If this mapping defaults to being external
+	 *
+	 * @throws BoxRuntimeException If the path does not exist
+	 *
+	 * @return The runtime configuration
+	 */
+	public Configuration registerMapping( Key name, Object data, boolean defaultExternal ) {
+		var m = Mapping.fromData( name.getName(), data, defaultExternal );
+		this.mappings.put( m.name(), m );
 		return this;
 	}
 
 	/**
 	 * Unregister a mapping in the runtime configuration
 	 *
-	 * @param mapping The String mapping to unregister: {@code /myMapping}, please
-	 *                note the leading slash
+	 * @param name The String mapping to unregister: {@code /myMapping}, please
+	 *             note the leading slash
 	 *
 	 * @return True if the mapping was removed, false otherwise
 	 */
-	public boolean unregisterMapping( String mapping ) {
-		return this.unregisterMapping( Key.of( mapping ) );
+	public boolean unregisterMapping( String name ) {
+		return this.mappings.remove( Key.of( Mapping.cleanName( name ) ) ) != null;
 	}
 
 	/**
 	 * Unregister a mapping in the runtime configuration using a {@link Key}
 	 *
-	 * @param mapping The Key mapping to unregister: {@code /myMapping}, please note
-	 *                the leading slash
+	 * @param name The Key mapping to unregister: {@code /myMapping}, please note
+	 *             the leading slash
 	 *
 	 * @return True if the mapping was removed, false otherwise
 	 */
-	public boolean unregisterMapping( Key mapping ) {
-		// Check if mapping has a leading slash else add it
-		if ( !mapping.getName().startsWith( "/" ) ) {
-			mapping = Key.of( "/" + mapping.getName() );
-		}
-		// Add traiing slash
-		if ( !mapping.getName().endsWith( "/" ) ) {
-			mapping = Key.of( mapping.getName() + "/" );
-		}
-
-		return this.mappings.remove( mapping ) != null;
+	public boolean unregisterMapping( Key name ) {
+		return unregisterMapping( name.getName() );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
@@ -60,6 +60,7 @@ import ortus.boxlang.runtime.types.exceptions.ScopeNotFoundException;
 import ortus.boxlang.runtime.util.Attachable;
 import ortus.boxlang.runtime.util.DataNavigator;
 import ortus.boxlang.runtime.util.DataNavigator.Navigator;
+import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.runtime.util.IBoxAttachable;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
@@ -672,7 +673,8 @@ public class BaseBoxContext implements IBoxContext {
 	 *
 	 * @param templatePath A relateive template path
 	 */
-	public void includeTemplate( String templatePath ) {
+	@Override
+	public void includeTemplate( String templatePath, boolean externalOnly ) {
 		Set<String>	VALID_TEMPLATE_EXTENSIONS	= BoxRuntime.getInstance().getConfiguration().getValidTemplateExtensions();
 
 		String		ext							= "";
@@ -694,12 +696,13 @@ public class BaseBoxContext implements IBoxContext {
 		// This extension check is duplicated in the runnableLoader right now since some code paths hit the runnableLoader directly
 		if ( ext.equals( "*" ) || VALID_TEMPLATE_EXTENSIONS.contains( ext ) ) {
 			// Load template class, compiling if neccessary
-			BoxTemplate template = RunnableLoader.getInstance().loadTemplateRelative( this, templatePath );
+			BoxTemplate template = RunnableLoader.getInstance().loadTemplateRelative( this, templatePath, externalOnly );
 
 			template.invoke( this );
 		} else {
 			// If this extension is not one we compile, then just read the contents and flush it to the buffer
-			writeToBuffer( invokeFunction( Key.fileread, new Object[] { templatePath } ) );
+			writeToBuffer(
+			    invokeFunction( Key.fileread, new Object[] { FileSystemUtil.expandPath( this, templatePath, externalOnly ).absolutePath().toString() } ) );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/context/IBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/IBoxContext.java
@@ -251,7 +251,16 @@ public interface IBoxContext extends IBoxAttachable, Serializable {
 	 *
 	 * @param templatePath A relateive template path
 	 */
-	public void includeTemplate( String templatePath );
+	public default void includeTemplate( String templatePath ) {
+		includeTemplate( templatePath, false );
+	}
+
+	/**
+	 * Invoke a template in the current context
+	 *
+	 * @param templatePath A relateive template path
+	 */
+	public void includeTemplate( String templatePath, boolean externalOnly );
 
 	/**
 	 * Register a UDF with the local context.

--- a/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
@@ -42,6 +42,7 @@ import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.util.ListUtil;
 import ortus.boxlang.runtime.util.LocalizationUtil;
+import ortus.boxlang.runtime.util.Mapping;
 import ortus.boxlang.runtime.util.RequestThreadManager;
 
 /**
@@ -429,8 +430,14 @@ public abstract class RequestBoxContext extends BaseBoxContext implements IJDBCC
 		}
 
 		// Mapping overrides
+		var configMappings = config.getAsStruct( Key.mappings );
 		StructCaster.attempt( appSettings.get( Key.mappings ) )
-		    .ifPresent( mappings -> config.getAsStruct( Key.mappings ).putAll( mappings ) );
+		    .ifPresent( mappings -> mappings.keySet().forEach( mappingKey -> {
+			    // translate from struct/string to mapping instance
+			    // Mappings declared in the Application.bx file default to external
+			    var m = Mapping.fromData( mappingKey.getName(), mappings.get( mappingKey ), true );
+			    configMappings.put( m.name(), m );
+		    } ) );
 
 		// If we have a customTagPaths, then transpile it to customComponentPaths
 		// This is a legacy setting that was used in older versions of BoxLang + CFML

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/BaseResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/BaseResolver.java
@@ -34,6 +34,7 @@ import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.loader.ImportDefinition;
 import ortus.boxlang.runtime.loader.util.ClassDiscovery;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
+import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 /**
@@ -193,7 +194,7 @@ public class BaseResolver implements IClassResolver {
 	 * @return An optional class object representing the class if found
 	 */
 	@Override
-	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports ) {
+	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, IStruct properties ) {
 		throw new BoxRuntimeException( "Implement the [resolve] method in your own resolver" );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/BoxResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/BoxResolver.java
@@ -38,8 +38,10 @@ import ortus.boxlang.runtime.modules.ModuleRecord;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ModuleService;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
 /**
@@ -106,7 +108,7 @@ public class BoxResolver extends BaseResolver {
 	 * @return An optional class object representing the class if found
 	 */
 	public Optional<ClassLocation> resolve( IBoxContext context, String name, boolean loadClass ) {
-		return resolve( context, name, EMPTY_IMPORTS, loadClass );
+		return resolve( context, name, EMPTY_IMPORTS, loadClass, Struct.EMPTY );
 	}
 
 	/**
@@ -121,7 +123,24 @@ public class BoxResolver extends BaseResolver {
 	 */
 	@Override
 	public Optional<ClassLocation> resolve( IBoxContext context, String name ) {
-		return resolve( context, name, EMPTY_IMPORTS, true );
+		return resolve( context, name, EMPTY_IMPORTS, true, Struct.EMPTY );
+	}
+
+	/**
+	 * Each resolver has a way to resolve the class it represents.
+	 * This method will be called by the {@link ClassLocator} class
+	 * to resolve the class if the prefix matches with imports.
+	 *
+	 * @param context    The current context of execution
+	 * @param name       The name of the class to resolve
+	 * @param imports    The list of imports to use
+	 * @param properties The properties to use
+	 *
+	 * @return An optional class object representing the class if found
+	 */
+	@Override
+	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, IStruct properties ) {
+		return resolve( context, name, imports, true, properties );
 	}
 
 	/**
@@ -135,9 +154,8 @@ public class BoxResolver extends BaseResolver {
 	 *
 	 * @return An optional class object representing the class if found
 	 */
-	@Override
 	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports ) {
-		return resolve( context, name, imports, true );
+		return resolve( context, name, imports, true, Struct.EMPTY );
 	}
 
 	/**
@@ -152,7 +170,7 @@ public class BoxResolver extends BaseResolver {
 	 *
 	 * @return An optional class object representing the class if found
 	 */
-	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, boolean loadClass ) {
+	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, boolean loadClass, IStruct properties ) {
 		// turn / into .
 		name	= name.replace( "../", "DOT_DOT_SLASH" )
 		    .replace( "/", "." )
@@ -166,7 +184,7 @@ public class BoxResolver extends BaseResolver {
 		// System.out.println( "--=--------> fullyQualifiedName: " + fullyQualifiedName );
 
 		return findFromModules( context, fullyQualifiedName, imports, loadClass )
-		    .or( () -> findFromLocal( context, fullyQualifiedName, imports, loadClass ) );
+		    .or( () -> findFromLocal( context, fullyQualifiedName, imports, loadClass, properties ) );
 	}
 
 	/**
@@ -265,7 +283,7 @@ public class BoxResolver extends BaseResolver {
 	 * @return The loaded class or null if not found
 	 */
 	public Optional<ClassLocation> findFromLocal( IBoxContext context, String fullyQualifiedName, List<ImportDefinition> imports ) {
-		return findFromLocal( context, fullyQualifiedName, imports, true );
+		return findFromLocal( context, fullyQualifiedName, imports, true, Struct.EMPTY );
 	}
 
 	/**
@@ -278,7 +296,8 @@ public class BoxResolver extends BaseResolver {
 	 *
 	 * @return The loaded class or null if not found
 	 */
-	public Optional<ClassLocation> findFromLocal( IBoxContext context, String fullyQualifiedName, List<ImportDefinition> imports, boolean loadClass ) {
+	public Optional<ClassLocation> findFromLocal( IBoxContext context, String fullyQualifiedName, List<ImportDefinition> imports, boolean loadClass,
+	    IStruct properties ) {
 		final String finalSlashName = getFullyQualifiedSlashName( fullyQualifiedName );
 		// Try to find the class using:
 		// 1. Relative to the current template
@@ -287,18 +306,19 @@ public class BoxResolver extends BaseResolver {
 		return findByRelativeLocation( context, finalSlashName, name, imports, loadClass )
 		    // TODO: both of these method call context.getConfig(), but ideally we just call it once
 		    // For classes found in a lookup directory, it will result in getConfig() being called twice.
-		    .or( () -> findByMapping( context, finalSlashName, name, imports, loadClass ) )
+		    .or( () -> findByMapping( context, finalSlashName, name, imports, loadClass, properties ) )
 		    .or( () -> findByLookupDirectory( context, finalSlashName, name, imports, loadClass ) );
 	}
 
 	/**
 	 * Find a class by mapping resolution
 	 *
-	 * @param context   The current context of execution
-	 * @param slashName The name of the class to find using slahes instead of dots
-	 * @param name      The original dot notation name of the class to find
-	 * @param imports   The list of imports to use
-	 * @param loadClass When false, the class location is returned with informatino about where the class was found, but the class is not loaded and will be null.
+	 * @param context    The current context of execution
+	 * @param slashName  The name of the class to find using slahes instead of dots
+	 * @param name       The original dot notation name of the class to find
+	 * @param imports    The list of imports to use
+	 * @param loadClass  When false, the class location is returned with informatino about where the class was found, but the class is not loaded and will be null.
+	 * @param properties The properties to use
 	 *
 	 * @return An Optional of {@link ClassLocation} if found, {@link Optional#empty()} otherwise
 	 */
@@ -307,10 +327,13 @@ public class BoxResolver extends BaseResolver {
 	    String slashName,
 	    String name,
 	    List<ImportDefinition> imports,
-	    boolean loadClass ) {
+	    boolean loadClass,
+	    IStruct properties ) {
+
+		boolean	externalOnly	= ( Boolean ) properties.getOrDefault( Key.externalOnly, false );
 
 		// Look for a mapping that matches the start of the path
-		IStruct mappings = context.getConfig().getAsStruct( Key.mappings );
+		IStruct	mappings		= context.getConfig().getAsStruct( Key.mappings );
 
 		// System.out.println( "mappings: " + mappings );
 		// System.out.println( "slashName: " + slashName );
@@ -322,7 +345,9 @@ public class BoxResolver extends BaseResolver {
 		    .entrySet()
 		    .stream()
 		    // Filter out mappings that don't match the start of the mapping path
-		    .filter( entry -> StringUtils.startsWithIgnoreCase( slashName, entry.getKey().getName() ) )
+		    // Also, filter out external mappings if externalOnly is true
+		    .filter( entry -> ( !externalOnly || ( ( Mapping ) entry.getValue() ).external() )
+		        && StringUtils.startsWithIgnoreCase( slashName, entry.getKey().getName() ) )
 		    // Map it to a Stream<Path> object representing the paths to the classes
 		    .flatMap( entry -> {
 			    // Generate multiple paths here

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/IClassResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/IClassResolver.java
@@ -24,6 +24,7 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.loader.ClassLocation;
 import ortus.boxlang.runtime.loader.ClassLocator;
 import ortus.boxlang.runtime.loader.ImportDefinition;
+import ortus.boxlang.runtime.types.IStruct;
 
 /**
  * This interface is to implement ways to resolve classes in BoxLang.
@@ -72,6 +73,6 @@ public interface IClassResolver {
 	 *
 	 * @return An optional class object representing the class if found
 	 */
-	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports );
+	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, IStruct properties );
 
 }

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/JavaResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/JavaResolver.java
@@ -35,6 +35,8 @@ import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.loader.ImportDefinition;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ModuleService;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.util.RegexBuilder;
 
@@ -103,7 +105,26 @@ public class JavaResolver extends BaseResolver {
 	 */
 	@Override
 	public Optional<ClassLocation> resolve( IBoxContext context, String name ) {
-		return resolve( context, name, List.of() );
+		return resolve( context, name, List.of(), Struct.EMPTY );
+	}
+
+	/**
+	 * Each resolver has a way to resolve the class it represents.
+	 * This method will be called by the {@link ClassLocator} class
+	 * to resolve the class if the prefix matches with imports.
+	 *
+	 * @param context    The current context of execution
+	 * @param name       The fully qualified name OR imported alias of the class to resolve
+	 * @param imports    The list of imports to use
+	 * @param properties The properties to use
+	 *
+	 * @return An optional class object representing the class if found
+	 */
+	@Override
+	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports, IStruct properties ) {
+		String fullyQualifiedName = expandFromImport( context, name, imports );
+		return findFromModules( fullyQualifiedName, imports, context )
+		    .or( () -> findFromSystem( fullyQualifiedName, imports, context ) );
 	}
 
 	/**
@@ -117,11 +138,8 @@ public class JavaResolver extends BaseResolver {
 	 *
 	 * @return An optional class object representing the class if found
 	 */
-	@Override
 	public Optional<ClassLocation> resolve( IBoxContext context, String name, List<ImportDefinition> imports ) {
-		String fullyQualifiedName = expandFromImport( context, name, imports );
-		return findFromModules( fullyQualifiedName, imports, context )
-		    .or( () -> findFromSystem( fullyQualifiedName, imports, context ) );
+		return resolve( context, name, imports, Struct.EMPTY );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -399,7 +399,7 @@ public class ModuleRecord {
 
 		// Register the module mapping in the this.runtime
 		// Called first in case this is used in the `configure` method
-		this.runtime.getConfiguration().registerMapping( this.mapping, this.path );
+		this.runtime.getConfiguration().registerMapping( this.mapping, this.path, false );
 
 		// Create the module class loader and seed it with the physical path to the
 		// module

--- a/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
@@ -181,9 +181,9 @@ public class RunnableLoader {
 	 *
 	 * @return The BoxTemplate instance
 	 */
-	public BoxTemplate loadTemplateRelative( IBoxContext context, String path ) {
+	public BoxTemplate loadTemplateRelative( IBoxContext context, String path, boolean externalOnly ) {
 		// Make absolute
-		return loadTemplateAbsolute( context, FileSystemUtil.expandPath( context, path ) );
+		return loadTemplateAbsolute( context, FileSystemUtil.expandPath( context, path, externalOnly ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -337,6 +337,8 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		expression2							= Key.of( "expression2" );
 	public static final Key		expressions							= Key.of( "expressions" );
 	public static final Key		extendedinfo						= Key.of( "extendedinfo" );
+	public static final Key		external							= Key.of( "external" );
+	public static final Key		externalOnly						= Key.of( "externalOnly" );
 	public static final Key		extrainfo							= Key.of( "extrainfo" );
 	public static final Key		fatalErrors							= Key.of( "fatalErrors" );
 	public static final Key		file								= Key.of( "file" );
@@ -803,6 +805,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		urlToken							= Key.of( "urlToken" );
 	public static final Key		US									= Key.of( "US" );
 	public static final Key		useCache							= Key.of( "useCache" );
+	public static final Key		useCaching							= Key.of( "useCaching" );
 	public static final Key		useCustomSerializer					= Key.of( "useCustomSerializer" );
 	public static final Key		useHighPrecisionMath				= Key.of( "useHighPrecisionMath" );
 	public static final Key		useLastAccessTimeouts				= Key.of( "useLastAccessTimeouts" );

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -361,11 +361,16 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 
 	/**
 	 * Convenience method for getting cast as BoxLang Attempt
-	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 * If the value is not already an attempt, it will be wrapped in an Attempt
 	 */
 	@SuppressWarnings( "unchecked" )
 	default Attempt<Object> getAsAttempt( Key key ) {
-		return ( Attempt<Object> ) DynamicObject.unWrap( get( key ) );
+		Object result = DynamicObject.unWrap( get( key ) );
+		// if it's already an Attempt, return it
+		if ( result instanceof Attempt ar ) {
+			return ar;
+		}
+		return Attempt.of( result );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/util/Mapping.java
+++ b/src/main/java/ortus/boxlang/runtime/util/Mapping.java
@@ -31,7 +31,7 @@ import ortus.boxlang.runtime.types.Struct;
 public record Mapping( String name, String path, boolean external ) {
 
 	/**
-	 * Factor method to create a new Mapping instance.
+	 * Factory method to create a new Mapping instance.
 	 * Mapping names such as foo/bar will be forced to have leading and trailing slashes.
 	 * /foo/bar/
 	 *

--- a/src/main/java/ortus/boxlang/runtime/util/Mapping.java
+++ b/src/main/java/ortus/boxlang/runtime/util/Mapping.java
@@ -33,7 +33,7 @@ public record Mapping( String name, String path, boolean external ) {
 	/**
 	 * Factory method to create a new Mapping instance.
 	 * Mapping names such as foo/bar will be forced to have leading and trailing slashes.
-	 * /foo/bar/
+	 * For example, foo/bar will be transformed to /foo/bar/.
 	 *
 	 * @param name     The mapping name
 	 * @param path     The mapping path

--- a/src/main/java/ortus/boxlang/runtime/util/Mapping.java
+++ b/src/main/java/ortus/boxlang/runtime/util/Mapping.java
@@ -1,0 +1,150 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.util;
+
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.dynamic.casters.StructCaster;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+
+/**
+ * I represent the a mapping such as /foo/ or /foo/bar/ which resolves to an absolute directory path.
+ *
+ */
+public record Mapping( String name, String path, boolean external ) {
+
+	/**
+	 * Factor method to create a new Mapping instance.
+	 * Mapping names such as foo/bar will be forced to have leading and trailing slashes.
+	 * /foo/bar/
+	 *
+	 * @param name     The mapping name
+	 * @param path     The mapping path
+	 * @param external Is this mapping externally accessible?
+	 *
+	 * @return A new Mapping instance.
+	 */
+	public static Mapping of( String name, String path, boolean external ) {
+		return new Mapping(
+		    cleanName( name ),
+		    path,
+		    external
+		);
+	}
+
+	/**
+	 * Factory method to create a new external Mapping instance
+	 *
+	 * @param name The mapping name
+	 * @param path The mapping path
+	 *
+	 * @return A new Mapping instance.
+	 */
+	public static Mapping ofExternal( String name, String path ) {
+		return Mapping.of(
+		    name,
+		    path,
+		    true
+		);
+	}
+
+	/**
+	 * Factory method to create a new internal Mapping instance
+	 *
+	 * @param name The mapping name
+	 * @param path The mapping path
+	 *
+	 * @return A new Mapping instance.
+	 */
+	public static Mapping ofInternal( String name, String path ) {
+		return Mapping.of(
+		    name,
+		    path,
+		    false
+		);
+	}
+
+	/**
+	 * Factory method to create a new Mapping instance from data.
+	 * This method will attempt to extract the mapping path and external flag from the data.
+	 * If the data is a Struct, it will extract the path and external flag.
+	 * If the data is not a Struct, it will assume the data is a string representing the mapping path and default the external flag.
+	 * 
+	 * @param name The mapping name
+	 * @param data The data to extract the mapping path and external flag from.
+	 * 
+	 * @return A new Mapping instance.
+	 */
+	public static Mapping fromData( String name, Object data, boolean defaultExternal ) {
+		// If the data is a Struct, we can extract the mapping path and external flag
+		return StructCaster.attempt( data ).map( s -> Mapping.of(
+		    name,
+		    s.getAsAttempt( Key.path ).map( StringCaster::cast ).orThrow( "Path is required for mapping" ),
+		    s.getAsAttempt( Key.external ).map( BooleanCaster::cast ).getOrDefault( defaultExternal )
+		) )
+		    // Otherwise, we assume the data is a string representing the mapping path (and default external)
+		    .orElseGet( () -> Mapping.of(
+		        name,
+		        StringCaster.cast( data ),
+		        defaultExternal
+		    ) );
+	}
+
+	/**
+	 * Convert this Mapping to a Struct representation.
+	 * 
+	 * @return A Struct representation of this Mapping.
+	 */
+	public IStruct toStruct() {
+		return Struct.of(
+		    Key._NAME, this.name,
+		    Key.path, this.path,
+		    Key.external, this.external
+		);
+	}
+
+	/**
+	 * Convert this Mapping to a Struct representation without the name.
+	 * 
+	 * @return A Struct representation of this Mapping without the name.
+	 */
+	public IStruct toStructNoName() {
+		return Struct.of(
+		    Key.path, this.path,
+		    Key.external, this.external
+		);
+	}
+
+	public static String cleanName( String name ) {
+		if ( !name.startsWith( "/" ) ) {
+			name = "/" + name;
+		}
+		if ( !name.endsWith( "/" ) ) {
+			name += "/";
+		}
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return path;
+	}
+
+}

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -60,7 +60,7 @@
 	"sessionStorage": "memory",
 	// A collection of BoxLang mappings, the key is the prefix and the value is the directory
 	// The key can also be a struct containing a "path" and "external" property 
-	// An non-external mapping will not be used in the web runtimes to resolve incoming file paths
+	// A non-external mapping will not be used in the web runtimes to resolve incoming file paths
 	"mappings": {
 		"/": "${user-dir}"
 	},

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -59,6 +59,8 @@
 	// This will apply to ALL applications unless overridden in the Application.cfc
 	"sessionStorage": "memory",
 	// A collection of BoxLang mappings, the key is the prefix and the value is the directory
+	// The key can also be a struct containing a "path" and "external" property 
+	// An non-external mapping will not be used in the web runtimes to resolve incoming file paths
 	"mappings": {
 		"/": "${user-dir}"
 	},

--- a/src/test/java/TestCases/applications/ApplicationLookups.java
+++ b/src/test/java/TestCases/applications/ApplicationLookups.java
@@ -31,6 +31,7 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.RequestScope;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 
 public class ApplicationLookups {
 
@@ -124,7 +125,7 @@ public class ApplicationLookups {
 
 	@Test
 	public void testAppClassInMapping() {
-		instance.getConfiguration().mappings.put( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
+		instance.getConfiguration().registerMapping( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
 		context = getContext( "src/test/java/TestCases/applications/appClass/", "secret/index.bxm" );
 		instance.executeTemplate(
 		    "secret/index.bxm",
@@ -138,7 +139,7 @@ public class ApplicationLookups {
 
 	@Test
 	public void testAppClassInMappingSub() {
-		instance.getConfiguration().mappings.put( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
+		instance.getConfiguration().registerMapping( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
 		context = getContext( "src/test/java/TestCases/applications/appClass/", "secret/sub1/index.bxm" );
 		instance.executeTemplate(
 		    "secret/sub1/index.bxm",
@@ -152,7 +153,7 @@ public class ApplicationLookups {
 
 	private IBoxContext getContext( String rootPath, String template ) {
 		return new ScriptingRequestBoxContext( new ConfigOverrideBoxContext( instance.getRuntimeContext(), config -> {
-			config.getAsStruct( Key.mappings ).put( "/", new java.io.File( rootPath ).getAbsolutePath() );
+			config.getAsStruct( Key.mappings ).put( "/", Mapping.ofExternal( "/", new java.io.File( rootPath ).getAbsolutePath() ) );
 			return config;
 		} ), FileSystemUtil.createFileUri( template ) );
 	}

--- a/src/test/java/TestCases/applications/ApplicationRequestStart.java
+++ b/src/test/java/TestCases/applications/ApplicationRequestStart.java
@@ -32,6 +32,7 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 
 public class ApplicationRequestStart {
 
@@ -62,7 +63,7 @@ public class ApplicationRequestStart {
 
 	private IBoxContext getContext( String rootPath, String template ) {
 		return new ScriptingRequestBoxContext( new ConfigOverrideBoxContext( instance.getRuntimeContext(), config -> {
-			config.getAsStruct( Key.mappings ).put( "/", new java.io.File( rootPath ).getAbsolutePath() );
+			config.getAsStruct( Key.mappings ).put( "/", Mapping.ofExternal( "/", new java.io.File( rootPath ).getAbsolutePath() ) );
 			return config;
 		} ), FileSystemUtil.createFileUri( template ) );
 	}

--- a/src/test/java/TestCases/phase3/ApplicationTest.java
+++ b/src/test/java/TestCases/phase3/ApplicationTest.java
@@ -334,7 +334,8 @@ public class ApplicationTest {
 		assertThat( result.get( Key._NAME ) ).isEqualTo( "testUpdateApplicationWithoutName" );
 		assertThat( result.get( Key.mappings ) ).isNotNull();
 		assertThat( result.get( Key.mappings ) ).isInstanceOf( IStruct.class );
-		assertThat( result.getAsStruct( Key.mappings ).get( "/UpdateApplicationWithoutName" ) ).isEqualTo( "/src/test/resources/libs/" );
+		assertThat( result.getAsStruct( Key.mappings ).getAsString( Key.of( "/UpdateApplicationWithoutName" ) ) )
+		    .isEqualTo( "/src/test/resources/libs/" );
 		assertThat( variables.get( Key.of( "firstSessionID" ) ) ).isEqualTo( variables.get( Key.of( "secondSessionID" ) ) );
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/io/ContractPathTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/io/ContractPathTest.java
@@ -46,7 +46,7 @@ public class ContractPathTest {
 	public static void setUp() throws IOException {
 		instance = BoxRuntime.getInstance( true );
 		// Create a mapping for the test
-		instance.getConfiguration().mappings.put( "/contract/path/test",
+		instance.getConfiguration().registerMapping( "/contract/path/test",
 		    Path.of( "src/test/java/ortus/boxlang/runtime/bifs/global/io/" ).toAbsolutePath().toString() );
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/io/ExpandPathTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/io/ExpandPathTest.java
@@ -42,6 +42,7 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
 public class ExpandPathTest {
@@ -55,9 +56,9 @@ public class ExpandPathTest {
 	public static void setUp() throws IOException {
 		instance = BoxRuntime.getInstance( true );
 		// Create a mapping for the test
-		instance.getConfiguration().mappings.put( "/expand/path/test",
+		instance.getConfiguration().registerMapping( "/expand/path/test",
 		    Path.of( "src/test/java/ortus/boxlang/runtime/bifs/global/io/" ).toAbsolutePath().toString() );
-		instance.getConfiguration().mappings.put( "/mytest",
+		instance.getConfiguration().registerMapping( "/mytest",
 		    Path.of( "src/test/java/ortus/boxlang/runtime/bifs/global/io/" ).toAbsolutePath().toString() );
 	}
 
@@ -235,7 +236,7 @@ public class ExpandPathTest {
 	public void testCanonicalize() {
 		// This test assumes the project is checked out at least 2 folders deep. If this becomes an issue
 		// then change the test to set the root `/` mapping equals to a fake folder at least 2 levels deep.
-		String	rootMapping						= ( String ) context.getConfigItems( Key.mappings, Key.of( "/" ) );
+		String	rootMapping						= ( ( Mapping ) context.getConfigItems( Key.mappings, Key.of( "/" ) ) ).path();
 		String	parentOfRootMappings			= Path.of( rootMapping ).getParent().toString();
 		String	parentOfParentOfRootMappings	= Path.of( parentOfRootMappings ).getParent().toString();
 		instance.executeSource(
@@ -276,7 +277,7 @@ public class ExpandPathTest {
 		      """,
 		    context );
 		assertThat( variables.getAsString( result ) )
-		    .isEqualTo( context.getConfig().getAsStruct( Key.mappings ).get( "/" ) + File.separator );
+		    .isEqualTo( context.getConfig().getAsStruct( Key.mappings ).getAs( Mapping.class, Key._slash ).path() + File.separator );
 	}
 
 	@Test

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTemplatePathTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTemplatePathTest.java
@@ -35,6 +35,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.RequestScope;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 
 public class GetBaseTemplatePathTest {
 
@@ -77,7 +78,7 @@ public class GetBaseTemplatePathTest {
 
 	@Test
 	public void testAppClassInMappingSub() {
-		instance.getConfiguration().mappings.put( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
+		instance.getConfiguration().registerMapping( "/secret", new java.io.File( "src/test/java/TestCases/applications/external" ).getAbsolutePath() );
 		context = getContext( "src/test/java/TestCases/applications/appClass/", "secret/sub1/index.bxm" );
 		instance.executeTemplate(
 		    "secret/sub1/index.bxm",
@@ -91,7 +92,7 @@ public class GetBaseTemplatePathTest {
 
 	private IBoxContext getContext( String rootPath, String template ) {
 		return new ScriptingRequestBoxContext( new ConfigOverrideBoxContext( instance.getRuntimeContext(), config -> {
-			config.getAsStruct( Key.mappings ).put( "/", new java.io.File( rootPath ).getAbsolutePath() );
+			config.getAsStruct( Key.mappings ).put( "/", Mapping.ofExternal( "/", new java.io.File( rootPath ).getAbsolutePath() ) );
 			return config;
 		} ), FileSystemUtil.createFileUri( template ) );
 	}


### PR DESCRIPTION
This change
* introduces a new class called Mapping that stores a mapping
  * name
  * path
  * new flag called external
* changes the mappings struct in the config to use this mapping class instead of just a string
* When defining a mapping in either the boxlang.json or the Application.bx, the mapping value can be either a string OR a struct containing the path and external flag
* All server level mappings and Application.bx mappings not explicitly labeled are added external by default (we can make this a compat behavior if we like)
* A module mappings are added internal by default
* URLs to a template (static or otherwise) will only be able to "see" external mappings
* URLs to a class will only be able to "see" external mappings as well


I also added some simple path traversal checks to the web runtime just to be safe.

I also exposed the ability to load templates and classes ONLY via externally-visible mappings to the `include` component and `createObject()` via a new `externalOnly` argument.  This is important for anyone overriding the `onRequest()` or `onClassRequest()` methods in their `Application.bx` to ensure they stay secure.

```js
bx:include template="/secret/file.cfm" externalOnly=true;

createObject( className="secret.path.to.Class", externalOnly=true );
```