### PR TITLE
BL-1785

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/async/BoxFuture.java
+++ b/src/main/java/ortus/boxlang/runtime/async/BoxFuture.java
@@ -46,6 +46,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ExceptionUtil;
 import ortus.boxlang.runtime.types.util.BLCollector;
 import ortus.boxlang.runtime.types.util.DateTimeHelper;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * This is the BoxLang version of a CompletableFuture to allow for more
@@ -860,8 +861,8 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 								// Apply the mapper function to the itemStruct
 								Object mappedResult = (IStruct) new ortus.boxlang.runtime.interop.proxies.Function<>( mapper, context, null ).apply( itemStruct );
 								if( !( mappedResult instanceof IStruct ) ) {
-									allLogger.error("Mapper function did not return an instance of IStruct. Returned: " + mappedResult.getClass().getName());
-									throw new BoxRuntimeException( "Mapper function must return a struct, but it returned a: " + mappedResult.getClass().getName() );
+									allLogger.error("Mapper function did not return an instance of IStruct. Returned: " + TypeUtil.getObjectName( mappedResult ));
+									throw new BoxRuntimeException( "Mapper function must return a struct, but it returned a: " + TypeUtil.getObjectName( mappedResult ) );
 								}
 								// Return the key with the processed value
 								return new AbstractMap.SimpleEntry<>(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/string/UCFirst.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/string/UCFirst.java
@@ -52,10 +52,23 @@ public class UCFirst extends BIF {
 	 * @argument.doLowerIfAllUppercase Boolean flag indicating whether to lowercase uppercase characters.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	input					= arguments.getAsString( Key.string );
-		boolean	doAll					= arguments.getAsBoolean( Key.doAll );
-		boolean	doLowerIfAllUppercase	= arguments.getAsBoolean( Key.doLowerIfAllUppercase );
+		return ucFirst(
+		    arguments.getAsString( Key.string ),
+		    arguments.getAsBoolean( Key.doAll ),
+		    arguments.getAsBoolean( Key.doLowerIfAllUppercase )
+		);
+	}
 
+	/**
+	 * Transform the first letter of a string to uppercase or the first letter of each word, and optionally lowercase uppercase characters.
+	 *
+	 * @param input                 The string to transform
+	 * @param doAll                 Boolean flag indicating whether to transform the first letter of each word
+	 * @param doLowerIfAllUppercase Boolean flag indicating whether to lowercase uppercase characters
+	 * 
+	 * @return The transformed string
+	 */
+	public static String ucFirst( String input, boolean doAll, boolean doLowerIfAllUppercase ) {
 		if ( input.isEmpty() ) {
 			return "";
 		}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/BoxRegisterInterceptor.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/BoxRegisterInterceptor.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 @BoxBIF( description = "Register an application-level interceptor" )
 public class BoxRegisterInterceptor extends BIF {
@@ -93,7 +94,7 @@ public class BoxRegisterInterceptor extends BIF {
 			default -> {
 				throw new BoxRuntimeException(
 				    "Invalid interceptor type. Expected a class, dynamic object, or closure/lambda, but got: "
-				        + interceptor.getClass().getName()
+				        + TypeUtil.getObjectName( interceptor )
 				);
 			}
 		}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/CreateObject.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/CreateObject.java
@@ -32,6 +32,7 @@ import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 @BoxBIF( description = "Create an instance of a Java class or component" )
 public class CreateObject extends BIF {
@@ -191,7 +192,7 @@ public class CreateObject extends BIF {
 			} else if ( properties instanceof Array ) {
 				classPaths = ( Array ) properties;
 			} else {
-				throw new BoxRuntimeException( "Invalid properties type: " + properties.getClass().getName() );
+				throw new BoxRuntimeException( "Invalid properties type: " + TypeUtil.getObjectName( properties ) );
 			}
 
 			return CLASS_LOCATOR.loadFromClassPaths(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/type/Len.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/type/Len.java
@@ -30,6 +30,7 @@ import ortus.boxlang.runtime.types.BoxLangType;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 @BoxBIF( description = "Get the length of a string, array, or struct" ) // Len()
 @BoxBIF( alias = "StructCount" )
@@ -120,7 +121,7 @@ public class Len extends BIF {
 			return structAttempt.get().size();
 		}
 
-		throw new BoxRuntimeException( "Cannot determine length of object of type " + object.getClass().getName() );
+		throw new BoxRuntimeException( "Cannot determine length of object of type " + TypeUtil.getObjectName( object ) );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
@@ -57,6 +57,7 @@ import ortus.boxlang.runtime.types.UDF;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.exceptions.ScopeNotFoundException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.Attachable;
 import ortus.boxlang.runtime.util.DataNavigator;
 import ortus.boxlang.runtime.util.DataNavigator.Navigator;
@@ -702,7 +703,7 @@ public class BaseBoxContext implements IBoxContext {
 			return funcAttempt.get();
 		} else {
 			throw new BoxRuntimeException(
-			    "Variable '" + name + "' of type  '" + result.value().getClass().getName() + "'  is not a function." );
+			    "Variable '" + name + "' of type  '" + TypeUtil.getObjectName( result.value() ) + "'  is not a function." );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
@@ -42,6 +42,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.exceptions.ScopeNotFoundException;
 import ortus.boxlang.runtime.types.meta.BoxMeta;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ArgumentUtil;
 
 /**
@@ -726,7 +727,7 @@ public class FunctionBoxContext extends BaseBoxContext {
 				    "Variable '" + name + "' is null and cannot be used as a function." );
 			} else {
 				throw new BoxRuntimeException(
-				    "Variable '" + name + "' of type  '" + value.getClass().getName() + "'  is not a function." );
+				    "Variable '" + name + "' of type  '" + TypeUtil.getObjectName( value ) + "'  is not a function." );
 			}
 		}
 

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/ArrayCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/ArrayCaster.java
@@ -25,6 +25,7 @@ import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.QueryColumn;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Array
@@ -114,7 +115,7 @@ public class ArrayCaster implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Can't cast [%s] to a Array.", object.getClass().getName() )
+			    String.format( "Can't cast [%s] to a Array.", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/BinaryCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/BinaryCaster.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Binary
@@ -71,7 +72,7 @@ public class BinaryCaster implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a Binary." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a Binary." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/BooleanCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/BooleanCaster.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a boolean
@@ -176,7 +177,7 @@ public class BooleanCaster implements IBoxCaster {
 				default -> {
 					if ( fail ) {
 						throw new BoxCastException(
-						    String.format( "Value [%s] cannot be cast to a boolean", object.getClass().getName() ) );
+						    String.format( "Value [%s] cannot be cast to a boolean", TypeUtil.getObjectName( object ) ) );
 					} else {
 						yield null;
 					}
@@ -186,7 +187,7 @@ public class BooleanCaster implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Value [%s] cannot be cast to a boolean", object.getClass().getName() )
+			    String.format( "Value [%s] cannot be cast to a boolean", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/ByteCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/ByteCaster.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything
@@ -79,7 +80,7 @@ public class ByteCaster implements IBoxCaster {
 		if ( number.wasSuccessful() ) {
 			return number.get().byteValue();
 		} else if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a byte." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a byte." );
 		} else {
 			return null;
 		}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/CharacterCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/CharacterCaster.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything
@@ -91,7 +92,7 @@ public class CharacterCaster implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Can't cast [%s] to a char.", object.getClass().getName() )
+			    String.format( "Can't cast [%s] to a char.", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/ClosureCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/ClosureCaster.java
@@ -20,6 +20,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.Closure;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Closure
@@ -74,7 +75,7 @@ public class ClosureCaster implements IBoxCaster {
 		} else {
 			if ( fail ) {
 				throw new BoxCastException(
-				    String.format( "Value [%s] cannot be cast to a Closure", object.getClass().getName() )
+				    String.format( "Value [%s] cannot be cast to a Closure", TypeUtil.getObjectName( object ) )
 				);
 			} else {
 				return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/CollectionCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/CollectionCaster.java
@@ -28,6 +28,7 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 import ortus.boxlang.runtime.types.util.ListUtil;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a collection
@@ -118,7 +119,7 @@ public class CollectionCaster implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Can't cast [%s] to a Collection.", object.getClass().getName() )
+			    String.format( "Can't cast [%s] to a Collection.", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/EmailCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/EmailCaster.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ValidationUtil;
 
 /**
@@ -76,7 +77,7 @@ public class EmailCaster implements IBoxCaster {
 				sObject = castAttempt.get();
 			} else {
 				if ( fail ) {
-					throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a Email." );
+					throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a Email." );
 				} else {
 					return null;
 				}
@@ -89,7 +90,7 @@ public class EmailCaster implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a Email." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a Email." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/FloatCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/FloatCaster.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything
@@ -79,7 +80,7 @@ public class FloatCaster implements IBoxCaster {
 		if ( number.wasSuccessful() ) {
 			return number.get().floatValue();
 		} else if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a float." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a float." );
 		} else {
 			return null;
 		}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/FunctionCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/FunctionCaster.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.JavaMethod;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Function
@@ -137,7 +138,7 @@ public class FunctionCaster implements IBoxCaster {
 		}
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Value [%s] cannot be cast to a Function", object.getClass().getName() )
+			    String.format( "Value [%s] cannot be cast to a Function", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/GenericCaster.java
@@ -35,6 +35,7 @@ import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.NullValue;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything
@@ -66,7 +67,7 @@ public class GenericCaster implements IBoxCaster {
 		if ( type.equalsIgnoreCase( "null" ) || type.equalsIgnoreCase( "void" ) ) {
 			if ( strict && object != null ) {
 				throw new BoxCastException(
-				    String.format( "Cannot cast type [%s] to %s.", object.getClass().getName(), type )
+				    String.format( "Cannot cast type [%s] to %s.", TypeUtil.getObjectName( object ), type )
 				);
 			}
 			return CastAttempt.ofNullable( new NullValue() );
@@ -178,7 +179,7 @@ public class GenericCaster implements IBoxCaster {
 				if ( fail ) {
 					throw new BoxCastException(
 					    String.format( "You asked for type %s, but input %s cannot be cast to an array.", type,
-					        object.getClass().getName() )
+					        TypeUtil.getObjectName( object ) )
 					);
 				} else {
 					return null;
@@ -383,11 +384,7 @@ public class GenericCaster implements IBoxCaster {
 	}
 
 	private static void throwCastException( String type, Object object ) {
-		String objectName = "null";
-		if ( object != null ) {
-			objectName = object.getClass().getName();
-		}
-		throw new BoxCastException( String.format( "Cannot cast %s, to a %s.", objectName, type ) );
+		throw new BoxCastException( String.format( "Cannot cast %s, to a %s.", TypeUtil.getObjectName( object ), type ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/QueryCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/QueryCaster.java
@@ -20,6 +20,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to Query
@@ -74,7 +75,7 @@ public class QueryCaster implements IBoxCaster {
 		}
 
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to Query." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to Query." );
 		} else {
 			return null;
 		}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCaster.java
@@ -39,6 +39,7 @@ import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 
 /**
@@ -266,7 +267,7 @@ public class StringCaster implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a string." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a string." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCasterStrict.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StringCasterStrict.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a string
@@ -160,7 +161,7 @@ public class StringCasterStrict implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a string." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a string." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StructCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StructCaster.java
@@ -25,6 +25,7 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.StructMapWrapper;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 import ortus.boxlang.runtime.types.exceptions.ExceptionUtil;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Struct
@@ -92,7 +93,7 @@ public class StructCaster implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Can't cast [%s] to a Struct.", object.getClass().getName() )
+			    String.format( "Can't cast [%s] to a Struct.", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/StructCasterLoose.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/StructCasterLoose.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Struct, except I'll also cast any Java classes which are not a built in datatype into a struct, using the public
@@ -155,7 +156,7 @@ public class StructCasterLoose implements IBoxCaster {
 
 		if ( fail ) {
 			throw new BoxCastException(
-			    String.format( "Can't cast [%s] to a Struct.", object.getClass().getName() )
+			    String.format( "Can't cast [%s] to a Struct.", TypeUtil.getObjectName( object ) )
 			);
 		} else {
 			return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/ThrowableCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/ThrowableCaster.java
@@ -23,6 +23,7 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.CustomException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a Throwable
@@ -125,7 +126,7 @@ public class ThrowableCaster implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a Throwable." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a Throwable." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/UUIDCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/UUIDCaster.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ValidationUtil;
 
 /**
@@ -76,7 +77,7 @@ public class UUIDCaster implements IBoxCaster {
 				sObject = castAttempt.get();
 			} else {
 				if ( fail ) {
-					throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a UUID." );
+					throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a UUID." );
 				} else {
 					return null;
 				}
@@ -89,7 +90,7 @@ public class UUIDCaster implements IBoxCaster {
 
 		// Do we throw?
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a UUID." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a UUID." );
 		}
 
 		return null;

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/VariableNameCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/VariableNameCaster.java
@@ -19,6 +19,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to a VariableName
@@ -75,7 +76,7 @@ public class VariableNameCaster implements IBoxCaster {
 				sObject = castAttempt.get();
 			} else {
 				if ( fail ) {
-					throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to a VariableName." );
+					throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to a VariableName." );
 				} else {
 					return null;
 				}
@@ -88,7 +89,7 @@ public class VariableNameCaster implements IBoxCaster {
 				if ( ! ( Character.isAlphabetic( nextChar ) || nextChar == '_' || nextChar == '$' ) ) {
 					if ( fail ) {
 						throw new BoxCastException(
-						    "Can't cast " + object.getClass().getName() + " to a VariableName.  Invalid start character for VariableName: " + nextChar );
+						    "Can't cast " + TypeUtil.getObjectName( object ) + " to a VariableName.  Invalid start character for VariableName: " + nextChar );
 					} else {
 						return null;
 					}
@@ -97,7 +98,7 @@ public class VariableNameCaster implements IBoxCaster {
 				if ( ! ( Character.isAlphabetic( nextChar ) || Character.isDigit( nextChar ) || nextChar == '_' || nextChar == '$' ) ) {
 					if ( fail ) {
 						throw new BoxCastException(
-						    "Can't cast " + object.getClass().getName() + " to a VariableName.  Invalid character in VariableName: " + nextChar );
+						    "Can't cast " + TypeUtil.getObjectName( object ) + " to a VariableName.  Invalid character in VariableName: " + nextChar );
 					} else {
 						return null;
 					}

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/XMLCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/XMLCaster.java
@@ -23,6 +23,7 @@ import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * I handle casting anything to XML
@@ -99,7 +100,7 @@ public class XMLCaster implements IBoxCaster {
 		}
 
 		if ( fail ) {
-			throw new BoxCastException( "Can't cast " + object.getClass().getName() + " to XML." );
+			throw new BoxCastException( "Can't cast " + TypeUtil.getObjectName( object ) + " to XML." );
 		} else {
 			return null;
 		}

--- a/src/main/java/ortus/boxlang/runtime/interop/proxies/GenericProxy.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/proxies/GenericProxy.java
@@ -28,6 +28,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ExceptionUtil;
 import ortus.boxlang.runtime.types.util.BooleanRef;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * A generic proxy allows you to wrap any object and call any method on it from Java/BoxLang
@@ -110,7 +111,7 @@ public class GenericProxy extends BaseProxy implements InvocationHandler {
 		    new AtomicInteger( 0 )
 		);
 		if ( !success ) {
-			throw new BoxRuntimeException( "Proxied method [ " + methodName + "() ] returned a value of type [ " + returnValue.getClass().getName()
+			throw new BoxRuntimeException( "Proxied method [ " + methodName + "() ] returned a value of type [ " + TypeUtil.getObjectName( returnValue )
 			    + " ] which could not be coerced to [ " + returnType.getName() + " ] in order to match the interface method signature." );
 		}
 		return args[ 0 ];

--- a/src/main/java/ortus/boxlang/runtime/jdbc/ConnectionManager.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ConnectionManager.java
@@ -34,6 +34,7 @@ import ortus.boxlang.runtime.services.DatasourceService;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * Manages the active JDBC Connection for the current request/thread/BoxLang context.
@@ -379,7 +380,7 @@ public class ConnectionManager {
 				return getDatasourceOrThrow( Key.of( datasourceName ) );
 			}
 			// INVALID DATASOURCE
-			throw new BoxRuntimeException( "Invalid datasource type: " + datasourceObject.getClass().getName() );
+			throw new BoxRuntimeException( "Invalid datasource type: " + TypeUtil.getObjectName( datasourceObject ) );
 		}
 		return getDefaultDatasourceOrThrow();
 	}

--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -50,6 +50,7 @@ import ortus.boxlang.runtime.types.QueryColumnType;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
 import ortus.boxlang.runtime.types.util.ListUtil;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * This class represents a query and any parameters/bindings before being
@@ -320,8 +321,7 @@ public class PendingQuery {
 		}
 
 		// We always have bindings, since we exit early if there are none
-		String className = bindings.getClass().getName();
-		throw new DatabaseException( "Invalid type for query params. Expected array or struct. Received: " + className );
+		throw new DatabaseException( "Invalid type for query params. Expected array or struct. Received: " + TypeUtil.getObjectName( bindings ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/operators/Compare.java
+++ b/src/main/java/ortus/boxlang/runtime/operators/Compare.java
@@ -33,6 +33,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * Performs EQ, GT, and LT comparisons
@@ -231,7 +232,7 @@ public class Compare implements IOperator {
 
 		if ( fail ) {
 			throw new BoxRuntimeException(
-			    String.format( "Can't compare [%s] against [%s]", left.getClass().getName(), right.getClass().getName() )
+			    String.format( "Can't compare [%s] against [%s]", TypeUtil.getObjectName( left ), TypeUtil.getObjectName( right ) )
 			);
 		}
 

--- a/src/main/java/ortus/boxlang/runtime/runnables/BoxClassSupport.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/BoxClassSupport.java
@@ -50,6 +50,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.meta.BoxMeta;
 import ortus.boxlang.runtime.types.meta.ClassMeta;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ArgumentUtil;
 import ortus.boxlang.runtime.util.BoxFQN;
 
@@ -399,7 +400,7 @@ public class BoxClassSupport {
 		// Not a function, throw an exception
 		if ( value != null ) {
 			throw new BoxRuntimeException(
-			    "key '" + name.getName() + "' of type  '" + value.getClass().getName() + "'  is not a function " );
+			    "key '" + name.getName() + "' of type  '" + TypeUtil.getObjectName( value ) + "'  is not a function " );
 		}
 
 		// Do we have a member function for classes?
@@ -486,7 +487,7 @@ public class BoxClassSupport {
 		// Not a function, throw an exception
 		if ( value != null ) {
 			throw new BoxRuntimeException(
-			    "key '" + name.getName() + "' of type  '" + value.getClass().getName() + "'  is not a function " );
+			    "key '" + name.getName() + "' of type  '" + TypeUtil.getObjectName( value ) + "'  is not a function " );
 		}
 
 		// Do we have a member function for classes?
@@ -817,7 +818,7 @@ public class BoxClassSupport {
 			return BoxRuntime.getInstance().getClassLocator().load( context, str, imports );
 		}
 		throw new BoxRuntimeException( "Cannot load class for static access.  Did you try to statically dereference an instance on accident?  Type provided: "
-		    + obj.getClass().getName() );
+		    + TypeUtil.getObjectName( obj ) );
 
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/scopes/ClassVariablesScope.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/ClassVariablesScope.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.types.BoxLangType;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ArgumentUtil;
 
 /**
@@ -93,7 +94,7 @@ public class ClassVariablesScope extends VariablesScope {
 				return function.invoke( fContext );
 			} else if ( memberDescriptor == null ) {
 				throw new BoxRuntimeException(
-				    "key '" + name.getName() + "' of type  '" + value.getClass().getName() + "'  is not a function " );
+				    "key '" + name.getName() + "' of type  '" + TypeUtil.getObjectName( value ) + "'  is not a function " );
 			}
 		}
 
@@ -141,7 +142,7 @@ public class ClassVariablesScope extends VariablesScope {
 				return function.invoke( fContext );
 			} else if ( memberDescriptor == null ) {
 				throw new BoxRuntimeException(
-				    "key '" + name.getName() + "' of type  '" + value.getClass().getName() + "'  is not a function "
+				    "key '" + name.getName() + "' of type  '" + TypeUtil.getObjectName( value ) + "'  is not a function "
 				);
 			}
 		}

--- a/src/main/java/ortus/boxlang/runtime/types/Array.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Array.java
@@ -56,6 +56,7 @@ import ortus.boxlang.runtime.types.meta.GenericMeta;
 import ortus.boxlang.runtime.types.meta.IChangeListener;
 import ortus.boxlang.runtime.types.meta.IListenable;
 import ortus.boxlang.runtime.types.unmodifiable.UnmodifiableArray;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.RegexBuilder;
 
 /**
@@ -234,7 +235,7 @@ public class Array implements List<Object>, IType, IReferenceable, IListenable<A
 			return new Array( new ArrayList<>( collection ) );
 		}
 		throw new BoxRuntimeException(
-		    "Cannot create Array from type: " + arr.getClass().getName() + ". Supported types: List, Array, Collection, or native arrays." );
+		    "Cannot create Array from type: " + TypeUtil.getObjectName( arr ) + ". Supported types: List, Array, Collection, or native arrays." );
 	}
 
 	public Object toVarArgsArray( Class<?> varArgType ) {
@@ -606,10 +607,21 @@ public class Array implements List<Object>, IType, IReferenceable, IListenable<A
 	}
 
 	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Array";
+	}
+
+	/**
 	 * Get the metadata object for this array
 	 *
 	 * @return The metadata object for the array
 	 */
+	@Override
 	public BoxMeta<?> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new GenericMeta( this );

--- a/src/main/java/ortus/boxlang/runtime/types/Closure.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Closure.java
@@ -71,4 +71,14 @@ public abstract class Closure extends Function {
 		return null;
 	}
 
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Closure";
+	}
+
 }

--- a/src/main/java/ortus/boxlang/runtime/types/DateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/types/DateTime.java
@@ -18,18 +18,18 @@
 package ortus.boxlang.runtime.types;
 
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.OffsetDateTime;
 import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.chrono.Chronology;
@@ -49,11 +49,11 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.jr.ob.api.ValueWriter;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
-
-import org.apache.commons.lang3.StringUtils;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.bifs.BoxMemberExpose;
@@ -553,8 +553,19 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	/**
 	 * Interface method to return the string representation
 	 **/
+	@Override
 	public String asString() {
 		return toString();
+	}
+
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "DateTime";
 	}
 
 	/**
@@ -562,6 +573,7 @@ public class DateTime implements IType, IReferenceable, Serializable, ValueWrite
 	 *
 	 * @return The string representation
 	 */
+	@Override
 	public BoxMeta<?> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new GenericMeta( this );

--- a/src/main/java/ortus/boxlang/runtime/types/File.java
+++ b/src/main/java/ortus/boxlang/runtime/types/File.java
@@ -429,10 +429,22 @@ public class File implements IType, IReferenceable {
 	 *
 	 * @return The string representation
 	 */
+	@Override
 	public String asString() {
 		return this.toString();
 	}
 
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "File";
+	}
+
+	@Override
 	public BoxMeta<?> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new GenericMeta( this );

--- a/src/main/java/ortus/boxlang/runtime/types/Function.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Function.java
@@ -47,6 +47,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
 import ortus.boxlang.runtime.types.meta.BoxMeta;
 import ortus.boxlang.runtime.types.meta.FunctionMeta;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ArgumentUtil;
 
 /**
@@ -191,8 +192,19 @@ public abstract class Function implements IType, IFunctionRunnable, Serializable
 	/**
 	 * Return a string representation of the function
 	 */
+	@Override
 	public String asString() {
 		return toString();
+	}
+
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Function";
 	}
 
 	/**
@@ -200,6 +212,7 @@ public abstract class Function implements IType, IFunctionRunnable, Serializable
 	 *
 	 * @return The source type of the function
 	 */
+	@Override
 	public BoxMeta<Function> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new FunctionMeta( this );
@@ -344,7 +357,7 @@ public abstract class Function implements IType, IFunctionRunnable, Serializable
 		if ( !typeCheck.wasSuccessful() ) {
 			throw new BoxRuntimeException(
 			    String.format( "The return value of the function [%s] is of type [%s] does not match the declared type of [%s]",
-			        getName().getName(), value.getClass().getName(), getReturnType() )
+			        getName().getName(), TypeUtil.getObjectName( value ), getReturnType() )
 			);
 		}
 		if ( typeCheck.get() instanceof NullValue ) {

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -83,6 +83,29 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 				);
 			}
 		}
