### PR TITLE
BL-1637 : Rename thisTag scope to thisComponent scope for consistency and transpile the old scope

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -88,23 +88,145 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 
 /**
- * Pretty print BoxLang AST nodes
+ * CF Transpiler Visitor for BoxLang AST Transformation
+ *
+ * This visitor transforms CFML/ColdFusion syntax into BoxLang-compatible syntax by traversing
+ * the Abstract Syntax Tree (AST) and performing various transformations including:
+ *
+ * <ul>
+ * <li>Renaming CF-specific variables and identifiers (cfcatch -> bxcatch, thisTag -> thisComponent)</li>
+ * <li>Converting CF BIFs to BoxLang equivalents (chr -> char, asc -> ascii)</li>
+ * <li>Transforming component names and attributes</li>
+ * <li>Handling case-sensitivity requirements (uppercase struct keys)</li>
+ * <li>Converting operator precedence issues</li>
+ * <li>Merging documentation annotations</li>
+ * <li>Adding output annotations for compatibility</li>
+ * </ul>
+ *
+ * <h2>Architecture</h2>
+ * The visitor extends {@link ReplacingBoxVisitor} and uses the visitor pattern to traverse
+ * the AST. Each visit method handles a specific type of AST node and applies the necessary
+ * transformations.
+ *
+ * <h2>Configuration</h2>
+ * The transpiler can be configured via module settings in the compat module:
+ *
+ * <pre>
+ * {
+ *   "transpiler": {
+ *     "upperCaseKeys": true,           // Convert struct keys to uppercase
+ *     "forceOutputTrue": true,         // Add @output true to functions/classes
+ *     "mergeDocsIntoAnnotations": true, // Convert doc comments to annotations
+ *     "isLucee": true                  // Enable Lucee-specific compatibility
+ *   }
+ * }
+ * </pre>
+ *
+ * <h2>How to Add New Transformations</h2>
+ *
+ * <h3>1. Adding BIF Mappings</h3>
+ * Add entries to the static {@code BIFMap} in the static initializer:
+ *
+ * <pre>
+ * BIFMap.put( "oldname", "newname" );
+ * </pre>
+ *
+ * <h3>2. Adding Variable Renamings</h3>
+ * Add entries to the static {@code identifierMap}:
+ *
+ * <pre>
+ * identifierMap.put( "cfvariable", "bxvariable" );
+ * </pre>
+ *
+ * <h3>3. Adding Component Transformations</h3>
+ * For component name changes, add to {@code componentMap}:
+ *
+ * <pre>
+ * componentMap.put( "oldcomponent", "newcomponent" );
+ * </pre>
+ *
+ * For attribute name changes, add to {@code componentAttrMap}:
+ *
+ * <pre>
+ * componentAttrMap.put( "componentname", Map.of( "oldattr", "newattr" ) );
+ * </pre>
+ *
+ * <h3>4. Adding New Visit Methods</h3>
+ * Override visit methods for specific AST node types:
+ *
+ * <pre>
+ * {@code @Override}
+ * public BoxNode visit(YourNodeType node) {
+ *     // Perform transformations
+ *     return super.visit(node); // Continue traversal
+ * }
+ * </pre>
+ *
+ * <h3>5. BIF Return Type Fixes</h3>
+ * For BIFs that should return the modified object instead of true/false,
+ * add to {@code BIFReturnTypeFixSet}:
+ *
+ * <pre>
+ * BIFReturnTypeFixSet.add( "bifname" );
+ * </pre>
+ *
+ * @see ReplacingBoxVisitor
+ * @see BoxNode
+ *
+ * @author BoxLang Team
  */
 public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 
+	/**
+	 * Static mappings for Built-In Function (BIF) name transformations.
+	 * Maps CF function names to their BoxLang equivalents.
+	 * All keys must be lowercase for consistent matching.
+	 */
 	private static Set<String>						BIFReturnTypeFixSet			= new HashSet<>();
