### PR TITLE
JDBC - Clean up JDBC vendor-specific tests, make setup and teardown consistent

### DIFF
--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/BaseJDBCTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/BaseJDBCTest.java
@@ -13,9 +13,6 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.jdbc.DataSource;
-import ortus.boxlang.runtime.jdbc.drivers.MSSQLDriverTest;
-import ortus.boxlang.runtime.jdbc.drivers.MariaDBDriverTest;
-import ortus.boxlang.runtime.jdbc.drivers.MySQLDriverTest;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -28,9 +25,6 @@ public class BaseJDBCTest {
 	public ScriptingRequestBoxContext	context;
 	public IScope						variables;
 	public static DataSource			datasource;
-	public static DataSource			mssqlDatasource;
-	public static DataSource			mysqlDatasource;
-	public static DataSource			mariaDBDatasource;
 	public static DatasourceService		datasourceService;
 
 	@BeforeAll
@@ -46,17 +40,6 @@ public class BaseJDBCTest {
 		    datasourceKey,
 		    datasource.getConfiguration()
 		);
-		if ( JDBCTestUtils.hasMSSQLModule() ) {
-			mssqlDatasource = MSSQLDriverTest.setupTestDatasource( instance, setUpContext );
-		}
-
-		if ( JDBCTestUtils.hasMySQLModule() ) {
-			mysqlDatasource = MySQLDriverTest.setupTestDatasource( instance, setUpContext );
-		}
-
-		if ( JDBCTestUtils.hasMariaDBModule() ) {
-			mariaDBDatasource = MariaDBDriverTest.setupTestDatasource( instance, setUpContext );
-		}
 	}
 
 	@AfterAll
@@ -64,18 +47,6 @@ public class BaseJDBCTest {
 		IBoxContext tearDownContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
 		JDBCTestUtils.dropTestTable( datasource, tearDownContext, "developers", true );
 		datasource.shutdown();
-		if ( mssqlDatasource != null ) {
-			JDBCTestUtils.dropTestTable( mssqlDatasource, tearDownContext, "developers", true );
-			mssqlDatasource.shutdown();
-		}
-		if ( mysqlDatasource != null ) {
-			JDBCTestUtils.dropTestTable( mysqlDatasource, tearDownContext, "developers", true );
-			mysqlDatasource.shutdown();
-		}
-		if ( mariaDBDatasource != null ) {
-			JDBCTestUtils.dropTestTable( mariaDBDatasource, tearDownContext, "developers", true );
-			mariaDBDatasource.shutdown();
-		}
 	}
 
 	@BeforeEach

--- a/src/test/java/ortus/boxlang/runtime/components/jdbc/StoredProcTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/jdbc/StoredProcTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
@@ -210,24 +209,6 @@ public class StoredProcTest extends BaseJDBCTest {
 		    getContext(), BoxSourceType.BOXTEMPLATE );
 		Integer subsequentActive = getDatasource().getPoolStats().getAsInteger( Key.of( "ActiveConnections" ) );
 		assertEquals( initiallyActive, subsequentActive );
