### PR TITLE
BL-1518

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/BXCompiler.java
+++ b/src/main/java/ortus/boxlang/compiler/BXCompiler.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.runnables.RunnableLoader;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ParseException;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
@@ -219,7 +220,7 @@ public class BXCompiler {
 		System.out.println( "Writing " + targetPath.toString() );
 		List<byte[]> bytesList = null;
 		try {
-			bytesList = runtime.getCompiler()
+			bytesList = RunnableLoader.getInstance().getBoxpiler()
 			    .compileTemplateBytes( ResolvedFilePath.of( "", "", sourcePath.toString(), sourcePath ) );
 		} catch ( ParseException e ) {
 			if ( stopOnError ) {

--- a/src/main/java/ortus/boxlang/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/Boxpiler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -376,4 +377,21 @@ public abstract class Boxpiler implements IBoxpiler {
 
 		return diskClassUtil.readLineNumbers( classPoolName, IBoxpiler.getBaseFQN( FQN ) );
 	}
+
+	@Override
+	public List<byte[]> compileTemplateBytes( ResolvedFilePath resolvedFilePath ) {
+		Path		path		= resolvedFilePath.absolutePath();
+		ClassInfo	classInfo	= null;
+		// file extension is .bx or .cfc
+		if ( path.toString().endsWith( ".bx" ) || path.toString().endsWith( ".cfc" ) ) {
+			classInfo = ClassInfo.forClass( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
+		} else {
+			classInfo = ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
+		}
+		var classPool = getClassPool( classInfo.classPoolName() );
+		classPool.putIfAbsent( classInfo.fqn().toString(), classInfo );
+		compileClassInfo( classInfo.classPoolName(), classInfo.fqn().toString() );
+		return diskClassUtil.readClassBytes( classInfo.classPoolName(), classInfo.fqn().toString() );
+	}
+
 }

--- a/src/main/java/ortus/boxlang/compiler/IBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/IBoxpiler.java
@@ -16,15 +16,17 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.javaproxy.InterfaceProxyDefinition;
 import ortus.boxlang.runtime.runnables.IBoxRunnable;
 import ortus.boxlang.runtime.runnables.IProxyRunnable;
+import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
 public interface IBoxpiler {
 
-	static final Set<String>	RESERVED_WORDS	= new HashSet<>( Arrays.asList( "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
-	    "class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if", "implements",
-	    "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private", "protected", "public", "return", "short", "static",
-	    "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile", "while" ) );
+	static final Set<String>	RESERVED_WORDS	= new HashSet<>(
+	    Arrays.asList( "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+	        "class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if", "implements",
+	        "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private", "protected", "public", "return", "short", "static",
+	        "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile", "while" ) );
 
 	static final Pattern		FQNBasePattern	= Pattern.compile( "(.*?)(\\$Closure_.*|\\$Func_.*|\\$Lambda_.*)$" );
 
@@ -92,4 +94,6 @@ public interface IBoxpiler {
 	void compileClassInfo( String classPoolName, String FQN );
 
 	void clearPagePool();
+
+	Key getName();
 }

--- a/src/main/java/ortus/boxlang/compiler/NoOpBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/NoOpBoxpiler.java
@@ -1,0 +1,79 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.compiler;
+
+import java.io.File;
+import java.io.PrintStream;
+
+import ortus.boxlang.compiler.parser.ParsingResult;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+/**
+ * This will load classes, but not compile them.
+ */
+public class NoOpBoxpiler extends Boxpiler {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Constructors
+	 * --------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Private constructor
+	 */
+	public NoOpBoxpiler() {
+		super();
+	}
+
+	@Override
+	public Key getName() {
+		return Key.noOp;
+	}
+
+	@Override
+	public void printTranspiledCode( ParsingResult result, ClassInfo classInfo, PrintStream target ) {
+		throw new BoxRuntimeException( "NoOpBoxpiler does not support printing transpiled code" );
+	}
+
+	@Override
+	public void compileClassInfo( String classPoolName, String FQN ) {
+		// logger.debug( "Java BoxPiler Compiling " + FQN );
+		ClassInfo classInfo = getClassPool( classPoolName ).get( FQN );
+		if ( classInfo == null ) {
+			throw new BoxRuntimeException( "ClassInfo not found for " + FQN );
+		}
+		if ( classInfo.resolvedFilePath() != null ) {
+			File sourceFile = classInfo.resolvedFilePath().absolutePath().toFile();
+			// Check if the source file contains Java bytecode by reading the first few bytes
+			if ( diskClassUtil.isJavaBytecode( sourceFile ) ) {
+				classInfo.getClassLoader().defineClasses( FQN, sourceFile, classInfo );
+				return;
+			}
+			throw new BoxRuntimeException( "NoOpBoxpiler does not support compiling source files." );
+		} else if ( classInfo.source() != null ) {
+			throw new BoxRuntimeException( "NoOpBoxpiler does not support compiling source files." );
+		} else if ( classInfo.interfaceProxyDefinition() != null ) {
+			throw new BoxRuntimeException( "NoOpBoxpiler does not support compiling source files." );
+		} else {
+			throw new BoxRuntimeException( "Unknown class info type: " + classInfo.toString() );
+		}
+	}
+
+}

--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/ASMBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/ASMBoxpiler.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import org.objectweb.asm.ClassWriter;
@@ -20,27 +18,21 @@ import ortus.boxlang.compiler.ast.BoxInterface;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
 import ortus.boxlang.compiler.ast.visitor.QueryEscapeSingleQuoteVisitor;
-import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
-import ortus.boxlang.runtime.util.ResolvedFilePath;
 import ortus.boxlang.runtime.util.Timer;
 
 public class ASMBoxpiler extends Boxpiler {
 
-	public static final boolean	DEBUG	= Boolean.getBoolean( "asmboxpiler.debug" );
+	public static final boolean DEBUG = Boolean.getBoolean( "asmboxpiler.debug" );
 
 	/**
 	 * --------------------------------------------------------------------------
 	 * Private Properties
 	 * --------------------------------------------------------------------------
 	 */
-
-	/**
-	 * Singleton instance
-	 */
-	private static ASMBoxpiler	instance;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -51,20 +43,13 @@ public class ASMBoxpiler extends Boxpiler {
 	/**
 	 * Private constructor
 	 */
-	private ASMBoxpiler() {
+	public ASMBoxpiler() {
 		super();
 	}
 
-	/**
-	 * Get the singleton instance
-	 *
-	 * @return TemplateLoader
-	 */
-	public static synchronized ASMBoxpiler getInstance() {
-		if ( instance == null ) {
-			instance = new ASMBoxpiler();
-		}
-		return instance;
+	@Override
+	public Key getName() {
+		return Key.asm;
 	}
 
 	@Override
@@ -180,19 +165,4 @@ public class ASMBoxpiler extends Boxpiler {
 		return null;
 	}
 
-	@Override
-	public List<byte[]> compileTemplateBytes( ResolvedFilePath resolvedFilePath ) {
-		Path		path		= resolvedFilePath.absolutePath();
-		ClassInfo	classInfo	= null;
-		// file extension is .bx or .cfc
-		if ( path.toString().endsWith( ".bx" ) || path.toString().endsWith( ".cfc" ) ) {
-			classInfo = ClassInfo.forClass( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
-		} else {
-			classInfo = ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
-		}
-		var classPool = getClassPool( classInfo.classPoolName() );
-		classPool.putIfAbsent( classInfo.fqn().toString(), classInfo );
-		compileClassInfo( classInfo.classPoolName(), classInfo.fqn().toString() );
-		return diskClassUtil.readClassBytes( classInfo.classPoolName(), classInfo.fqn().toString() );
-	}
 }

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/JavaBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/JavaBoxpiler.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,14 +57,13 @@ import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.visitor.QueryEscapeSingleQuoteVisitor;
 import ortus.boxlang.compiler.javaboxpiler.transformer.ProxyTransformer;
 import ortus.boxlang.compiler.javaboxpiler.transformer.indexer.BoxNodeKey;
-import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ExpressionException;
 import ortus.boxlang.runtime.util.RegexBuilder;
-import ortus.boxlang.runtime.util.ResolvedFilePath;
 import ortus.boxlang.runtime.util.Timer;
 
 /**
@@ -80,14 +78,9 @@ public class JavaBoxpiler extends Boxpiler {
 	 */
 
 	/**
-	 * Singleton instance
-	 */
-	private static JavaBoxpiler	instance;
-
-	/**
 	 * The Java compiler
 	 */
-	private JavaCompiler		compiler;
+	private JavaCompiler compiler;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -98,21 +91,14 @@ public class JavaBoxpiler extends Boxpiler {
 	/**
 	 * Private constructor
 	 */
-	private JavaBoxpiler() {
+	public JavaBoxpiler() {
 		super();
 		this.compiler = ToolProvider.getSystemJavaCompiler();
 	}
 
-	/**
-	 * Get the singleton instance
-	 *
-	 * @return TemplateLoader
-	 */
-	public static synchronized JavaBoxpiler getInstance() {
-		if ( instance == null ) {
-			instance = new JavaBoxpiler();
-		}
-		return instance;
+	@Override
+	public Key getName() {
+		return Key.java;
 	}
 
 	@Override
@@ -355,58 +341,4 @@ public class JavaBoxpiler extends Boxpiler {
 		return ProxyTransformer.transform( classInfo );
 	}
 
-	/**
-	 * Compile a template, returning a list of byte arrays representing the compiled class and its inner classes
-	 */
-	@Override
-	public List<byte[]> compileTemplateBytes( ResolvedFilePath resolvedFilePath ) {
-		Path		path		= resolvedFilePath.absolutePath();
-		ClassInfo	classInfo	= null;
-		// file extension is .bx or .cfc
-		if ( path.toString().endsWith( ".bx" ) || path.toString().endsWith( ".cfc" ) ) {
-			classInfo = ClassInfo.forClass( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
-		} else {
-			classInfo = ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
-		}
-		var classPool = getClassPool( classInfo.classPoolName() );
-		classPool.putIfAbsent( classInfo.fqn().toString(), classInfo );
-		compileClassInfo( classInfo.classPoolName(), classInfo.fqn().toString() );
-		return diskClassUtil.readClassBytes( classInfo.classPoolName(), classInfo.fqn().toString() );
-	}
-
-	/*
-	 * private static class CustomOutputStream extends OutputStream {
-	 * 
-	 * private final OutputStream delegate;
-	 * private final Path path;
-	 * private final Instant customModifiedDate;
-	 * 
-	 * public CustomOutputStream( OutputStream delegate, Path path, Instant customModifiedDate ) {
-	 * this.delegate = delegate;
-	 * this.path = path;
-	 * this.customModifiedDate = customModifiedDate;
-	 * }
-	 * 
-	 * @Override
-	 * public void write( int b ) throws IOException {
-	 * delegate.write( b );
-	 * }
-	 * 
-	 * @Override
-	 * public void write( byte[] b ) throws IOException {
-	 * delegate.write( b );
-	 * }
-	 * 
-	 * @Override
-	 * public void write( byte[] b, int off, int len ) throws IOException {
-	 * delegate.write( b, off, len );
-	 * }
-	 * 
-	 * @Override
-	 * public void close() throws IOException {
-	 * delegate.close();
-	 * Files.setLastModifiedTime( path, FileTime.from( customModifiedDate ) );
-	 * }
-	 * }
-	 */
 }

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -42,9 +42,7 @@ import org.slf4j.Logger;
 
 import ortus.boxlang.compiler.ClassInfo;
 import ortus.boxlang.compiler.IBoxpiler;
-import ortus.boxlang.compiler.asmboxpiler.ASMBoxpiler;
 import ortus.boxlang.compiler.ast.BoxExpression;
-import ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.parser.ParsingResult;
@@ -226,17 +224,6 @@ public class BoxRuntime implements java.io.Closeable {
 	 * The Module service in charge of all modules
 	 */
 	private ModuleService						moduleService;
-
-	/**
-	 * The BoxPiler implementation the runtime will use. At this time we offer two
-	 * choices:
-	 * 1. JavaBoxpiler - Generates Java source code and compiles it via the JDK
-	 * 2. ASMBoxpiler - Generates bytecode directly via ASM
-	 * However, developers can create their own Boxpiler implementations and
-	 * register them with the runtime
-	 * via configuration.
-	 */
-	private IBoxpiler							boxpiler;
 
 	/**
 	 * The Scheduler service in charge of all schedulers
@@ -488,8 +475,6 @@ public class BoxRuntime implements java.io.Closeable {
 		this.schedulerService.onConfigurationLoad();
 		this.dataSourceService.onConfigurationLoad();
 
-		// Startup the right Compiler according to settings
-		this.boxpiler = chooseBoxpiler();
 		// Seed Mathematical Precision for the runtime
 		MathUtil.setHighPrecisionMath( getConfiguration().useHighPrecisionMath );
 
@@ -665,13 +650,6 @@ public class BoxRuntime implements java.io.Closeable {
 	 */
 	public static Boolean hasInstance() {
 		return instance != null;
-	}
-
-	/**
-	 * Returns the compiler instance to use based on the configuration
-	 */
-	public IBoxpiler getCompiler() {
-		return this.boxpiler;
 	}
 
 	/**
@@ -1060,24 +1038,6 @@ public class BoxRuntime implements java.io.Closeable {
 	 * Utility Methods
 	 * --------------------------------------------------------------------------
 	 */
-
-	/**
-	 * Switch the runtime to generate java source and compile via the JDK
-	 */
-	public IBoxpiler useJavaBoxpiler() {
-		this.boxpiler = JavaBoxpiler.getInstance();
-		RunnableLoader.getInstance().selectBoxPiler( this.boxpiler );
-		return this.boxpiler;
-	}
-
-	/**
-	 * Switch the runtime to generate bytecode directly via ASM
-	 */
-	public IBoxpiler useASMBoxPiler() {
-		this.boxpiler = ASMBoxpiler.getInstance();
-		RunnableLoader.getInstance().selectBoxPiler( this.boxpiler );
-		return this.boxpiler;
-	}
 
 	/**
 	 * Get a Struct of version information from the version.properties
@@ -1646,13 +1606,14 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @param filePath The path to the source file
 	 */
 	public void printTranspiledJavaCode( String filePath ) {
+		IBoxpiler		boxpiler	= RunnableLoader.getInstance().getBoxpiler();
 		ClassInfo		classInfo	= ClassInfo.forTemplate(
 		    ResolvedFilePath.of( "", "", Path.of( filePath ).getParent().toString(), filePath ),
 		    BoxSourceType.BOXSCRIPT,
-		    this.boxpiler
+		    boxpiler
 		);
-		ParsingResult	result		= this.boxpiler.parseOrFail( Path.of( filePath ).toFile() );
-		this.boxpiler.printTranspiledCode( result, classInfo, System.out );
+		ParsingResult	result		= boxpiler.parseOrFail( Path.of( filePath ).toFile() );
+		boxpiler.printTranspiledCode( result, classInfo, System.out );
 	}
 
 	/**
@@ -1662,7 +1623,7 @@ public class BoxRuntime implements java.io.Closeable {
 	 *
 	 */
 	public void printSourceAST( String source ) {
-		ParsingResult result = this.boxpiler.parseOrFail( source, BoxSourceType.BOXSCRIPT, false );
+		ParsingResult result = RunnableLoader.getInstance().getBoxpiler().parseOrFail( source, BoxSourceType.BOXSCRIPT, false );
 		System.out.println( result.getRoot().toJSON() );
 	}
 
@@ -1755,27 +1716,6 @@ public class BoxRuntime implements java.io.Closeable {
 			return new ScriptingRequestBoxContext( context, template );
 		} else {
 			return new ScriptingRequestBoxContext( context );
-		}
-	}
-
-	/**
-	 * Choose the Boxpiler implementation to use according to the configuration
-	 * We only support two direct implementations, Java and ASM
-	 * Later on we need to inspect the class path for specific files if we want this configurable.
-	 *
-	 * @return The Boxpiler implementation to use
-	 */
-	private IBoxpiler chooseBoxpiler() {
-		// System.out.println( "Choosing Boxpiler implementation..." );
-		switch ( ( String ) this.configuration.experimental.getOrDefault( "compiler", "asm" ) ) {
-			case "java" :
-				this.loggingService.getRootLogger().info( "+ Choosing " + JavaBoxpiler.class.getSimpleName() + " as the Boxpiler implementation" );
-				return useJavaBoxpiler();
-			case "asm" :
-				this.loggingService.getRootLogger().info( "+ Choosing " + ASMBoxpiler.class.getSimpleName() + " as the Boxpiler implementation" );
-			default :
-				this.loggingService.getRootLogger().info( "+ Choosing " + ASMBoxpiler.class.getSimpleName() + " as the Boxpiler implementation" );
-				return useASMBoxPiler();
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -111,6 +111,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		array2								= Key.of( "array2" );
 	public static final Key		arrayFind							= Key.of( "arrayFind" );
 	public static final Key		arrayFindAll						= Key.of( "arrayFindAll" );
+	public static final Key		asm									= Key.of( "asm" );
 	public static final Key		asOptional							= Key.of( "asOptional" );
 	public static final Key		assocAttribs						= Key.of( "assocAttribs" );
 	public static final Key		assignableArray						= Key.of( "assignableArray" );
@@ -541,6 +542,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		newDelimiter						= Key.of( "newDelimiter" );
 	public static final Key		newDirectory						= Key.of( "newDirectory" );
 	public static final Key		newPath								= Key.of( "newPath" );
+	public static final Key		noOp								= Key.of( "noop" );
 	public static final Key		noInit								= Key.of( "noInit" );
 	public static final Key		notify								= Key.of( "notify" );
 	public static final Key		notifyAll							= Key.of( "notifyAll" );

--- a/src/main/java/ortus/boxlang/runtime/types/exceptions/ExceptionUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/exceptions/ExceptionUtil.java
@@ -43,6 +43,7 @@ import ortus.boxlang.runtime.dynamic.casters.StructCasterLoose;
 import ortus.boxlang.runtime.dynamic.casters.ThrowableCaster;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.operators.InstanceOf;
+import ortus.boxlang.runtime.runnables.RunnableLoader;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
@@ -201,7 +202,7 @@ public class ExceptionUtil {
 						BLFileName = element.getFileName();
 					}
 
-					IBoxpiler	boxpiler	= BoxRuntime.getInstance().getCompiler();
+					IBoxpiler	boxpiler	= RunnableLoader.getInstance().getBoxpiler();
 					SourceMap	sourceMap	= null;
 
 					if ( boxpiler instanceof JavaBoxpiler ) {

--- a/src/main/resources/META-INF/services/ortus.boxlang.compiler.IBoxpiler
+++ b/src/main/resources/META-INF/services/ortus.boxlang.compiler.IBoxpiler
@@ -1,0 +1,3 @@
+ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler
+ortus.boxlang.compiler.asmboxpiler.ASMBoxpiler
+ortus.boxlang.compiler.NoOpBoxpiler

--- a/src/test/java/TestCases/phase2/UDFFunctionTest.java
+++ b/src/test/java/TestCases/phase2/UDFFunctionTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.FunctionBoxContext;
@@ -38,6 +37,7 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.Referencer;
 import ortus.boxlang.runtime.loader.ImportDefinition;
+import ortus.boxlang.runtime.runnables.RunnableLoader;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
@@ -172,7 +172,7 @@ public class UDFFunctionTest {
 	@DisplayName( "It should not allow you to declare multiple functions with the same name" )
 	@Test
 	public void testMultipleFunctionDeclarationsSameName() {
-		if ( instance.getCompiler() instanceof JavaBoxpiler ) {
+		if ( RunnableLoader.getInstance().getBoxpiler().getName().equals( Key.java ) ) {
 			return;
 		}
 

--- a/src/test/java/ortus/boxlang/compiler/SourceMapTest.java
+++ b/src/test/java/ortus/boxlang/compiler/SourceMapTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ortus.boxlang.compiler.javaboxpiler.JavaBoxpiler;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.runnables.RunnableLoader;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -59,7 +59,7 @@ public class SourceMapTest {
 
 	@Test
 	public void testVariableLineNumber() {
-		if ( instance.getCompiler() instanceof JavaBoxpiler ) {
+		if ( RunnableLoader.getInstance().getBoxpiler().getName().equals( Key.java ) ) {
 			return;
 		}
 		Exception		e		= assertThrows( KeyNotFoundException.class, () -> {
@@ -79,7 +79,7 @@ public class SourceMapTest {
 
 	@Test
 	public void testTemmplateMissingVariable() {
-		if ( instance.getCompiler() instanceof JavaBoxpiler ) {
+		if ( RunnableLoader.getInstance().getBoxpiler().getName().equals( Key.java ) ) {
 			return;
 		}
 
@@ -100,7 +100,7 @@ public class SourceMapTest {
 
 	@Test
 	public void testTemmplateMissingVariableInComponent() {
-		if ( instance.getCompiler() instanceof JavaBoxpiler ) {
+		if ( RunnableLoader.getInstance().getBoxpiler().getName().equals( Key.java ) ) {
 			return;
 		}
 		Exception		e		= assertThrows( KeyNotFoundException.class, () -> {


### PR DESCRIPTION
There are now THREE BoxPilers

- ASM (default, if present)
- Java
- NoOp - default if no other boxpilers are present

The NoOp Boxpiler will load classes so long as they are already compiled and exist on disk, but will throw an exception if you ask it to actually compile something.

The NoOp is required for the use case of deploying a fully pre-compiled app

Note, the ASM library must remain in the core regardless of the boxpiler that is bundled or chosen as the BL runtime does some bytecode manipulation with it.

We will leave the source code for both asm and java in the main repo for now for ease of development

Next, we will modify Gradle to output 4 artifacts (names are negotiable)

- `boxlang-runtime-noop.jar` PURE runtime with NoOp BoxPiler.  For precompiled deploys or build-your-own-classpath scenarios
- `boxlang-runtime-asm.jar` Default download.  Runtime with ASM classes bundled.
- `bx-asm-compiler.jar` JUST the ASM BoxPiler (for you to combine on the classpath with the bare runtime)
- `bx-java-compiler.jar` JUST the Java BoxPiler (for you to combine on the classpath with the bare runtime)

90% of people would just use the runtime + ASM jar.  People creating pre-compiled deploys and/or who want to ensure no runtime compilation can happen for security would use the bare NoOp jar.  The last two jars would be mixed into the class path at runtime like this



java -cp boxlang-runtime-noop;bx-java-compiler.jar ortus.boxlang.BoxRunner