+
+	/**
+	 * Maps CF BIF names to BoxLang BIF names.
+	 * Used to rename function calls during transpilation.
+	 */
 	private static Map<String, String>				BIFMap						= new HashMap<>();
+
+	/**
+	 * Maps CF variable/identifier names to BoxLang equivalents.
+	 * Used for renaming variables like cfcatch -> bxcatch.
+	 */
 	private static Map<String, String>				identifierMap				= new HashMap<>();
+
+	/**
+	 * Maps CF component names to BoxLang component names.
+	 * Used for renaming component tags during transpilation.
+	 */
 	private static Map<String, String>				componentMap				= new HashMap<>();
+
+	/**
+	 * Maps component names to their attribute rename mappings.
+	 * Outer key is component name, inner map is old->new attribute names.
+	 */
 	private static Map<String, Map<String, String>>	componentAttrMap			= new HashMap<>();
+
+	/**
+	 * Configuration keys for transpiler settings
+	 */
 	private static Key								transpilerKey				= Key.of( "transpiler" );
 	private static Key								upperCaseKeysKey			= Key.of( "upperCaseKeys" );
 	private static Key								forceOutputTrueKey			= Key.of( "forceOutputTrue" );
 	private static Key								mergeDocsIntoAnnotationsKey	= Key.of( "mergeDocsIntoAnnotations" );
 	private static Key								isLuceeKey					= Key.of( "isLucee" );
 	private static Key								compatKey					= Key.of( "compat-cfml" );
+
+	/**
+	 * Runtime and service references
+	 */
 	private static BoxRuntime						runtime						= BoxRuntime.getInstance();
 	private static ModuleService					moduleService				= runtime.getModuleService();
+
+	/**
+	 * Instance state variables
+	 */
 	private boolean									isClass						= false;
 	private String									className					= "";
 	private boolean									upperCaseKeys				= true;
@@ -156,6 +278,7 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		identifierMap.put( "cfquery", "bxquery" );
 		identifierMap.put( "cfdocument", "bxdocument" );
 		identifierMap.put( "cfstoredproc", "bxstoredproc" );
+		identifierMap.put( "thistag", "thiscomponent" );
 
 		/**
 		 * These are components that have been renamed
@@ -197,6 +320,24 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	/**
 	 * Constructor
 	 */
