### PR TITLE
BL-1769 & BL-1771

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/types/Array.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Array.java
@@ -773,7 +773,7 @@ public class Array implements List<Object>, IType, IReferenceable, IListenable<A
 	}
 
 	/**
-	 * Returns a new array removing all of the duplicates caseSenstively
+	 * Returns a new array removing all of the duplicates caseSensitively
 	 *
 	 * @return The new array
 	 */
@@ -782,9 +782,9 @@ public class Array implements List<Object>, IType, IReferenceable, IListenable<A
 	}
 
 	/**
-	 * Returns a new array removing all of the duplicates - either caseSenstively or not
+	 * Returns a new array removing all of the duplicates - either caseSensitively or not
 	 *
-	 * @param caseSensitive whether to perform the deduplication caseSenstively
+	 * @param caseSensitive whether to perform the deduplication caseSensitively
 	 *
 	 * @return The new array
 	 */

--- a/src/main/java/ortus/boxlang/runtime/types/DelimitedArray.java
+++ b/src/main/java/ortus/boxlang/runtime/types/DelimitedArray.java
@@ -479,9 +479,9 @@ public class DelimitedArray extends Array {
 	 */
 
 	/**
-	 * Returns a new array removing all of the duplicates - either caseSenstively or not
+	 * Returns a new array removing all of the duplicates - either caseSensitively or not
 	 *
-	 * @param caseSensitive whether to perform the deduplication caseSenstively
+	 * @param caseSensitive whether to perform the deduplication caseSensitively
 	 *
 	 * @return The new array
 	 */

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -473,6 +473,8 @@ public class XML implements Serializable, IStruct {
 			node = newDocumentBuilder().newDocument();
 			if ( name.equals( Key.XMLRoot ) ) {
 				return this;
+			} else if ( name.equals( Key.XMLAttributes ) ) {
+				return getXMLAttributes();
 			} else if ( name.equals( Key.XMLComment ) ) {
 				return getNodeComments();
 			} else if ( name.equals( Key.XMLDocType ) ) {
@@ -488,6 +490,8 @@ public class XML implements Serializable, IStruct {
 		if ( node instanceof Document document ) {
 			if ( name.equals( Key.XMLRoot ) ) {
 				return new XML( document.getDocumentElement() );
+			} else if ( name.equals( Key.XMLAttributes ) ) {
+				return new XML( document.getDocumentElement() ).getXMLAttributes();
 			} else if ( name.equals( Key.XMLComment ) ) {
 				return getNodeComments();
 			} else if ( name.equals( Key.XMLDocType ) ) {

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -156,7 +156,7 @@ public class XML implements Serializable, IStruct {
 	}
 
 	/**
-	 * Creates a new document builder for either parsing or docuemnt creation
+	 * Creates a new document builder for either parsing or document creation
 	 */
 	private static DocumentBuilder newDocumentBuilder() {
 		DocumentBuilderFactory	factory	= DocumentBuilderFactory.newNSInstance();

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -129,21 +129,8 @@ public class XML implements Serializable, IStruct {
 	public XML( String xmlData ) {
 
 		this.type = TYPES.DEFAULT;
-
-		DocumentBuilderFactory	factory	= DocumentBuilderFactory.newNSInstance();
-
-		DocumentBuilder			builder;
-		try {
-			// Disable DTD validation
-			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false );
-			factory.setFeature( "http://xml.org/sax/features/validation", false );
-			factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", false );
-
-			builder = factory.newDocumentBuilder();
-		} catch ( ParserConfigurationException e ) {
-			throw new BoxRuntimeException( "Error creating XML document builder", e );
-		}
-		InputSource inputSource = new InputSource( new StringReader( xmlData ) );
+		DocumentBuilder	builder		= newDocumentBuilder();
+		InputSource		inputSource	= new InputSource( new StringReader( xmlData ) );
 		try {
 			node = builder.parse( inputSource );
 		} catch ( SAXException e ) {
@@ -166,6 +153,26 @@ public class XML implements Serializable, IStruct {
 	 */
 	public XML( Boolean caseSenstive ) {
 		this.type = caseSenstive ? TYPES.CASE_SENSITIVE : TYPES.DEFAULT;
+	}
+
+	/**
+	 * Creates a new document builder for either parsing or docuemnt creation
+	 */
+	private static DocumentBuilder newDocumentBuilder() {
+		DocumentBuilderFactory	factory	= DocumentBuilderFactory.newNSInstance();
+
+		DocumentBuilder			builder;
+		try {
+			// Disable DTD validation
+			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false );
+			factory.setFeature( "http://xml.org/sax/features/validation", false );
+			factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", false );
+
+			builder = factory.newDocumentBuilder();
+		} catch ( ParserConfigurationException e ) {
+			throw new BoxRuntimeException( "Error creating XML document builder", e );
+		}
+		return builder;
 	}
 
 	/**
@@ -461,9 +468,24 @@ public class XML implements Serializable, IStruct {
 			return getXMLValue();
 		}
 
+		// If we were initialized with an empty XML object and an attempt is made to access a property, then we need to create the document now.
+		if ( node == null ) {
+			node = newDocumentBuilder().newDocument();
+			if ( name.equals( Key.XMLRoot ) ) {
+				return this;
+			} else if ( name.equals( Key.XMLComment ) ) {
+				return getNodeComments();
+			} else if ( name.equals( Key.XMLDocType ) ) {
+				return new XML( ( ( Document ) node ).getDoctype() );
+			} else if ( name.equals( Key.XMLChildren ) ) {
+				return getXMLChildren();
+			} else if ( name.equals( Key.XMLNodes ) ) {
+				return getXMLNodes();
+			}
+		}
+
 		// Document nodes support the following:
-		if ( node.getNodeType() == Node.DOCUMENT_NODE ) {
-			Document document = ( Document ) node;
+		if ( node instanceof Document document ) {
 			if ( name.equals( Key.XMLRoot ) ) {
 				return new XML( document.getDocumentElement() );
 			} else if ( name.equals( Key.XMLComment ) ) {

--- a/src/main/java/ortus/boxlang/runtime/types/listeners/XMLChildrenListener.java
+++ b/src/main/java/ortus/boxlang/runtime/types/listeners/XMLChildrenListener.java
@@ -17,6 +17,7 @@
  */
 package ortus.boxlang.runtime.types.listeners;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -53,10 +54,15 @@ public class XMLChildrenListener implements IChangeListener<Array> {
 		if ( oldValue == null && newValue == null ) {
 			parentNode.removeChild( childNodeList.item( index ) );
 		} else if ( newValue != null && oldValue == null ) {
+			Node importNode = newValue instanceof Node ? ( Node ) newValue : ( ( XML ) newValue ).getNode();
+			// If two documents are being merged, we need to import before appending
+			if ( parentNode instanceof Document docParent && importNode instanceof Document docImport ) {
+				importNode = docParent.importNode( docImport.getDocumentElement(), true );
+			}
 			if ( childNodeList.item( index ) == null ) {
-				parentNode.appendChild( newValue instanceof Node ? ( Node ) newValue : ( ( XML ) newValue ).getNode() );
+				parentNode.appendChild( importNode );
 			} else {
-				parentNode.insertBefore( newValue instanceof Node ? ( Node ) newValue : ( ( XML ) newValue ).getNode(), childNodeList.item( index ) );
+				parentNode.insertBefore( importNode, childNodeList.item( index ) );
 			}
 		} else if ( newValue == null && oldValue != null ) {
 			parentNode.removeChild( oldValue instanceof Node ? ( Node ) oldValue : ( ( XML ) oldValue ).getNode() );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListRemoveDuplicatesTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListRemoveDuplicatesTest.java
@@ -105,7 +105,7 @@ public class ListRemoveDuplicatesTest {
 
 	@DisplayName( "Can deduplicate case sensitively" )
 	@Test
-	public void testCaseSenstive() {
+	public void testCaseSensitive() {
 		instance.executeSource(
 		    """
 		        nums = "Brad,BRAD,Luis,Luis,LUIS";

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructNewTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructNewTest.java
@@ -194,7 +194,7 @@ public class StructNewTest {
 
 	@DisplayName( "case sensitive access" )
 	@Test
-	public void testCaseSenstiveAccess() {
+	public void testCaseSensitiveAccess() {
 		variables.put( Key.of( "struct" ), new Struct( Struct.TYPES.CASE_SENSITIVE ) );
 		instance.executeSource(
 		    """

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLNewTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLNewTest.java
@@ -76,12 +76,15 @@ public class XMLNewTest {
 		    """
 			rootNode = xmlNew();
 			newNode = xmlElemNew( rootNode, "foo" );
+			newNode.XmlAttributes[ "nil" ] = "true";
 			arrayAppend( rootNode.xmlChildren, newNode );
 			result = structKeyExists( rootNode, "foo" );
+			result2 = structKeyExists( rootNode.foo.XmlAttributes, "nil" ) and ( rootNode.foo.XmlAttributes.nil == "true" );
 		    """, context );
 		// @formatter:on
 
 		assertTrue( variables.getAsBoolean( result ) );
+		assertTrue( variables.getAsBoolean( Key.of( "result2" ) ) );
 
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLNewTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLNewTest.java
@@ -68,4 +68,21 @@ public class XMLNewTest {
 		assertEquals( xmlObject.size(), 0 );
 	}
 
+	@DisplayName( "It tests the BIF XMLNew creates a usable element" )
+	@Test
+	public void testUsability() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+			rootNode = xmlNew();
+			newNode = xmlElemNew( rootNode, "foo" );
+			arrayAppend( rootNode.xmlChildren, newNode );
+			result = structKeyExists( rootNode, "foo" );
+		    """, context );
+		// @formatter:on
+
+		assertTrue( variables.getAsBoolean( result ) );
+
+	}
+
 }

--- a/workbench/samples/types/struct.md
+++ b/workbench/samples/types/struct.md
@@ -8,7 +8,7 @@ myStruct = structNew();
 myStruct = structNew( "ordered" );
 
 // Create a case-sensitive struct which will require key access to use the exact casing
-myStruct = structNew( "casesenstive" );
+myStruct = structNew( "casesensitive" );
 myStruct[ "cat" ] = "pet";
 myStruct[ "Cat" ] = "wild";
 


### PR DESCRIPTION
# Description

Allows direct usability to objects created by XMLNew and XMLElemNew if a root has not yet been assigned.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-1769
https://ortussolutions.atlassian.net/browse/BL-1771


## Type of change

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