+
+		public String getHumanReadableName() {
+			// return the opposite of the case statement above
+			switch ( this ) {
+				case CASE_SENSITIVE :
+					return "Case Sensitive";
+				case DEFAULT :
+					return "Default";
+				case LINKED_CASE_SENSITIVE :
+					return "Ordered Case Sensitive";
+				case LINKED :
+					return "Ordered";
+				case SOFT :
+					return "Soft";
+				case SORTED :
+					return "Sorted";
+				case WEAK :
+					return "Weak";
+				default :
+					return this.name();
+			}
+		}
+
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/IType.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IType.java
@@ -48,13 +48,40 @@ public interface IType {
 	 */
 	public String asString();
 
+	/**
+	 * Create a set that uses identity for equality
+	 * 
+	 * @return The identity set
+	 */
 	static Set<IType> createIdentitySetForType() {
 		return Collections.newSetFromMap( new IdentityHashMap<>() );
 	}
 
+	/**
+	 * Compute a hash code for this type, avoiding cycles
+	 * 
+	 * @param visited The set of visited types
+	 * 
+	 * @return The hash code
+	 */
 	default int computeHashCode( Set<IType> visited ) {
 		return this.hashCode();
 	}
 
+	/**
+	 * Get the BoxMeta for this type
+	 * 
+	 * @return The BoxMeta for this type
+	 */
 	public BoxMeta<?> getBoxMeta();
+
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	default String getBoxTypeName() {
+		return this.getClass().getSimpleName();
+	}
+
 }

