### PR TITLE
Add failing test for `listDeleteAt` losing preceding slashes

### DIFF
--- a/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListDeleteAtTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListDeleteAtTest.java
@@ -133,4 +133,19 @@ public class ListDeleteAtTest {
 		assertEquals( "coldbox.system", variables.getAsString( result ) );
 
 	}
+
+	@DisplayName( "It does not lose preceding slashes when dealing with paths" )
+	@Test
+	public void itDoesNotLosePrecedingSlashes() {
+		instance.executeSource(
+		    """
+		    path = "/Users/elpete/Developer/github/coldbox-modules/quick/";
+		    position = listLen( path, "\\/" );
+			result = listDeleteAt( path, position, "\\/" );
+		    """,
+		    context );
+		assertEquals( 6, variables.getAsInteger( Key.position ) );
+		assertEquals( "/Users/elpete/Developer/github/coldbox-modules", variables.getAsString( result ) );
+
+	}
 }


### PR DESCRIPTION
# Description

This adds a failing test for the `listDeleteAt` function deleting preceding slashes.


## Jira Issues


## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
