### PR TITLE
JDBC - Ensure executedQuery implements Serializable

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ExecutedQuery.java
@@ -17,6 +17,7 @@ package ortus.boxlang.runtime.jdbc;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 
+import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,7 +44,7 @@ import ortus.boxlang.runtime.types.exceptions.DatabaseException;
  * This class represents a query that has been executed and contains the results of executing that query.
  * It contains a reference to the {@link PendingQuery} that was executed to create this.
  */
-public final class ExecutedQuery {
+public final class ExecutedQuery implements Serializable {
 
 	private static final InterceptorService	interceptorService	= BoxRuntime.getInstance().getInterceptorService();
 	private static final BoxLangLogger		logger				= BoxRuntime.getInstance().getLoggingService().DATASOURCE_LOGGER;

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -36,12 +36,14 @@ import org.junit.jupiter.api.condition.EnabledIf;
 
 import ortus.boxlang.runtime.dynamic.casters.DoubleCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
+import ortus.boxlang.runtime.jdbc.ExecutedQuery;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
+import ortus.boxlang.runtime.util.conversion.ObjectMarshaller;
 import tools.JDBCTestUtils;
 
 public class QueryExecuteTest extends BaseJDBCTest {
@@ -940,4 +942,10 @@ public class QueryExecuteTest extends BaseJDBCTest {
 		assertEquals( 0, query.size() );
 	}
 
+	@DisplayName( "ExecutedQuery instances are serializable" )
+	@Test
+	public void testObjectMarshallingOfExecutedQuery() {
+		ExecutedQuery executedQuery = new ExecutedQuery( new Query(), null );
+		ObjectMarshaller.serialize( context, executedQuery );
+	}
 }


### PR DESCRIPTION
# Description

Ensure executedQuery is serializable for redis usage.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1621


## Type of change

- [X] Improvement

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
