### PR TITLE
BL-1633

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -316,6 +316,12 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	 */
 	@Override
 	public BoxNode visit( BoxDotAccess node ) {
+		// This renames the columnNames to columnArray
+		if ( node.getAccess() instanceof BoxIdentifier id && id.getName().equalsIgnoreCase( "columnNames" ) ) {
+			id.setName( "columnArray" );
+		}
+
+		// Make sure we upper case the dot access keys like in CFML
 		upperCaseDotAceessKeys( node );
 		return super.visit( node );
 	}
@@ -1215,9 +1221,9 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	/**
 	 * Determine if a node is inside a script or template
 	 * TODO: Does this deserve to exist on BoxNode?
-	 * 
+	 *
 	 * @param node The node to check
-	 * 
+	 *
 	 * @return true if the node is inside a script or template, false otherwise
 	 */
 	@SuppressWarnings( "unchecked" )

--- a/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
@@ -255,7 +255,7 @@ public class BaseBoxContext implements IBoxContext {
 
 	/**
 	 * Is there at least one output component on the stack
-	 * 
+	 *
 	 * @return True if there is at least one output component, else false
 	 */
 	public boolean isInOutputComponent() {
@@ -741,9 +741,9 @@ public class BaseBoxContext implements IBoxContext {
 	 * This allows us to "reserve" known scope names to ensure arguments.foo
 	 * will always look in the proper arguments scope and never in
 	 * local.arguments.foo for example
-	 * 
+	 *
 	 * @param key The key to check for visibility
-	 * 
+	 *
 	 * @return True if the key is visible in the current context, else false
 	 */
 	public boolean isKeyVisibleScope( Key key ) {
@@ -755,11 +755,11 @@ public class BaseBoxContext implements IBoxContext {
 	 * This allows us to "reserve" known scope names to ensure arguments.foo
 	 * will always look in the proper arguments scope and never in
 	 * local.arguments.foo for example
-	 * 
+	 *
 	 * @param key     The key to check for visibility
 	 * @param nearby  true, check only scopes that are nearby to the current execution context
 	 * @param shallow true, do not delegate to parent or default scope if not found
-	 * 
+	 *
 	 * @return True if the key is visible in the current context, else false
 	 */
 	public boolean isKeyVisibleScope( Key key, boolean nearby, boolean shallow ) {
@@ -878,6 +878,9 @@ public class BaseBoxContext implements IBoxContext {
 				}
 				if ( key.equals( Key.columnList ) ) {
 					return new ScopeSearchResult( null, query.getColumnList(), key );
+				}
+				if ( key.equals( Key.columnArray ) ) {
+					return new ScopeSearchResult( null, query.getColumnArray(), key );
 				}
 				if ( query.hasColumn( key ) ) {
 					// TODO: create query scope wrapper for edge cases

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -189,6 +189,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		column_name							= Key.of( "column_name" );
 	public static final Key		columnKey							= Key.of( "columnKey" );
 	public static final Key		columnList							= Key.of( "columnList" );
+	public static final Key		columnArray							= Key.of( "columnArray" );
 	public static final Key		columnName							= Key.of( "columnName" );
 	public static final Key		columns								= Key.of( "columns" );
 	public static final Key		columnType							= Key.of( "columnType" );

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -1138,12 +1138,14 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 		if ( name.equals( BoxMeta.key ) ) {
 			return getBoxMeta();
 		}
-
 		if ( name.equals( Key.recordCount ) ) {
 			return size();
 		}
 		if ( name.equals( Key.columnList ) ) {
 			return getColumnList();
+		}
+		if ( name.equals( Key.columnArray ) ) {
+			return getColumnArray();
 		}
 		if ( name.equals( Key.currentRow ) ) {
 			return getRowFromContext( context ) + 1;

--- a/src/test/java/TestCases/phase2/QueryTest.java
+++ b/src/test/java/TestCases/phase2/QueryTest.java
@@ -61,6 +61,47 @@ public class QueryTest {
 		variables	= context.getScopeNearby( VariablesScope.name );
 	}
 
+	@DisplayName( "Test query.columnArray" )
+	@Test
+	public void testColumnArray() {
+		// Test implementation goes here
+		// @formatter:off
+		instance.executeSource( """
+					qry = queryNew( "col1,col2", "string,integer", [ "foo", 42 ] );
+					result = qry.columnArray;
+					println( result )
+			"""
+			, context );
+		// @formatter:on
+		assertThat( variables.getAsArray( result ) ).isInstanceOf( Array.class );
+		assertThat( variables.getAsArray( result ).size() ).isEqualTo( 2 );
+		assertThat( variables.getAsArray( result ).get( 0 ) ).isEqualTo( "col1" );
+		assertThat( variables.getAsArray( result ).get( 1 ) ).isEqualTo( "col2" );
+	}
+
+	@DisplayName( "Test query.columnArray in a loop" )
+	@Test
+	public void testColumnArrayInLoop() {
+		// Test implementation goes here
+		// @formatter:off
+		instance.executeSource( """
+					qry = queryNew( "col1,col2", "string,integer", [
+						[ "foo", 42 ],
+						[ "bar", 100 ]
+					] );
+					bx:loop query=#qry#{
+						println( col1 )
+						result = columnArray
+					}
+			"""
+			, context );
+		// @formatter:on
+		assertThat( variables.getAsArray( result ) ).isInstanceOf( Array.class );
+		assertThat( variables.getAsArray( result ).size() ).isEqualTo( 2 );
+		assertThat( variables.getAsArray( result ).get( 0 ) ).isEqualTo( "col1" );
+		assertThat( variables.getAsArray( result ).get( 1 ) ).isEqualTo( "col2" );
+	}
+
 	@DisplayName( "Query" )
 	@Disabled( "Issue with member function vs java method" )
 	@Test


### PR DESCRIPTION
queryObject.columnnames not supported

- Added transpilation rule: query.columnNames -> query.columnArray
- Added support for query.columnArray and query.columnList

