### PR TITLE
JDBC - Move driver validation warning to occur on datasource initialization

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/DataSource.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/DataSource.java
@@ -79,11 +79,12 @@ public class DataSource implements Comparable<DataSource> {
 		);
 		// Retrieve and store the potentially modified configuration from the event.
 		this.configuration = eventParams.getAs( DatasourceConfig.class, Key.of( "config" ) );
+
+		// Warn if driver is not found in the datasource service
+		this.configuration.validateDriver();
+
 		HikariConfig hikariConfig = null;
 		try {
-			// Warn if driver is not found in the datasource service
-			this.configuration.validateDriver();
-
 			hikariConfig			= this.configuration.toHikariConfig();
 			this.hikariDataSource	= new HikariDataSource( hikariConfig );
 		} catch ( RuntimeException e ) {

--- a/src/main/java/ortus/boxlang/runtime/jdbc/DataSource.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/DataSource.java
@@ -81,6 +81,9 @@ public class DataSource implements Comparable<DataSource> {
 		this.configuration = eventParams.getAs( DatasourceConfig.class, Key.of( "config" ) );
 		HikariConfig hikariConfig = null;
 		try {
+			// Warn if driver is not found in the datasource service
+			this.configuration.validateDriver();
+
 			hikariConfig			= this.configuration.toHikariConfig();
 			this.hikariDataSource	= new HikariDataSource( hikariConfig );
 		} catch ( RuntimeException e ) {


### PR DESCRIPTION
# Description

Move driver validation warning to occur on datasource initialization. This resolves BL-1671, while preserving the warning in case the datasource creation fails.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1671

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