--- a/src/main/java/ortus/boxlang/runtime/types/Lambda.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Lambda.java
@@ -37,4 +37,14 @@ public abstract class Lambda extends Function {
 		super();
 	}
 
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Lambda";
+	}
+
 }

--- a/src/main/java/ortus/boxlang/runtime/types/NullValue.java
+++ b/src/main/java/ortus/boxlang/runtime/types/NullValue.java
@@ -50,8 +50,19 @@ public class NullValue implements IType, IUnmodifiable, Serializable {
 	 *
 	 * @return The string representation
 	 */
+	@Override
 	public String asString() {
 		return "[null]";
+	}
+
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Null";
 	}
 
 	/**
@@ -59,6 +70,7 @@ public class NullValue implements IType, IUnmodifiable, Serializable {
 	 *
 	 * @return The metadata object
 	 */
+	@Override
 	public BoxMeta<?> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new GenericMeta( this );

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -1232,6 +1232,16 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 		return sb.toString();
 	}
 
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "Query";
+	}
+
 	@Override
 	public BoxMeta<Query> getBoxMeta() {
 		if ( this.$bx == null ) {

--- a/src/main/java/ortus/boxlang/runtime/types/Struct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Struct.java
@@ -858,10 +858,24 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 	}
 
 	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		if ( getType() != TYPES.DEFAULT ) {
+			return "Struct<" + getType().getHumanReadableName() + ">";
+		}
+		return "Struct";
+	}
+
+	/**
 	 * Get the BoxMetadata object for this struct
 	 *
 	 * @return The {@Link BoxMeta} object for this struct
 	 */
