### PR TITLE
ModuleRecord - Deregister resources on module unload

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -28,6 +28,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -88,32 +90,32 @@ public class ModuleRecord {
 	/**
 	 * Unique internal ID for the module
 	 */
-	public final String			id							= UUID.randomUUID().toString();
+	public final String				id							= UUID.randomUUID().toString();
 
 	/**
 	 * The name of the module, defaults to the folder name on disk
 	 */
-	public Key					name;
+	public Key						name;
 
 	/**
 	 * The version of the module, defaults to 1.0.0
 	 */
-	public String				version						= "1.0.0";
+	public String					version						= "1.0.0";
 
 	/**
 	 * The author of the module or empty if not set
 	 */
-	public String				author						= "";
+	public String					author						= "";
 
 	/**
 	 * The description of the module or empty if not set
 	 */
-	public String				description					= "";
+	public String					description					= "";
 
 	/**
 	 * The web URL of the module or empty if not set
 	 */
-	public String				webURL						= "";
+	public String					webURL						= "";
 
 	/**
 	 * The BoxLang mapping of the module used to construct classes from within it.
@@ -121,74 +123,74 @@ public class ModuleRecord {
 	 * {@link ModuleService#MODULE_MAPPING_INVOCATION_PREFIX}
 	 *
 	 */
-	public String				mapping;
+	public String					mapping;
 
 	/**
 	 * If the module is enabled for activation, defaults to false
 	 */
-	public boolean				enabled						= true;
+	public boolean					enabled						= true;
 
 	/**
 	 * Flag to indicate if the module has been activated or not yet
 	 */
-	public boolean				activated					= false;
+	public boolean					activated					= false;
 
 	/**
 	 * The settings of the module
 	 */
-	public Struct				settings					= new Struct();
+	public Struct					settings					= new Struct();
 
 	/**
 	 * The object mappings of the module
 	 */
-	public Struct				objectMappings				= new Struct();
+	public Struct					objectMappings				= new Struct();
 
 	/**
 	 * The datasources to register by the module
 	 */
-	public Struct				datasources					= new Struct( Struct.TYPES.LINKED );
+	public Struct					datasources					= new Struct( Struct.TYPES.LINKED );
 
 	/**
 	 * Any module activation dependencies
 	 */
-	public Array				dependencies				= new Array();
+	public Array					dependencies				= new Array();
 
 	/**
 	 * The interceptors of the module
 	 */
-	public Array				interceptors				= new Array();
+	public Array					interceptors				= new Array();
 
 	/**
 	 * The BIFS collaborated by the module
 	 */
-	public Array				bifs						= new Array();
+	public Array					bifs						= new Array();
 
 	/**
 	 * The Components collaborated by the module
 	 */
-	public Array				components					= new Array();
+	public Array					components					= new Array();
 
 	/**
 	 * The member Methods collaborated by the module
 	 */
-	public Array				memberMethods				= new Array();
+	public Array					memberMethods				= new Array();
 
 	/**
 	 * The custom interception points of the module
 	 */
-	public Array				customInterceptionPoints	= new Array();
+	public Array					customInterceptionPoints	= new Array();
 
 	/**
 	 * The physical path of the module on disk as a Java {@link Path}
 	 */
-	public Path					physicalPath;
+	public Path						physicalPath;
 
 	/**
 	 * The physical path of the module but in string format. Used by BoxLang code
 	 * mostly
 	 * Same as the {@link ModuleRecord#physicalPath} but in string format
 	 */
-	public String				path;
+	public String					path;
 
 	/**
 	 * The invocation path of the module which is a composition of the
@@ -196,37 +198,37 @@ public class ModuleRecord {
 	 * Example: {@code /bxModules/MyModule} is the mapping for the module
 	 * the invocation path would be {@code bxModules.MyModule}
 	 */
-	public String				invocationPath;
+	public String					invocationPath;
 
 	/**
 	 * The timestamp when the module was registered
 	 */
-	public Instant				registeredOn;
+	public Instant					registeredOn;
 
 	/**
 	 * The time it took in ms to register the module
 	 */
-	public long					registrationTime			= 0;
+	public long						registrationTime			= 0;
 
 	/**
 	 * The timestamp when the module was activated
 	 */
-	public Instant				activatedOn;
+	public Instant					activatedOn;
 
 	/**
 	 * The time it took in ms to activate the module
 	 */
-	public long					activationTime				= 0;
+	public long						activationTime				= 0;
 
 	/**
 	 * The Dynamic class loader for the module
 	 */
-	public DynamicClassLoader	classLoader					= null;
+	public DynamicClassLoader		classLoader					= null;
 
 	/**
 	 * The descriptor for the module
 	 */
-	public IClassRunnable		moduleConfig;
+	public IClassRunnable			moduleConfig;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -237,22 +239,24 @@ public class ModuleRecord {
 	/**
 	 * This prefix is used a virtual package name for the module
 	 */
-	private static final String	MODULE_PACKAGE_NAME			= "ortus.boxlang.runtime.modules.";
+	private static final String		MODULE_PACKAGE_NAME			= "ortus.boxlang.runtime.modules.";
 
 	/**
 	 * The name of the descriptor file for the module based on CommandBox
 	 */
-	private static final String	MODULE_CONFIG_FILE			= "box.json";
+	private static final String		MODULE_CONFIG_FILE			= "box.json";
 
 	/**
 	 * Logger
 	 */
-	private BoxLangLogger		logger;
+	private BoxLangLogger			logger;
 
 	/**
 	 * Runtime
 	 */
-	private BoxRuntime			runtime;
+	private BoxRuntime				runtime;
+
+	private Map<Key, DriverShim>	jdbcDrivers					= new HashMap<>();
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -492,8 +496,10 @@ public class ModuleRecord {
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( driver -> {
+			    DriverShim driverShim = new DriverShim( driver );
+			    this.jdbcDrivers.put( Key.of( driver.getClass().getName() ), driverShim );
 			    try {
-				    DriverManager.registerDriver( new DriverShim( driver ) );
+				    DriverManager.registerDriver( driverShim );
 			    } catch ( SQLException e ) {
 				    throw new DatabaseException( e );
 			    }
@@ -556,8 +562,7 @@ public class ModuleRecord {
 	 */
 	public ModuleRecord unload( IBoxContext context ) {
 		// Convenience References
-		ThisScope			thisScope			= this.moduleConfig.getThisScope();
-		InterceptorService	interceptorService	= this.runtime.getInterceptorService();
+		ThisScope thisScope = this.moduleConfig.getThisScope();
 
 		// Call the onLoad() method if it exists in the descriptor
 		if ( thisScope.containsKey( Key.onUnload ) ) {
@@ -572,6 +577,80 @@ public class ModuleRecord {
 			}
 		}
 
+		this.unregister( context );
+
+		// Destroy the ClassLoader
+		try {
+			this.classLoader.close();
+		} catch ( IOException e ) {
+			this.logger.error( "Error while closing the DynamicClassLoader for module [{}]", this.name, e );
+		} finally {
+			this.classLoader = null;
+		}
+
+		return this;
+	}
+
+	public ModuleRecord unregister( IBoxContext context ) {
+		InterceptorService interceptorService = this.runtime.getInterceptorService();
+
+		// Unregister any global services
+		ServiceLoader.load( IService.class, this.classLoader )
+		    .stream()
+		    .map( ServiceLoader.Provider::get )
+		    .forEach( service -> this.runtime.removeGlobalService( service.getName() ) );
+
+		// Unload JDBC drivers from the JVM
+		ServiceLoader.load( Driver.class, this.classLoader )
+		    .stream()
+		    .map( ServiceLoader.Provider::get )
+		    .forEach( driver -> {
+			    Key driverKey = Key.of( driver.getClass().getName() );
+			    try {
+				    DriverManager.deregisterDriver( this.jdbcDrivers.get( driverKey ) );
+			    } catch ( SQLException e ) {
+				    throw new DatabaseException( e );
+			    }
+			    this.jdbcDrivers.remove( driverKey );
+		    } );
+
+		// Unregister JDBC drivers from the datasource service
+		ServiceLoader.load( IJDBCDriver.class, this.classLoader )
+		    .stream()
+		    .map( ServiceLoader.Provider::get )
+		    .forEach( driver -> this.runtime.getDataSourceService().removeDriver( driver.getName() ) );
+
+		// @TODO: Unregister BIFs; we're lacking an unregister method in the FunctionService
+		// as a counterpart to `functionService.processBIFRegistration`.
+
+		// @TODO: Unregister components; we're lacking an unregisterComponent method in the ComponentService
+
+		// unregister schedulers
+		ServiceLoader.load( IScheduler.class, this.classLoader )
+		    .stream()
+		    .map( ServiceLoader.Provider::get )
+		    .forEach( scheduler -> this.runtime.getSchedulerService()
+		        .removeScheduler( Key.of( scheduler.getSchedulerName() + "@" + this.name ), true, 500 ) );
+
+		// Unregister cache providers
+		ServiceLoader.load( ICacheProvider.class, this.classLoader )
+		    .stream()
+		    .map( ServiceLoader.Provider::type )
+		    .forEach( provider -> this.runtime.getCacheService().removeProvider( Key.of( provider.getSimpleName() ) ) );
+
+		// Unregister java interceptors
+		ServiceLoader.load( IInterceptor.class, this.classLoader )
+		    .stream()
+		    // Only load interceptors that are set to auto-load by default or by
+		    // configuration
+		    .filter( provider -> interceptorService.canLoadInterceptor( provider.type() ) )
+		    // Register the interceptor with the module settings
+		    .map( ServiceLoader.Provider::get )
+		    .forEach( targetInterceptor -> interceptorService.register( targetInterceptor, this.settings ) );
+
+		// unregister the module mapping from the runtime
+		this.runtime.getConfiguration().unregisterMapping( this.mapping );
+
 		// Unregister all interceptors from all states
 		if ( !this.interceptors.isEmpty() ) {
 			for ( Object interceptor : this.interceptors ) {
@@ -585,15 +664,6 @@ public class ModuleRecord {
 
 		// Unregister the ModuleConfig
 		interceptorService.unregister( DynamicObject.of( this.moduleConfig ) );
-
-		// Destroy the ClassLoader
-		try {
-			this.classLoader.close();
-		} catch ( IOException e ) {
-			this.logger.error( "Error while closing the DynamicClassLoader for module [{}]", this.name, e );
-		} finally {
-			this.classLoader = null;
-		}
 
 		return this;
 	}


### PR DESCRIPTION
# Description

Currently, any usage of boxModuleReload() within a running app results in duplicate resources being loaded in the box runtime. This is because module unload/uninstall fails to remove any registered resources, such as schedulers, JDBC drivers, JDBC datasources, registered BIFs and Components, etc.

Any module unload must deregister all associated resources.

Resolves BL-1705.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1705

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [X] Improvement

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