+	/**
+	 * Constructor initializes the visitor with configuration settings from the BoxLang runtime.
+	 * Reads transpiler-specific settings from the runtime configuration to customize
+	 * the transpilation behavior.
+	 *
+	 * The constructor performs the following initialization:
+	 * 1. Retrieves the transpiler configuration section from runtime settings
+	 * 2. Sets up case sensitivity for generated keys
+	 * 3. Configures output behavior for components
+	 * 4. Determines documentation merge strategy
+	 * 5. Checks for CFML compatibility mode
+	 *
+	 * Configuration options:
+	 * - upperCaseKeys: Controls whether generated keys are uppercase (default: true)
+	 * - forceOutputTrue: Forces components to have output=true (default: true)
+	 * - mergeDocsIntoAnnotations: Merges documentation into annotations (default: true)
+	 * - isLucee: Sets Lucee compatibility mode based on compat module presence
+	 */
 	public CFTranspilerVisitor() {
 		// This may change when moving this visitor to the actual compat module
 		this( moduleService.hasModule( compatKey ) ? StructCaster.cast( moduleService.getModuleSettings( compatKey ) ) : Struct.EMPTY );
@@ -224,9 +365,18 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Transpile Box Classes
-	 * - Merge documentation into annotations
-	 * - enable output
+	 * Main entry point for AST transformation. Transforms a BoxLang AST into a CFML-compatible
+	 * format by applying visitor pattern transformations to all nodes in the tree.
+	 *
+	 * This method orchestrates the entire transpilation process:
+	 * 1. Resets internal state for the new transformation
+	 * 2. Determines if the root node represents a class or script
+	 * 3. Applies recursive transformations to all child nodes
+	 * 4. Returns the transformed AST ready for code generation
+	 *
+	 * @param node The root AST node to transform (typically BoxScript or BoxClass)
+	 *
+	 * @return The transformed AST node with CFML-compatible structure
 	 */
 	@Override
 	public BoxNode visit( BoxClass node ) {
@@ -259,10 +409,20 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Transpile UDF declarations
-	 * - Merge documentation into annotations
-	 * - enable output
-	 * - rename onCFCRequest to onClassRequest
+	 * Transforms User Defined Function (UDF) declarations for CFML compatibility.
+	 *
+	 * Key transformations applied:
+	 * - Merges documentation comments into function annotations
+	 * - Enables output=true for functions (configurable)
+	 * - Renames CFML-specific lifecycle methods (onCFCRequest -> onClassRequest)
+	 * - Applies return type fixes for certain BIFs
+	 *
+	 * Special handling for lifecycle methods:
+	 * - onCFCRequest becomes onClassRequest for BoxLang compatibility
+	 *
+	 * @param node The BoxFunctionDeclaration node to transform
+	 *
+	 * @return The transformed BoxFunctionDeclaration node
 	 */
 	@Override
 	public BoxNode visit( BoxFunctionDeclaration node ) {
@@ -288,7 +448,17 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename CF variables
+	 * Transforms BoxIdentifier nodes by renaming CF-specific variables to BoxLang equivalents.
+	 *
+	 * This method handles the renaming of reserved CFML variables to their BoxLang counterparts:
+	 * - cfcatch -> bxcatch
+	 * - cfthread -> bxthread
+	 * - cffile -> bxfile
+	 * - etc.
+	 *
+	 * @param node The BoxIdentifier node to transform
+	 *
+	 * @return The transformed BoxIdentifier node with renamed variables
 	 */
 	@Override
 	public BoxNode visit( BoxIdentifier node ) {
@@ -297,8 +467,19 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename CF variables
-	 * change variables[ "cfcatch" ] to variables[ "bxcatch" ]
+	 * Transforms BoxArrayAccess nodes by renaming CF-specific variables in array access patterns.
+	 *
+	 * This method specifically handles string literal array access where CF variables are accessed:
+	 * - variables["cfcatch"] becomes variables["bxcatch"]
+	 * - variables["cfthread"] becomes variables["bxthread"]
+	 * - etc.
+	 *
+	 * This ensures that code like `variables.cfcatch` or `variables["cfcatch"]` gets properly
+	 * renamed to use BoxLang variable names.
+	 *
+	 * @param node The BoxArrayAccess node to transform
+	 *
+	 * @return The transformed BoxArrayAccess node with renamed variable references
 	 */
 	@Override
 	public BoxNode visit( BoxArrayAccess node ) {
@@ -312,7 +493,22 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * change foo.bar to foo.BAR
+	 * Transforms BoxDotAccess nodes for CFML compatibility.
+	 *
+	 * Key transformations applied:
+	 * - Renames specific properties (columnNames -> columnArray)
+	 * - Converts dot access keys to uppercase (configurable via upperCaseKeys setting)
+	 *
+	 * Examples:
+	 * - obj.columnNames becomes obj.columnArray
+	 * - obj.myProperty becomes obj.MYPROPERTY (if upperCaseKeys is true)
+	 *
+	 * This maintains CFML's case-insensitive behavior while ensuring
+	 * consistent key casing for compatibility.
+	 *
+	 * @param node The BoxDotAccess node to transform
+	 *
+	 * @return The transformed BoxDotAccess node
 	 */
 	@Override
 	public BoxNode visit( BoxDotAccess node ) {
@@ -340,8 +536,18 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename top level CF variables
-	 * change { foo : 'bar' } to { FOO : 'bar' }
+	 * Transforms BoxStructLiteral nodes by converting keys to uppercase for CFML compatibility.
+	 *
+	 * In CFML, struct keys are typically case-insensitive but displayed in uppercase.
+	 * This transformation ensures consistent key casing:
+	 * - { foo : 'bar' } becomes { FOO : 'bar' }
+	 * - { myKey : 'value' } becomes { MYKEY : 'value' }
+	 *
+	 * The transformation is controlled by the upperCaseKeys configuration setting.
+	 *
+	 * @param node The BoxStructLiteral node to transform
+	 *
+	 * @return The transformed BoxStructLiteral node with uppercase keys
 	 */
 	public BoxNode visit( BoxStructLiteral node ) {
 		upperCaseStructLiteralKeys( node );
@@ -367,12 +573,24 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename some common CF built-in functions like chr() to char()
+	 * Transforms BoxFunctionInvocation nodes by applying BIF (Built-In Function) mappings and
+	 * special transformations for CFML compatibility.
 	 *
-	 * Replace
-	 * structKeyExists( struct, key )
-	 * with
-	 * !isNull( struct[ key ] )
+	 * Key transformations applied:
+	 * 1. BIF Name Mapping: Renames functions using the BIFMap (e.g., chr() -> char())
+	 * 2. QueryExecute Parameter Transformation: Converts CFML query parameters to BoxLang format
+	 * - Renames cfsqltype -> sqltype in parameter structs
+	 * - Removes "cf_sql_" prefix from sqltype values
+	 * 3. Special Function Handling: Applies custom transpilation logic for specific functions
+	 *
+	 * Examples:
+	 * - chr(65) becomes char(65)
+	 * - structKeyExists(obj, "key") gets special handling
+	 * - queryExecute() parameters get normalized for BoxLang
+	 *
+	 * @param node The BoxFunctionInvocation node to transform
+	 *
+	 * @return The transformed BoxFunctionInvocation node or alternative representation
 	 */
 	@Override
 	public BoxNode visit( BoxFunctionInvocation node ) {
@@ -861,6 +1079,20 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 
 	}
 
+	/**
+	 * Helper method to transpile structKeyExists() function calls to BoxLang-compatible null checks.
+	 *
+	 * Transforms CFML structKeyExists(struct, key) calls into BoxLang !isNull(struct[key]) expressions.
+	 * This provides equivalent functionality while using BoxLang's null-checking semantics.
+	 *
+	 * Transformation example:
+	 * - structKeyExists(myStruct, "key") becomes !isNull(myStruct["key"])
+	 * - structKeyExists(obj, varname) becomes !isNull(obj[varname])
+	 *
+	 * @param node The BoxFunctionInvocation node representing structKeyExists call
+	 *
+	 * @return A BoxUnaryOperation node representing the !isNull() equivalent
+	 */
 	private BoxNode transpileStructKeyExists( BoxFunctionInvocation node ) {
 		BoxUnaryOperation newNode = new BoxUnaryOperation(
 		    new BoxFunctionInvocation(
@@ -888,8 +1120,24 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename components and attributes
-	 * Rename enablecfoutputonly attribute on cfsetting tag
+	 * Transforms BoxComponent nodes for CFML tag compatibility.
+	 *
+	 * Key transformations applied:
+	 * 1. Component Name Mapping: Renames components using componentMap (e.g., module -> component)
+	 * 2. CF Identifier Updates: Updates CF-prefixed identifiers in component attributes
+	 * - Handles "result" attribute string literals containing CF variable references
+	 * 3. Attribute Transformations: Applies component-specific attribute mappings
+	 *
+	 * Examples:
+	 * - <cfmodule> becomes <component>
+	 * - result="cfthread" becomes result="bxthread" in string literals
+	 *
+	 * Special handling for lifecycle components and their result attributes ensures
+	 * proper variable reference updates throughout the transformation.
+	 *
+	 * @param node The BoxComponent node to transform
+	 *
+	 * @return The transformed BoxComponent node
 	 */
 	@Override
 	public BoxNode visit( BoxComponent node ) {
@@ -994,10 +1242,27 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rewrite !foo eq bar
-	 * as !(foo eq bar)
-	 * These operators should be higher precedence than the not operator
-	 * EQ, NEQ, LT, LTE, GT, GTE, ==, !=, >, >=, &lt;, &lt;=
+	 * Transforms BoxComparisonOperation nodes to fix operator precedence issues with the NOT operator.
+	 *
+	 * In CFML, comparison operators have higher precedence than the NOT operator, which differs
+	 * from some other languages. This method ensures proper precedence by restructuring
+	 * expressions where NOT appears on the left side of a comparison.
+	 *
+	 * Transformations applied:
+	 * - !foo eq bar becomes !(foo eq bar)
+	 * - !obj.prop > 5 becomes !(obj.prop > 5)
+	 *
+	 * This affects all comparison operators: EQ, NEQ, LT, LTE, GT, GTE, ==, !=, >, >=, <, <=
+	 *
+	 * The transformation:
+	 * 1. Detects NOT operator on the left side of comparison
+	 * 2. Removes the NOT from the left operand
+	 * 3. Wraps the entire comparison in parentheses
+	 * 4. Applies the NOT to the parenthesized expression
+	 *
+	 * @param node The BoxComparisonOperation node to transform
+	 *
+	 * @return The transformed node with corrected operator precedence
 	 */
 	public BoxNode visit( BoxComparisonOperation node ) {
 		BoxExpression left = node.getLeft();
@@ -1038,10 +1303,26 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	 * @foo bar
 	 *      as an actual "annotation" for classes and functions and properties.
 	 *      We'll need to merge these in manually as BL keeps them separate.
+	 *      /**
+	 *      Helper method to merge documentation annotations into the formal annotation list.
 	 *
-	 * @param annotations   The annotations for the node
-	 * @param documentation The documentation for the node
+	 *      This method bridges CFML's documentation comments with BoxLang's annotation system
+	 *      by converting documentation annotations into formal annotations that can be
+	 *      processed by the runtime.
 	 *
+	 *      Key behaviors:
+	 *      - Only merges if mergeDocsIntoAnnotations configuration is enabled
+	 *      - Skips "hint" annotations (handled separately)
+	 *      - Avoids overriding existing formal annotations
+	 *      - Trims whitespace from string values and converts empty strings to null
+	 *
+	 *      Examples:
+	 *      - @param name "User name" becomes a formal annotation
+	 *      - @return "Generated user ID" becomes a return annotation
+	 *      - @deprecated "Use newMethod instead" becomes a deprecated annotation
+	 *
+	 * @param annotations   The existing formal annotations list to merge into
+	 * @param documentation The documentation annotations to merge from
 	 */
 	private void mergeDocsIntoAnnotations( List<BoxAnnotation> annotations, List<BoxDocumentationAnnotation> documentation ) {
 		if ( !mergeDocsIntoAnnotations )
@@ -1175,9 +1456,22 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Add output annotation and set to true if it doesn't exist
+	 * Helper method to add or ensure the output annotation is set to true for CFML compatibility.
 	 *
-	 * @param annotations The annotations for the node
+	 * In CFML, components and functions typically have output enabled by default,
+	 * whereas BoxLang may have different defaults. This method ensures consistent
+	 * behavior by adding output=true annotations when they don't exist.
+	 *
+	 * Behavior:
+	 * - Only operates if forceOutputTrue configuration is enabled
+	 * - Checks if an "output" annotation already exists
+	 * - Adds output=true annotation if none exists
+	 * - Preserves existing output annotations (doesn't override)
+	 *
+	 * This maintains CFML's output behavior while allowing explicit override
+	 * when developers specify their own output annotations.
+	 *
+	 * @param annotations The annotations list to potentially modify
 	 */
 	private void enableOutput( List<BoxAnnotation> annotations ) {
 		if ( !forceOutputTrue )
@@ -1196,12 +1490,28 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	}
 
 	/**
-	 * Rename some common CF variables like
-	 * cfcatch
-	 * to
-	 * bxcatch
+	 * Helper method to rename top-level CF variables to BoxLang equivalents.
 	 *
-	 * @param BoxIdentifier The identifier node
+	 * This method handles the systematic renaming of CFML reserved variables
+	 * to their BoxLang counterparts, ensuring compatibility while avoiding
+	 * naming conflicts with BoxLang's own reserved words.
+	 *
+	 * Variable mappings applied:
+	 * - cfcatch -> bxcatch (exception handling variable)
+	 * - cfthread -> bxthread (threading variable)
+	 * - cffile -> bxfile (file operation variable)
+	 * - cfftp -> bxftp (FTP operation variable)
+	 * - cfhttp -> bxhttp (HTTP operation variable)
+	 * - cfquery -> bxquery (query operation variable)
+	 * - thisTag -> thisComponent (component scope reference)
+	 * - etc.
+	 *
+	 * The method uses case-insensitive matching but preserves the original
+	 * casing pattern in the replacement to maintain code readability.
+	 * Special logic prevents renaming when the identifier represents a function
+	 * argument with the same name.
+	 *
+	 * @param id The BoxIdentifier node to potentially rename
 	 */
 	private void renameTopLevelVars( BoxIdentifier id ) {
 		String name = id.getName().toLowerCase();

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTagData.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTagData.java
@@ -73,7 +73,8 @@ public class GetBaseTagData extends BIF {
 		IStruct component = components.get( ancestorLevels - 1 );
 		return Struct.of(
 		    Key.caller, component.get( Key.caller ),
-		    Key.thisTag, component.get( Key.thisTag ),
+		    Key.thisTag, component.get( Key.thisComponent ),
+		    Key.thisComponent, component.get( Key.thisComponent ),
 		    Key.attributes, component.getAsStruct( Key.attributes ).get( Key.attributes )
 		);
 	}

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -785,6 +785,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		text								= Key.of( "text" );
 	public static final Key		textQualifier						= Key.of( "textQualifier" );
 	public static final Key		thisTag								= Key.of( "thisTag" );
+	public static final Key		thisComponent						= Key.of( "thisComponent" );
 	public static final Key		thread								= Key.of( "thread" );
 	public static final Key		threadGroup							= Key.of( "threadGroup" );
 	public static final Key		threadName							= Key.of( "threadName" );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTagDataTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetBaseTagDataTest.java
@@ -88,6 +88,13 @@ public class GetBaseTagDataTest {
 		assertThat( resultStruct.containsKey( Key.caller ) ).isTrue();
 		assertThat( resultStruct.getAsStruct( Key.caller ).containsKey( Key.of( "thisIsCaller" ) ) ).isTrue();
 
+		// New Form
+		assertThat( resultStruct.containsKey( Key.thisComponent ) ).isTrue();
+		assertThat( resultStruct.getAsStruct( Key.thisComponent ).containsKey( Key.generatedContent ) ).isTrue();
+		assertThat( resultStruct.getAsStruct( Key.thisComponent ).containsKey( Key.hasEndTag ) ).isTrue();
+		assertThat( resultStruct.getAsStruct( Key.thisComponent ).containsKey( Key.executionMode ) ).isTrue();
+		assertThat( resultStruct.getAsStruct( Key.thisComponent ).get( Key.executionMode ) ).isEqualTo( "inactive" );
+		// Old Form
 		assertThat( resultStruct.containsKey( Key.thisTag ) ).isTrue();
 		assertThat( resultStruct.getAsStruct( Key.thisTag ).containsKey( Key.generatedContent ) ).isTrue();
 		assertThat( resultStruct.getAsStruct( Key.thisTag ).containsKey( Key.hasEndTag ) ).isTrue();

--- a/src/test/java/ortus/boxlang/runtime/components/system/CustomTagA.cfm
+++ b/src/test/java/ortus/boxlang/runtime/components/system/CustomTagA.cfm
@@ -1,3 +1,3 @@
-<cfif thisTag.executionMode == "start">
+<cfif thisComponent.executionMode == "start">
 	CustomTagA
 </cfif>

--- a/src/test/java/ortus/boxlang/runtime/components/system/CustomTagB.cfm
+++ b/src/test/java/ortus/boxlang/runtime/components/system/CustomTagB.cfm
@@ -1,3 +1,3 @@
-<cfif thisTag.executionMode == "start">
+<cfif thisComponent.executionMode == "start">
 	CustomTagB
 </cfif>

--- a/src/test/java/ortus/boxlang/runtime/components/system/ExitTests/module.bxm
+++ b/src/test/java/ortus/boxlang/runtime/components/system/ExitTests/module.bxm
@@ -1,4 +1,4 @@
-<bx:if thisTag.executionMode == "start">
+<bx:if thisComponent.executionMode == "start">
 	<bx:if request.exitWhen == "start" >
 		<bx:set caller.result &= "beforestart">
 		<bx:exit method="#request.exitMethod#">
@@ -6,7 +6,7 @@
 	<bx:else>
 		<bx:set caller.result &= "start">
 	</bx:if>
-<bx:elseif thisTag.executionMode == "end">
+<bx:elseif thisComponent.executionMode == "end">
 	<bx:if request.exitWhen == "end" && request.loopCount++ LT 1 >
 		<bx:set caller.result &= "beforeend">
 		<bx:exit method="#request.exitMethod#">


### PR DESCRIPTION
Rename thisTag scope to thisComponent scope for consistency and transpile the old scope

This pull request introduces a comprehensive `CFTranspilerVisitor` to transform CFML/ColdFusion syntax into BoxLang-compatible syntax. The changes include detailed transformations for variables, functions, components, and AST nodes, ensuring compatibility and configurability. Key features include mappings for built-in functions (BIFs), variable renaming, operator precedence fixes, and output annotations.

### Core Enhancements to AST Transformation:
* **Visitor Overview and Configuration:**
  - Added a detailed class-level Javadoc describing the purpose, architecture, and configuration of the `CFTranspilerVisitor`, including examples for adding new transformations.
  - Constructor now initializes settings like uppercasing keys, forcing output annotations, and merging documentation into annotations.

* **Variable and Identifier Transformations:**
  - Introduced mappings to rename CF-specific variables (e.g., `cfcatch` → `bxcatch`, `thisTag` → `thisComponent`). [[1]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceR281) [[2]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL1199-R1514)
  - Added transformations for array access patterns and struct literal keys to ensure compatibility with BoxLang conventions. [[1]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL300-R482) [[2]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL343-R550)

### Functionality Improvements:
* **Function and Operator Handling:**
  - Enhanced handling of user-defined functions (UDFs) by merging documentation into annotations, enabling `output=true`, and renaming lifecycle methods (e.g., `onCFCRequest` → `onClassRequest`).
  - Fixed operator precedence issues for NOT operations in comparison expressions.

* **Built-In Function (BIF) Mappings:**
  - Added mappings for CFML BIFs to their BoxLang equivalents (e.g., `chr()` → `char()`) and implemented query parameter transformations for compatibility.

### Component and Annotation Updates:
* **Component Transformations:**
  - Renamed CF components and their attributes (e.g., `<cfmodule>` → `<component>`) and updated CF-specific identifiers in attributes.
* **Annotation Enhancements:**
  - Merged documentation annotations into formal annotations and ensured `output=true` annotations are added where necessary. [[1]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceR1306-R1325) [[2]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL1178-R1474)