+	@Override
 	public BoxMeta<?> getBoxMeta() {
 		if ( this.$bx == null ) {
 			this.$bx = new StructMeta( this );

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -40,8 +40,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
 import org.w3c.dom.Element;
@@ -58,6 +58,7 @@ import org.xml.sax.SAXException;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.bifs.BoxMemberExpose;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
+import ortus.boxlang.runtime.bifs.global.string.UCFirst;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.KeyCaster;
@@ -706,6 +707,16 @@ public class XML implements Serializable, IStruct {
 		    "method", "xml",
 		    "indent", "yes"
 		) );
+	}
+
+	/**
+	 * Get the BoxLang type name for this type
+	 * 
+	 * @return The BoxLang type name
+	 */
+	@Override
+	public String getBoxTypeName() {
+		return "XML<" + UCFirst.ucFirst( getXMLType(), false, true ) + ">";
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/types/util/TypeUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/TypeUtil.java
@@ -1,0 +1,101 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.types.util;
+
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
+import ortus.boxlang.runtime.types.IType;
+
+/**
+ * Utility class for type related operations
+ *
+ * @author BoxLang Development Team
+ *
+ * @since 1.6.0
+ */
+public class TypeUtil {
+
+	/**
+	 * Get the name of an object or class suitable for error messages.
+	 * Adjust this further as neccessary.
+	 * 
+	 * - For null it returns the string "null"
+	 * - DynamicObjects are unwrapped
+	 * - BL classes use the class name
+	 * - Java Class objects are represented as Class<FQN>
+	 * - Java arrays are represented as FQN[]
+	 * - BoxLang types (IType) use their BoxLang type name
+	 * - Java primitive wrappers (String, Integer, Boolean, etc) in the java.lang package use their simple name
+	 * - Java Number types are represented as Number<name>
+	 * - All other objects, return the Java class name
+	 */
+	public static String getObjectName( Object obj ) {
+		if ( obj == null ) {
+			return "null";
+		}
+
+		obj = DynamicObject.unWrap( obj );
+
+		if ( obj instanceof Class clazz ) {
+			return "Class<" + getSimplishName( clazz ) + ">";
+		}
+
+		if ( obj instanceof IClassRunnable icr ) {
+			return icr.bxGetName().getName();
+		}
+
+		if ( obj instanceof IType it ) {
+			return it.getBoxTypeName();
+		}
+
+		Class<?> clazz = obj.getClass();
+		if ( clazz.isArray() ) {
+			return getArrayTypeName( clazz );
+		}
+
+		String name = getSimplishName( clazz );
+
+		if ( obj instanceof Number ) {
+			return "Number<" + name + ">";
+		}
+
+		return name;
+	}
+
+	private static String getArrayTypeName( Class<?> arrayClass ) {
+		int			dimensions		= 0;
+
+		// Count dimensions and get the base component type
+		Class<?>	componentType	= arrayClass;
+		while ( componentType.isArray() ) {
+			dimensions++;
+			componentType = componentType.getComponentType();
+		}
+
+		String brackets = "[]".repeat( dimensions );
+		return getSimplishName( componentType ) + brackets;
+	}
+
+	private static String getSimplishName( Class<?> clazz ) {
+		if ( clazz.getPackageName().equals( "java.lang" ) ) {
+			return clazz.getSimpleName();
+		} else {
+			return clazz.getName();
+		}
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/ArgumentUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/ArgumentUtil.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.GenericCaster;
-import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.IntKey;
 import ortus.boxlang.runtime.scopes.Key;
@@ -34,6 +33,7 @@ import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.NullValue;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * Represents an argument to a function or BIF
@@ -272,7 +272,7 @@ public class ArgumentUtil {
 			        "In function [%s], argument [%s] with a type of [%s] does not match the declared type of [%s]",
 			        functionName.getName(),
 			        name.getName(),
-			        DynamicObject.unWrap( value ).getClass().getName(),
+			        TypeUtil.getObjectName( value ),
 			        type
 			    )
 			);

--- a/src/main/java/ortus/boxlang/runtime/util/DataNavigator.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DataNavigator.java
@@ -42,6 +42,7 @@ import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxIOException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.JSONUtil;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 
 /**
  * This utility class is a fluent class that can navigate
@@ -84,7 +85,7 @@ public class DataNavigator {
 			return new Navigator( Struct.fromMap( map ) );
 		}
 
-		throw new BoxRuntimeException( "The JSON data must be a Map and it's a [" + data.getClass().getName() + "]" );
+		throw new BoxRuntimeException( "The JSON data must be a Map and it's a [" + TypeUtil.getObjectName( data ) + "]" );
 	}
 
 	/**
@@ -288,7 +289,7 @@ public class DataNavigator {
 
 				// If it's not a map/struct then we can't navigate it, blow up
 				if ( ! ( lastResult instanceof Map<?, ?> ) ) {
-					throw new BoxRuntimeException( "The requested segment is not a Struct, but a [" + lastResult.getClass().getName() + "]" );
+					throw new BoxRuntimeException( "The requested segment is not a Struct, but a [" + TypeUtil.getObjectName( lastResult ) + "]" );
 				}
 
 				// Set the navigable segment

--- a/src/main/java/ortus/boxlang/runtime/util/FileSystemUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/FileSystemUtil.java
@@ -78,6 +78,7 @@ import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxIOException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.ListUtil;
+import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.conversion.RuntimeObjectInputStream;
 
 /**
@@ -655,7 +656,7 @@ public final class FileSystemUtil {
 			} catch ( IOException e ) {
 				throw new BoxIOException( String.format(
 				    "The target entry [%s] could not be written to the file path [%s]. The message received was: %s",
-				    target.getClass().getName(),
+				    TypeUtil.getObjectName( target ),
 				    filePath.toString(),
 				    e.getMessage()
 				),

--- a/src/test/java/ortus/boxlang/runtime/types/util/TypeUtilTest.java
+++ b/src/test/java/ortus/boxlang/runtime/types/util/TypeUtilTest.java
@@ -1,0 +1,94 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.types.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IType;
+import ortus.boxlang.runtime.types.meta.BoxMeta;
+
+class TypeUtilTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@Test
+	void testGetObjectName() {
+
+		assertEquals( "src.test.java.TestCases.phase3.MyClass",
+		    TypeUtil.getObjectName( instance.executeStatement( "new src.test.java.TestCases.phase3.MyClass()" ) ) );
+		assertEquals( "Struct", TypeUtil.getObjectName( instance.executeStatement( "{}" ) ) );
+		assertEquals( "Struct<Ordered>", TypeUtil.getObjectName( instance.executeStatement( "[:]" ) ) );
+		assertEquals( "XML<Document>", TypeUtil.getObjectName( instance.executeStatement( "XMLParse( '<root />' )" ) ) );
+		assertEquals( "null", TypeUtil.getObjectName( null ) );
+		assertEquals( "Class<String>", TypeUtil.getObjectName( String.class ) );
+		assertEquals( "Class<ortus.boxlang.runtime.types.util.TypeUtilTest$MyClass>", TypeUtil.getObjectName( MyClass.class ) );
+		assertEquals( "MyClassType", TypeUtil.getObjectName( new MyClass() ) );
+		assertEquals( "Number<Integer>", TypeUtil.getObjectName( 42 ) );
+		assertEquals( "Number<Double>", TypeUtil.getObjectName( 3.14 ) );
+		assertEquals( "String", TypeUtil.getObjectName( "Hello" ) );
+		assertEquals( "String[]", TypeUtil.getObjectName( new String[ 0 ] ) );
+		assertEquals( "Number[]", TypeUtil.getObjectName( new Number[ 0 ] ) );
+		assertEquals( "Integer[]", TypeUtil.getObjectName( new Integer[ 0 ] ) );
+		assertEquals( "ortus.boxlang.runtime.types.util.TypeUtilTest$MyClass[]", TypeUtil.getObjectName( new MyClass[ 0 ] ) );
+	}
+
+	static class MyClass implements IType {
+
+		@Override
+		public String getBoxTypeName() {
+			return "MyClassType";
+		}
+
+		@Override
+		public String asString() {
+			// TODO Auto-generated method stub
+			throw new UnsupportedOperationException( "Unimplemented method 'asString'" );
+		}
+
+		@Override
+		public BoxMeta<?> getBoxMeta() {
+			// TODO Auto-generated method stub
+			throw new UnsupportedOperationException( "Unimplemented method 'getBoxMeta'" );
+		}
+	}
+
+}


### PR DESCRIPTION
We have lot of places where we throw validation message like so


```
"Expected type foo, but you passed " + value.getClass().getName()
```

This doesn’t account for null, and always just displays the Java class name without regard for known BoxLang types, Box Classes, or common JDK types. 

Switch these over to a common helper which uses the following rules:

* For null it returns the string "null"
* DynamicObjects are unwrapped
* BL classes use the class name
* Java Class objects are represented as Class<FQN>
* Java arrays are represented as FQN[]
* BoxLang types (IType) use their BoxLang type name
* Java primitive wrappers (String, Integer, Boolean, etc) in the java.lang package use their simple name
* Java Number types are represented as Number<name>
* All other objects, return the Java class name