-	}
-
-	// Derby does a poor job of implementing the stored procedure spec, so we'll only run this test on mysql.
-	@Disabled( "TODO: Update Mysql stored procedure setup in MySQLDriverTest.java" )
-	@EnabledIf( "tools.JDBCTestUtils#hasMySQLModule" )
-	@Test
-	public void testMultiResultSets() {
-		getInstance().executeSource(
-		    """
-		        storedproc dataSource = "MysqlStoredProcTest" procedure = "sp_multi_result_set" {
-		        	procparam sqltype="varchar" value="SEGA";
-		        	procresult name="names_asc" resultSet=1 maxRows=1;
-		        	procresult name="names_desc" resultSet=2 maxRows=2;
-		        };
-		    """,
-		    getContext(), BoxSourceType.BOXTEMPLATE );
-		assertThat( getVariables().get( Key.of( "names_asc" ) ) ).isInstanceOf( Query.class );
-		assertThat( getVariables().get( Key.of( "names_desc" ) ) ).isInstanceOf( Query.class );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/AbstractDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/AbstractDriverTest.java
@@ -63,6 +63,18 @@ public abstract class AbstractDriverTest extends BaseJDBCTest {
 		return theDatasource;
 	}
 
+	/**
+	 * Tears down a specific driver type datasource after testing is complete.
+	 * 
+	 * @param tearDownContext The context to use for teardown
+	 * @param theDatasource   The datasource to teardown
+	 */
+	public static void teardownTestDatasource( IBoxContext tearDownContext, DataSource theDatasource ) {
+		JDBCTestUtils.dropTestTable( theDatasource, tearDownContext, "developers", true );
+		JDBCTestUtils.dropTestTable( theDatasource, tearDownContext, "generatedKeyTest", true );
+		theDatasource.shutdown();
+	}
+
 	@DisplayName( "It sets generatedKey in query meta" )
 	@Test
 	public void testGeneratedKey() {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
@@ -7,12 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.DoubleCaster;
 import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
 import ortus.boxlang.runtime.jdbc.DataSource;
@@ -22,24 +25,38 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
+import tools.JDBCTestUtils;
 
 @EnabledIf( "tools.JDBCTestUtils#hasMSSQLModule" )
 public class MSSQLDriverTest extends AbstractDriverTest {
 
-	protected static Key datasourceName = Key.of( "MSSQLdatasource" );
+	public static DataSource	mssqlDatasource;
 
-	public static DataSource setupTestDatasource( BoxRuntime instance, IBoxContext setUpContext ) {
-		IStruct		dsConfig		= Struct.of(
-		    "username", "sa",
-		    "password", "123456Password",
-		    "host", "localhost",
-		    "port", "1433",
-		    "driver", "mssql",
-		    "database", "master"
-		);
-		DataSource	theDatasource	= AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, dsConfig );
-		MSSQLDriverTest.createGeneratedKeyTable( theDatasource, setUpContext );
-		return theDatasource;
+	protected static Key		datasourceName		= Key.of( "MSSQLdatasource" );
+
+	protected static IStruct	datasourceConfig	= Struct.of(
+	    "username", "sa",
+	    "password", "123456Password",
+	    "host", "localhost",
+	    "port", "1433",
+	    "driver", "mssql",
+	    "database", "master"
+	);
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+		IBoxContext setUpContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		mssqlDatasource = AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, datasourceConfig );
+		MSSQLDriverTest.createGeneratedKeyTable( mssqlDatasource, setUpContext );
+	}
+
+	@AfterAll
+	public static void teardown() throws SQLException {
+		IBoxContext tearDownContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		JDBCTestUtils.dropTestTable( mssqlDatasource, tearDownContext, "developers", true );
+		JDBCTestUtils.dropTestTable( mssqlDatasource, tearDownContext, "generatedKeyTest", true );
+		mssqlDatasource.shutdown();
 	}
 
 	public static void createGeneratedKeyTable( DataSource dataSource, IBoxContext context ) {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
@@ -25,7 +25,6 @@ import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
-import tools.JDBCTestUtils;
 
 @EnabledIf( "tools.JDBCTestUtils#hasMSSQLModule" )
 public class MSSQLDriverTest extends AbstractDriverTest {
@@ -54,9 +53,7 @@ public class MSSQLDriverTest extends AbstractDriverTest {
 	@AfterAll
 	public static void teardown() throws SQLException {
 		IBoxContext tearDownContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
-		JDBCTestUtils.dropTestTable( mssqlDatasource, tearDownContext, "developers", true );
-		JDBCTestUtils.dropTestTable( mssqlDatasource, tearDownContext, "generatedKeyTest", true );
-		mssqlDatasource.shutdown();
+		AbstractDriverTest.teardownTestDatasource( tearDownContext, mssqlDatasource );
 	}
 
 	public static void createGeneratedKeyTable( DataSource dataSource, IBoxContext context ) {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MariaDBDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MariaDBDriverTest.java
@@ -53,7 +53,8 @@ public class MariaDBDriverTest extends AbstractDriverTest {
 
 	@AfterAll
 	public static void teardown() throws SQLException {
-		AbstractDriverTest.teardownTestDatasource( new ScriptingRequestBoxContext( instance.getRuntimeContext() ), mariaDBDatasource );
+		IBoxContext tearDownContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		AbstractDriverTest.teardownTestDatasource( tearDownContext, mariaDBDatasource );
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MariaDBDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MariaDBDriverTest.java
@@ -11,6 +11,8 @@ import java.nio.ByteOrder;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.jdbc.DataSource;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
@@ -28,19 +31,29 @@ import ortus.boxlang.runtime.types.exceptions.DatabaseException;
 @EnabledIf( "tools.JDBCTestUtils#hasMariaDBModule" )
 public class MariaDBDriverTest extends AbstractDriverTest {
 
-	protected static Key datasourceName = Key.of( "MariaDBdatasource" );
+	public static DataSource	mariaDBDatasource;
 
-	public static DataSource setupTestDatasource( BoxRuntime instance, IBoxContext setUpContext ) {
-		IStruct dsConfig = Struct.of(
-		    "username", "root",
-		    "password", "123456Password",
-		    "connectionString", "jdbc:mariadb://localhost:3360",
-		    "database", "myDB",
-		    "custom", "allowMultiQueries=true&returnMultiValuesGeneratedIds=true"
-		);
-		mariaDBDatasource = AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, dsConfig );
+	protected static Key		datasourceName		= Key.of( "MariaDBdatasource" );
+
+	protected static IStruct	datasourceConfig	= Struct.of(
+	    "username", "root",
+	    "password", "123456Password",
+	    "connectionString", "jdbc:mariadb://localhost:3360",
+	    "database", "myDB",
+	    "custom", "allowMultiQueries=true&returnMultiValuesGeneratedIds=true"
+	);
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+		IBoxContext setUpContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		mariaDBDatasource = AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, datasourceConfig );
 		MariaDBDriverTest.createGeneratedKeyTable( mariaDBDatasource, setUpContext );
-		return mariaDBDatasource;
+	}
+
+	@AfterAll
+	public static void teardown() throws SQLException {
+		AbstractDriverTest.teardownTestDatasource( new ScriptingRequestBoxContext( instance.getRuntimeContext() ), mariaDBDatasource );
 	}
 
 	/**
@@ -54,12 +67,12 @@ public class MariaDBDriverTest extends AbstractDriverTest {
 	/**
 	 * Create a table that uses generated keys so we can test our generated key retrieval in BL.
 	 * 
-	 * @param ds      Datasource object
-	 * @param context Box context
+	 * @param dataSource Datasource object
+	 * @param context    Box context
 	 */
-	public static void createGeneratedKeyTable( DataSource ds, IBoxContext context ) {
+	public static void createGeneratedKeyTable( DataSource dataSource, IBoxContext context ) {
 		try {
-			mariaDBDatasource.execute( "CREATE TABLE generatedKeyTest( id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(155))", context );
+			dataSource.execute( "CREATE TABLE generatedKeyTest( id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(155))", context );
 		} catch ( DatabaseException ignored ) {
 		}
 	}

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MySQLDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MySQLDriverTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.jdbc.DataSource;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
@@ -26,77 +29,88 @@ import ortus.boxlang.runtime.types.exceptions.DatabaseException;
 @EnabledIf( "tools.JDBCTestUtils#hasMySQLModule" )
 public class MySQLDriverTest extends AbstractDriverTest {
 
-	protected static Key		datasourceName	= Key.of( "MySQLdatasource" );
 	public static DataSource	mysqlDatasource;
 
-	public static DataSource setupTestDatasource( BoxRuntime instance, IBoxContext setUpContext ) {
-		IStruct dsConfig = Struct.of(
-		    "username", "root",
-		    "password", "123456Password",
-		    "host", "localhost",
-		    "port", "3309",
-		    "driver", "mysql",
-		    "database", "myDB",
-		    "custom", "allowMultiQueries=true"
-		);
-		mysqlDatasource = AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, dsConfig );
+	protected static Key		datasourceName		= Key.of( "MySQLdatasource" );
+
+	protected static IStruct	datasourceConfig	= Struct.of(
+	    "username", "root",
+	    "password", "123456Password",
+	    "host", "localhost",
+	    "port", "3309",
+	    "driver", "mysql",
+	    "database", "myDB",
+	    "custom", "allowMultiQueries=true"
+	);
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+		IBoxContext setUpContext = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+
+		mysqlDatasource = AbstractDriverTest.setupTestDatasource( instance, setUpContext, datasourceName, datasourceConfig );
 		MySQLDriverTest.createGeneratedKeyTable( mysqlDatasource, setUpContext );
 
-		/***
-		 * Set up stored procedure and supporting table for testing. See StoredProcTest.
-		 */
-		if ( false ) {
-			mysqlDatasource.execute(
-			    """
-			    CREATE DEFINER=`root`@`%` PROCEDURE `sp_multi_result_set` (IN `companyName` VARCHAR(255))   BEGIN
-			    	SELECT *
-			    	FROM company
-			    	WHERE name <> companyName
-			    	order by name asc;
+		// @TODO: Move mysql-specific StoredProcTest here and uncomment this setup.
+		// setupStoredProcTests();
+	}
 
-			    	SELECT *
-			    	FROM company
-			    	WHERE name <> companyName
-			    	order by name desc;
-			    END$$
-			    """,
-			    setUpContext
-			);
-			mysqlDatasource.execute(
-			    """
-			    CREATE TABLE `company` (
-			    `id` int NOT NULL,
-			    `name` text NOT NULL,
-			    `active` tinyint(1) NOT NULL DEFAULT '1'
-			    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-			    	""",
-			    setUpContext
-			);
-			mysqlDatasource.execute(
-			    """
-			    INSERT INTO `company` (`id`, `name`, `active`) VALUES
-			    (1, 'Nintendo', 1),
-			    (2, 'SEGA', 0),
-			    (3, 'Sony', 1),
-			    (4, 'Microsoft', 1);
-			    	""",
-			    setUpContext
-			);
-		}
+	@AfterAll
+	public static void teardown() throws SQLException {
+		AbstractDriverTest.teardownTestDatasource( new ScriptingRequestBoxContext( instance.getRuntimeContext() ), mysqlDatasource );
+	}
 
-		return mysqlDatasource;
+	/***
+	 * Set up stored procedure and supporting table for testing. See StoredProcTest.
+	 */
+	public static void setupStoredProcTests( BoxRuntime instance, IBoxContext setUpContext ) {
+		mysqlDatasource.execute(
+		    """
+		    CREATE DEFINER=`root`@`%` PROCEDURE `sp_multi_result_set` (IN `companyName` VARCHAR(255))   BEGIN
+		    	SELECT *
+		    	FROM company
+		    	WHERE name <> companyName
+		    	order by name asc;
+
+		    	SELECT *
+		    	FROM company
+		    	WHERE name <> companyName
+		    	order by name desc;
+		    END$$
+		    """,
+		    setUpContext
+		);
+		mysqlDatasource.execute(
+		    """
+		    CREATE TABLE `company` (
+		    `id` int NOT NULL,
+		    `name` text NOT NULL,
+		    `active` tinyint(1) NOT NULL DEFAULT '1'
+		    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+		    	""",
+		    setUpContext
+		);
+		mysqlDatasource.execute(
+		    """
+		    INSERT INTO `company` (`id`, `name`, `active`) VALUES
+		    (1, 'Nintendo', 1),
+		    (2, 'SEGA', 0),
+		    (3, 'Sony', 1),
+		    (4, 'Microsoft', 1);
+		    	""",
+		    setUpContext
+		);
 	}
 
 	/**
 	 * Create a table that uses generated keys so we can test our generated key retrieval in BL.
-	 * Create a table that uses generated keys so we can test our generated key retrieval in BL.
 	 * 
-	 * @param ds      Datasource object
-	 * @param context Box context
+	 * @param dataSource Datasource object
+	 * @param context    Box context
 	 */
-	public static void createGeneratedKeyTable( DataSource ds, IBoxContext context ) {
+	public static void createGeneratedKeyTable( DataSource dataSource, IBoxContext context ) {
 		try {
-			mysqlDatasource.execute( "CREATE TABLE generatedKeyTest( id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(155))", context );
+			dataSource.execute( "CREATE TABLE generatedKeyTest( id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(155))", context );
 		} catch ( DatabaseException ignored ) {
 		}
 	}


### PR DESCRIPTION
# Description

Refactors JDBC driver tests to be clearer and more consistent across all drivers.