### PR TITLE
BL-1667 #resolve

### DIFF
--- a/src/test/java/ortus/boxlang/runtime/interop/DynamicInteropServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interop/DynamicInteropServiceTest.java
@@ -1156,4 +1156,18 @@ public class DynamicInteropServiceTest {
 		assertThat( variables.get( Key.result ) ).isEqualTo( true );
 	}
 
+	@Test
+	void testParseFormatCoercion() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+				formatter = createObject( "java", "java.text.SimpleDateFormat" ).init(
+					"yyyy-MM-dd'T'HH:mm:ssXXX"
+				);
+				result = formatter.format( parseDateTime( "2025-07-01T00:00:00-06:00" ) );
+				println( result )
+			""", context);
+		// @formatter:on
+	}
+
 }


### PR DESCRIPTION
Interop service when dealing with methods with `Object` arguments, would give preference to coercionable arguments. Ex: Formatter.format( BoxLang DateTime ) would fail

https://ortussolutions.atlassian.net/browse/BL-1667