### PR TITLE
BL-1786 Update getInstance synchronization

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/AsmHelper.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/AsmHelper.java
@@ -794,18 +794,36 @@ public class AsmHelper {
 		    null );
 		fieldVisitor.visitEnd();
 		MethodVisitor methodVisitor = classVisitor.visitMethod(
-		    Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNCHRONIZED | Opcodes.ACC_STATIC,
+		    Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
 		    "getInstance",
 		    Type.getMethodDescriptor( type ),
 		    null,
 		    null );
 		methodVisitor.visitCode();
-		Label after = new Label();
+
+		// First null check (outside synchronized block)
+		Label endOfMethod = new Label();
 		methodVisitor.visitFieldInsn( Opcodes.GETSTATIC,
 		    type.getInternalName(),
 		    "instance",
 		    type.getDescriptor() );
-		methodVisitor.visitJumpInsn( Opcodes.IFNONNULL, after );
+		methodVisitor.visitJumpInsn( Opcodes.IFNONNULL, endOfMethod );
+
+		// Synchronized block on class
+		methodVisitor.visitLdcInsn( type );
+		methodVisitor.visitInsn( Opcodes.MONITORENTER );
+
+		// Second null check (inside synchronized block)
+		methodVisitor.visitFieldInsn( Opcodes.GETSTATIC,
+		    type.getInternalName(),
+		    "instance",
+		    type.getDescriptor() );
+		Label start = new Label(), end = new Label(), handler = new Label();
+		methodVisitor.visitTryCatchBlock( start, end, handler, null );
+		methodVisitor.visitLabel( start );
+		methodVisitor.visitJumpInsn( Opcodes.IFNONNULL, end );
+
+		// Create new instance
 		methodVisitor.visitTypeInsn( Opcodes.NEW, type.getInternalName() );
 		methodVisitor.visitInsn( Opcodes.DUP );
 		methodVisitor.visitMethodInsn( Opcodes.INVOKESPECIAL,
@@ -817,12 +835,26 @@ public class AsmHelper {
 		    type.getInternalName(),
 		    "instance",
 		    type.getDescriptor() );
-		methodVisitor.visitLabel( after );
+
+		// Exit synchronized block normally
+		methodVisitor.visitLabel( end );
+		methodVisitor.visitLdcInsn( type );
+		methodVisitor.visitInsn( Opcodes.MONITOREXIT );
+
+		// Return instance
+		methodVisitor.visitLabel( endOfMethod );
 		methodVisitor.visitFieldInsn( Opcodes.GETSTATIC,
 		    type.getInternalName(),
 		    "instance",
 		    type.getDescriptor() );
 		methodVisitor.visitInsn( Opcodes.ARETURN );
+
+		// Exception handler for synchronized block
+		methodVisitor.visitLabel( handler );
+		methodVisitor.visitLdcInsn( type );
+		methodVisitor.visitInsn( Opcodes.MONITOREXIT );
+		methodVisitor.visitInsn( Opcodes.ATHROW );
+
 		methodVisitor.visitMaxs( 0, 0 );
 		methodVisitor.visitEnd();
 	}

--- a/src/test/java/ortus/boxlang/compiler/ASMTest.java
+++ b/src/test/java/ortus/boxlang/compiler/ASMTest.java
@@ -105,4 +105,31 @@ public class ASMTest {
 		// @formatter:on
 	}
 
+	@Test
+	public void testGetInstancePattern() {
+		// Test that getInstance methods work correctly for functions and lambdas
+		instance.executeSource(
+		    """
+		    	// Test function getInstance via compilation
+		    	function testFunc() {
+		    		return "function result";
+		    	}
+
+		    	// Test lambda getInstance via compilation
+		    	lambda = () => {
+		    		return "lambda result";
+		    	};
+
+		    	result = testFunc();
+		    	lambdaResult = lambda();
+		    """, context );
+
+		// Verify the functions execute correctly (indicating getInstance works)
+		var	result			= context.getScopeNearby( VariablesScope.name ).get( new Key( "result" ) );
+		var	lambdaResult	= context.getScopeNearby( VariablesScope.name ).get( new Key( "lambdaResult" ) );
+
+		assert result.equals( "function result" );
+		assert lambdaResult.equals( "lambda result" );
+	}
+
 }


### PR DESCRIPTION
The original getInstance implementation caused method level synchronization. We've updated this to be within the method so we can do a faster non-synchronized is null check that will account for most times the method is invoked.

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL/issues


## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
