### PR TITLE
BL-1961: Function Inception: Allow for functions to be declared within functions

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -43,6 +43,8 @@ import ortus.boxlang.compiler.ast.BoxExpression;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
 import ortus.boxlang.compiler.ast.BoxTemplate;
+import ortus.boxlang.compiler.ast.expression.BoxClosure;
+import ortus.boxlang.compiler.ast.expression.BoxLambda;
 import ortus.boxlang.compiler.ast.statement.BoxAccessModifier;
 import ortus.boxlang.compiler.ast.statement.BoxFunctionDeclaration;
 import ortus.boxlang.compiler.ast.statement.BoxMethodDeclarationModifier;
@@ -53,8 +55,12 @@ import ortus.boxlang.compiler.ast.statement.component.BoxTemplateIsland;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.context.FunctionBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.LocalScope;
 import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.Closure;
+import ortus.boxlang.runtime.types.ClosureDefinition;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.UDF;
@@ -62,9 +68,8 @@ import ortus.boxlang.runtime.util.ResolvedFilePath;
 
 /**
  * Transform a Function Declaration using the static method + method handle pattern.
- * Instead of generating a separate inner class per function, this generates:
- * 1. A static invoker method on the enclosing class
- * 2. An instantiation of UDF with a method reference to the static invoker
+ * Supports both top-level UDF declarations (hoisted) and nested function declarations
+ * inside other functions/closures (compiled as closures and assigned to the local scope).
  */
 public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 
@@ -76,27 +81,35 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 	@Override
 	public List<AbstractInsnNode> transform( BoxNode node, TransformerContext context, ReturnValueContext returnContext ) throws IllegalStateException {
 		BoxFunctionDeclaration	function	= ( BoxFunctionDeclaration ) node;
-		TransformerContext		safe		= function.getName().equalsIgnoreCase( "isnull" ) ? TransformerContext.SAFE : context;
 
-		if ( transpiler.hasCompiledFunction( function.getName() ) ) {
-			if ( transpiler.getProperty( "sourceType" ).equals( BoxSourceType.BOXSCRIPT.name() )
-			    || transpiler.getProperty( "sourceType" ).equals( BoxSourceType.BOXTEMPLATE.name() ) ) {
-				throw new IllegalStateException( "Cannot define multiple functions with the same name: " + function.getName() );
-			} else {
-				ArrayList<AbstractInsnNode> blankResult = new ArrayList<>();
-
-				if ( returnContext == ReturnValueContext.VALUE || returnContext == ReturnValueContext.VALUE_OR_NULL ) {
-					blankResult.add( new InsnNode( Opcodes.ACONST_NULL ) );
-				}
-
-				return blankResult;
-			}
-
+		if ( isNestedFunction( function ) ) {
+			return transformNestedFunction( function, context, returnContext );
 		}
 
-		BoxReturnType	boxReturnType	= function.getType();
-		BoxType			returnType		= BoxType.Any;
-		String			fqn				= null;
+		return transformTopLevelFunction( function, context, returnContext );
+	}
+
+	/**
+	 * Detect if this function declaration is nested inside another function, closure, or lambda body.
+	 */
+	private boolean isNestedFunction( BoxFunctionDeclaration function ) {
+		return function.getFirstAncestorOfType( BoxFunctionDeclaration.class ) != null
+		    || function.getFirstAncestorOfType( BoxClosure.class ) != null
+		    || function.getFirstAncestorOfType( BoxLambda.class ) != null;
+	}
+
+	/**
+	 * Transform a nested function declaration as a named closure assigned to the parent's local scope.
+	 * Generates a ClosureDefinition (stored in the static closures list) and inline bytecode that
+	 * calls newInstance(context) and puts the resulting Closure into the local scope.
+	 */
+	private List<AbstractInsnNode> transformNestedFunction( BoxFunctionDeclaration function, TransformerContext context,
+	    ReturnValueContext returnContext ) {
+		TransformerContext	safe			= function.getName().equalsIgnoreCase( "isnull" ) ? TransformerContext.SAFE : context;
+
+		BoxReturnType		boxReturnType	= function.getType();
+		BoxType				returnType		= BoxType.Any;
+		String				fqn				= null;
 		if ( boxReturnType != null ) {
 			returnType = boxReturnType.getType();
 			if ( returnType.equals( BoxType.Fqn ) ) {
@@ -104,31 +117,27 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 			}
 		}
 		String				returnTypeName		= returnType.equals( BoxType.Fqn ) ? fqn : returnType.name();
-
 		BoxAccessModifier	access				= function.getAccessModifier() == null ? BoxAccessModifier.Public : function.getAccessModifier();
 
-		String				invokerMethodName	= IBoxpiler.INVOKE_FUNCTION_PREFIX + IBoxpiler.sanitizeForJavaIdentifier( function.getName() );
+		int					closureIndex		= transpiler.getClosureInstantiations().size();
+		transpiler.getClosureInstantiations().add( null );
+		String				invokerMethodName	= "invokeClosure_" + closureIndex;
 
 		Type				declaringType		= Type.getType( "L" + transpiler.getProperty( "packageName" ).replace( '.', '/' )
 		    + "/" + transpiler.getProperty( "classname" )
 		    + ";" );
 
-		// Generate the static invoker method on the owning class
 		ClassNode			owningClass			= transpiler.getOwningClass();
 
-		// Mark this function as compiled to prevent duplicate method generation
-		// (e.g., when the same function is encountered via multiple AST traversal paths in tag-based CFCs with cfscript blocks)
-		transpiler.markFunctionCompiled( function.getName() );
+		// Generate the static invoker method for the nested function body
 		transpiler.incrementfunctionBodyCounter();
 		AsmHelper.methodWithContextAndClassLocator( owningClass, invokerMethodName, Type.getType( FunctionBoxContext.class ), Type.getType( Object.class ),
 		    true,
 		    transpiler, true,
 		    () -> {
-
 			    if ( function.getBody() == null ) {
 				    return new ArrayList<AbstractInsnNode>();
 			    }
-
 			    return function.getBody()
 			        .stream()
 			        .flatMap( statement -> transpiler.transform( statement, safe, ReturnValueContext.EMPTY ).stream() )
@@ -136,15 +145,13 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		    } );
 		transpiler.decrementfunctionBodyCounter();
 
-		// Generate the UDF instantiation bytecode: new UDF(name, arguments, returnType, access, annotations, documentation, modifiers, defaultOutput,
-		// imports, sourceType, path, ClassName::invokerMethodName)
+		// Generate the ClosureDefinition instantiation bytecode
 		List<AbstractInsnNode> instantiation = new ArrayList<>();
 
-		// NEW UDF
-		instantiation.add( new TypeInsnNode( Opcodes.NEW, Type.getInternalName( UDF.class ) ) );
+		instantiation.add( new TypeInsnNode( Opcodes.NEW, Type.getInternalName( ClosureDefinition.class ) ) );
 		instantiation.add( new InsnNode( Opcodes.DUP ) );
 
-		// Arg 1: name (Key)
+		// Arg 1: name (Key) - use the function's actual name
 		instantiation.addAll( transpiler.createKey( function.getName() ) );
 
 		// Arg 2: arguments (Argument[])
@@ -191,25 +198,19 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		// Arg 8: defaultOutput (boolean)
 		instantiation.add( new InsnNode( shouldDefaultOutput( function ) ? Opcodes.ICONST_1 : Opcodes.ICONST_0 ) );
 
-		// Arg 9: imports (List) - from enclosing class static field
+		// Arg 9: imports (List)
 		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
-		    declaringType.getInternalName(),
-		    "imports",
-		    Type.getDescriptor( List.class ) ) );
+		    declaringType.getInternalName(), "imports", Type.getDescriptor( List.class ) ) );
 
-		// Arg 10: sourceType (BoxSourceType) - from enclosing class static field
+		// Arg 10: sourceType (BoxSourceType)
 		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
-		    declaringType.getInternalName(),
-		    "sourceType",
-		    Type.getDescriptor( BoxSourceType.class ) ) );
+		    declaringType.getInternalName(), "sourceType", Type.getDescriptor( BoxSourceType.class ) ) );
 
-		// Arg 11: path (ResolvedFilePath) - from enclosing class static field
+		// Arg 11: path (ResolvedFilePath)
 		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
-		    declaringType.getInternalName(),
-		    "path",
-		    Type.getDescriptor( ResolvedFilePath.class ) ) );
+		    declaringType.getInternalName(), "path", Type.getDescriptor( ResolvedFilePath.class ) ) );
 
-		// Arg 12: method reference - ClassName::invokerMethodName as Function<FunctionBoxContext, Object>
+		// Arg 12: method reference
 		instantiation.add( new InvokeDynamicInsnNode(
 		    "apply",
 		    "()Ljava/util/function/Function;",
@@ -237,7 +238,229 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		    Type.getMethodType( "(Lortus/boxlang/runtime/context/FunctionBoxContext;)Ljava/lang/Object;" )
 		) );
 
-		// INVOKESPECIAL UDF.<init>(Key, Argument[], String, Access, IStruct, IStruct, List, boolean, List, BoxSourceType, ResolvedFilePath, Function)V
+		// INVOKESPECIAL ClosureDefinition.<init>(...)
+		instantiation.add( new MethodInsnNode( Opcodes.INVOKESPECIAL,
+		    Type.getInternalName( ClosureDefinition.class ),
+		    "<init>",
+		    Type.getMethodDescriptor(
+		        Type.VOID_TYPE,
+		        Type.getType( Key.class ),
+		        Type.getType( Argument[].class ),
+		        Type.getType( String.class ),
+		        Type.getType( Function.Access.class ),
+		        Type.getType( IStruct.class ),
+		        Type.getType( IStruct.class ),
+		        Type.getType( List.class ),
+		        Type.BOOLEAN_TYPE,
+		        Type.getType( List.class ),
+		        Type.getType( BoxSourceType.class ),
+		        Type.getType( ResolvedFilePath.class ),
+		        Type.getType( java.util.function.Function.class )
+		    ),
+		    false ) );
+
+		transpiler.getClosureInstantiations().set( closureIndex, instantiation );
+
+		// Generate inline bytecode: context.getScopeNearby(LocalScope.name, false).put(Key.of("name"), closures.get(index).newInstance(context))
+		List<AbstractInsnNode> nodes = new ArrayList<>();
+
+		// context.getScopeNearby(LocalScope.name, false)
+		nodes.addAll( transpiler.getCurrentMethodContextTracker().get().loadCurrentContext() );
+		nodes.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    Type.getInternalName( LocalScope.class ),
+		    "name",
+		    Type.getDescriptor( Key.class ) ) );
+		nodes.add( new InsnNode( Opcodes.ICONST_0 ) );
+		nodes.add( new MethodInsnNode( Opcodes.INVOKEINTERFACE,
+		    Type.getInternalName( IBoxContext.class ),
+		    "getScopeNearby",
+		    Type.getMethodDescriptor( Type.getType( IScope.class ), Type.getType( Key.class ), Type.BOOLEAN_TYPE ),
+		    true ) );
+
+		// .put(Key.of("name"), closures.get(index).newInstance(context))
+		// Stack: [IScope]
+		nodes.addAll( transpiler.createKey( function.getName() ) );
+		// Stack: [IScope, Key]
+
+		// closures.get(closureIndex)
+		nodes.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    declaringType.getInternalName(),
+		    "closures",
+		    Type.getDescriptor( List.class ) ) );
+		nodes.add( new LdcInsnNode( closureIndex ) );
+		nodes.add( new MethodInsnNode( Opcodes.INVOKEINTERFACE,
+		    Type.getInternalName( List.class ),
+		    "get",
+		    Type.getMethodDescriptor( Type.getType( Object.class ), Type.INT_TYPE ),
+		    true ) );
+		nodes.add( new TypeInsnNode( Opcodes.CHECKCAST, Type.getInternalName( ClosureDefinition.class ) ) );
+
+		// .newInstance(context)
+		nodes.addAll( transpiler.getCurrentMethodContextTracker().get().loadCurrentContext() );
+		nodes.add( new MethodInsnNode( Opcodes.INVOKEVIRTUAL,
+		    Type.getInternalName( ClosureDefinition.class ),
+		    "newInstance",
+		    Type.getMethodDescriptor( Type.getType( Closure.class ), Type.getType( IBoxContext.class ) ),
+		    false ) );
+
+		// Stack: [IScope, Key, Closure]
+		// IScope.put(Key, Object) -> returns Object
+		nodes.add( new MethodInsnNode( Opcodes.INVOKEINTERFACE,
+		    Type.getInternalName( IScope.class ),
+		    "put",
+		    Type.getMethodDescriptor( Type.getType( Object.class ), Type.getType( Object.class ), Type.getType( Object.class ) ),
+		    true ) );
+
+		// put() returns the previous value; discard it unless a value is expected
+		if ( returnContext != ReturnValueContext.VALUE && returnContext != ReturnValueContext.VALUE_OR_NULL ) {
+			nodes.add( new InsnNode( Opcodes.POP ) );
+		}
+
+		return nodes;
+	}
+
+	/**
+	 * Transform a top-level function declaration as a hoisted UDF registration (original behavior).
+	 */
+	private List<AbstractInsnNode> transformTopLevelFunction( BoxFunctionDeclaration function, TransformerContext context,
+	    ReturnValueContext returnContext ) {
+		TransformerContext safe = function.getName().equalsIgnoreCase( "isnull" ) ? TransformerContext.SAFE : context;
+
+		if ( transpiler.hasCompiledFunction( function.getName() ) ) {
+			if ( transpiler.getProperty( "sourceType" ).equals( BoxSourceType.BOXSCRIPT.name() )
+			    || transpiler.getProperty( "sourceType" ).equals( BoxSourceType.BOXTEMPLATE.name() ) ) {
+				throw new IllegalStateException( "Cannot define multiple functions with the same name: " + function.getName() );
+			} else {
+				ArrayList<AbstractInsnNode> blankResult = new ArrayList<>();
+
+				if ( returnContext == ReturnValueContext.VALUE || returnContext == ReturnValueContext.VALUE_OR_NULL ) {
+					blankResult.add( new InsnNode( Opcodes.ACONST_NULL ) );
+				}
+
+				return blankResult;
+			}
+
+		}
+
+		BoxReturnType	boxReturnType	= function.getType();
+		BoxType			returnType		= BoxType.Any;
+		String			fqn				= null;
+		if ( boxReturnType != null ) {
+			returnType = boxReturnType.getType();
+			if ( returnType.equals( BoxType.Fqn ) ) {
+				fqn = boxReturnType.getFqn();
+			}
+		}
+		String				returnTypeName		= returnType.equals( BoxType.Fqn ) ? fqn : returnType.name();
+
+		BoxAccessModifier	access				= function.getAccessModifier() == null ? BoxAccessModifier.Public : function.getAccessModifier();
+
+		String				invokerMethodName	= IBoxpiler.INVOKE_FUNCTION_PREFIX + IBoxpiler.sanitizeForJavaIdentifier( function.getName() );
+
+		Type				declaringType		= Type.getType( "L" + transpiler.getProperty( "packageName" ).replace( '.', '/' )
+		    + "/" + transpiler.getProperty( "classname" )
+		    + ";" );
+
+		ClassNode			owningClass			= transpiler.getOwningClass();
+
+		transpiler.markFunctionCompiled( function.getName() );
+		transpiler.incrementfunctionBodyCounter();
+		AsmHelper.methodWithContextAndClassLocator( owningClass, invokerMethodName, Type.getType( FunctionBoxContext.class ), Type.getType( Object.class ),
+		    true,
+		    transpiler, true,
+		    () -> {
+
+			    if ( function.getBody() == null ) {
+				    return new ArrayList<AbstractInsnNode>();
+			    }
+
+			    return function.getBody()
+			        .stream()
+			        .flatMap( statement -> transpiler.transform( statement, safe, ReturnValueContext.EMPTY ).stream() )
+			        .collect( Collectors.toList() );
+		    } );
+		transpiler.decrementfunctionBodyCounter();
+
+		List<AbstractInsnNode> instantiation = new ArrayList<>();
+
+		instantiation.add( new TypeInsnNode( Opcodes.NEW, Type.getInternalName( UDF.class ) ) );
+		instantiation.add( new InsnNode( Opcodes.DUP ) );
+
+		instantiation.addAll( transpiler.createKey( function.getName() ) );
+
+		instantiation.addAll(
+		    AsmHelper.array( Type.getType( Argument.class ), function.getArgs(), ( arg, i ) -> transpiler.transform( arg, safe ) )
+		);
+
+		instantiation.add( new LdcInsnNode( returnTypeName ) );
+
+		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    Type.getInternalName( Function.Access.class ),
+		    access.name().toUpperCase(),
+		    Type.getDescriptor( Function.Access.class ) ) );
+
+		instantiation.addAll( transpiler.transformAnnotations( function.getAnnotations() ) );
+
+		instantiation.addAll( transpiler.transformDocumentation( function.getDocumentation() ) );
+
+		instantiation.addAll(
+		    AsmHelper.array(
+		        Type.getType( BoxMethodDeclarationModifier.class ),
+		        function.getModifiers(),
+		        ( bmdm, i ) -> List.of(
+		            new FieldInsnNode(
+		                Opcodes.GETSTATIC,
+		                Type.getInternalName( BoxMethodDeclarationModifier.class ),
+		                bmdm.toString().toUpperCase(),
+		                Type.getDescriptor( BoxMethodDeclarationModifier.class )
+		            )
+		        )
+		    )
+		);
+		instantiation.add( new MethodInsnNode( Opcodes.INVOKESTATIC,
+		    Type.getInternalName( List.class ),
+		    "of",
+		    Type.getMethodDescriptor( Type.getType( List.class ), Type.getType( Object[].class ) ),
+		    true ) );
+
+		instantiation.add( new InsnNode( shouldDefaultOutput( function ) ? Opcodes.ICONST_1 : Opcodes.ICONST_0 ) );
+
+		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    declaringType.getInternalName(), "imports", Type.getDescriptor( List.class ) ) );
+
+		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    declaringType.getInternalName(), "sourceType", Type.getDescriptor( BoxSourceType.class ) ) );
+
+		instantiation.add( new FieldInsnNode( Opcodes.GETSTATIC,
+		    declaringType.getInternalName(), "path", Type.getDescriptor( ResolvedFilePath.class ) ) );
+
+		instantiation.add( new InvokeDynamicInsnNode(
+		    "apply",
+		    "()Ljava/util/function/Function;",
+		    new Handle(
+		        Opcodes.H_INVOKESTATIC,
+		        "java/lang/invoke/LambdaMetafactory",
+		        "metafactory",
+		        "(Ljava/lang/invoke/MethodHandles$Lookup;"
+		            + "Ljava/lang/String;"
+		            + "Ljava/lang/invoke/MethodType;"
+		            + "Ljava/lang/invoke/MethodType;"
+		            + "Ljava/lang/invoke/MethodHandle;"
+		            + "Ljava/lang/invoke/MethodType;)"
+		            + "Ljava/lang/invoke/CallSite;",
+		        false
+		    ),
+		    Type.getMethodType( "(Ljava/lang/Object;)Ljava/lang/Object;" ),
+		    new Handle(
+		        Opcodes.H_INVOKESTATIC,
+		        declaringType.getInternalName(),
+		        invokerMethodName,
+		        "(Lortus/boxlang/runtime/context/FunctionBoxContext;)Ljava/lang/Object;",
+		        false
+		    ),
+		    Type.getMethodType( "(Lortus/boxlang/runtime/context/FunctionBoxContext;)Ljava/lang/Object;" )
+		) );
+
 		instantiation.add( new MethodInsnNode( Opcodes.INVOKESPECIAL,
 		    Type.getInternalName( UDF.class ),
 		    "<init>",
@@ -258,16 +481,10 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		    ),
 		    false ) );
 
-		// Store the UDF instantiation bytecode in the transpiler for later clinit population
 		transpiler.getUDFInstantiations().put( Key.of( function.getName() ), instantiation );
 
-		// Generate registration bytecode: context.registerUDF( udfs.get( Key.of("name") ) )
-		// NOTE: Do NOT add loadCurrentContext() here. The registration nodes may be generated inside a
-		// static component body method (e.g., componentBody_N) but consumed inside the non-static _invoke method,
-		// which has a different context slot. The context loading is deferred to getUDFRegistrations().
 		List<AbstractInsnNode> registrationNodes = new ArrayList<>();
 
-		// udfs.get( Key.of("name") )
 		registrationNodes.add( new FieldInsnNode( Opcodes.GETSTATIC,
 		    declaringType.getInternalName(),
 		    "udfs",
@@ -280,7 +497,6 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		    true ) );
 		registrationNodes.add( new TypeInsnNode( Opcodes.CHECKCAST, Type.getInternalName( UDF.class ) ) );
 
-		// context.registerUDF( udf )
 		registrationNodes.add(
 		    new MethodInsnNode( Opcodes.INVOKEINTERFACE,
 		        Type.getInternalName( IBoxContext.class ),
@@ -295,8 +511,6 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		}
 
 		if ( function.getModifiers().contains( BoxMethodDeclarationModifier.STATIC ) ) {
-			// Static UDF registrations are returned inline (not deferred), so they need
-			// context loading from the current (correct) tracker right here.
 			List<AbstractInsnNode> staticResult = new ArrayList<>();
 			staticResult.addAll( transpiler.getCurrentMethodContextTracker().get().loadCurrentContext() );
 			staticResult.addAll( registrationNodes );
@@ -313,7 +527,6 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 	}
 
 	private boolean shouldDefaultOutput( BoxFunctionDeclaration function ) {
-		// If the closest ancestor is a script, then the default output is true
 		@SuppressWarnings( "unchecked" )
 		BoxNode	ancestor		= function.getFirstNodeOfTypes( BoxTemplate.class, BoxScript.class, BoxExpression.class, BoxScriptIsland.class,
 		    BoxTemplateIsland.class );

--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -80,7 +80,7 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 	// @formatter:on
 	@Override
 	public List<AbstractInsnNode> transform( BoxNode node, TransformerContext context, ReturnValueContext returnContext ) throws IllegalStateException {
-		BoxFunctionDeclaration	function	= ( BoxFunctionDeclaration ) node;
+		BoxFunctionDeclaration function = ( BoxFunctionDeclaration ) node;
 
 		if ( isNestedFunction( function ) ) {
 			return transformNestedFunction( function, context, returnContext );
@@ -116,18 +116,18 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 				fqn = boxReturnType.getFqn();
 			}
 		}
-		String				returnTypeName		= returnType.equals( BoxType.Fqn ) ? fqn : returnType.name();
-		BoxAccessModifier	access				= function.getAccessModifier() == null ? BoxAccessModifier.Public : function.getAccessModifier();
+		String				returnTypeName	= returnType.equals( BoxType.Fqn ) ? fqn : returnType.name();
+		BoxAccessModifier	access			= function.getAccessModifier() == null ? BoxAccessModifier.Public : function.getAccessModifier();
 
-		int					closureIndex		= transpiler.getClosureInstantiations().size();
+		int					closureIndex	= transpiler.getClosureInstantiations().size();
 		transpiler.getClosureInstantiations().add( null );
-		String				invokerMethodName	= "invokeClosure_" + closureIndex;
+		String		invokerMethodName	= "invokeClosure_" + closureIndex;
 
-		Type				declaringType		= Type.getType( "L" + transpiler.getProperty( "packageName" ).replace( '.', '/' )
+		Type		declaringType		= Type.getType( "L" + transpiler.getProperty( "packageName" ).replace( '.', '/' )
 		    + "/" + transpiler.getProperty( "classname" )
 		    + ";" );
 
-		ClassNode			owningClass			= transpiler.getOwningClass();
+		ClassNode	owningClass			= transpiler.getOwningClass();
 
 		// Generate the static invoker method for the nested function body
 		transpiler.incrementfunctionBodyCounter();

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -156,9 +156,11 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		}
 
 		@SuppressWarnings( "unchecked" )
-		BoxNode				ancestor		= function.getFirstNodeOfTypes( BoxTemplate.class, BoxScript.class, BoxExpression.class, BoxScriptIsland.class,
+		BoxNode										ancestor			= function.getFirstNodeOfTypes( BoxTemplate.class, BoxScript.class, BoxExpression.class,
+		    BoxScriptIsland.class,
 		    BoxTemplateIsland.class );
-		boolean				defaultOutput	= ancestor == null || !Set.of( BoxTemplate.class, BoxTemplateIsland.class ).contains( ancestor.getClass() );
+		boolean										defaultOutput		= ancestor == null
+		    || !Set.of( BoxTemplate.class, BoxTemplateIsland.class ).contains( ancestor.getClass() );
 
 		int											closureIndex		= transpiler.incrementAndGetClosureCounter();
 		String										invokerMethodName	= "invokeClosure_" + closureIndex;
@@ -167,7 +169,7 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		int											mySlot				= closureInvokers.size();
 		closureInvokers.add( null );
 
-		Map<String, String>	values			= Map.ofEntries(
+		Map<String, String>				values	= Map.ofEntries(
 		    Map.entry( "className", className ),
 		    Map.entry( "access", access.toString().toUpperCase() ),
 		    Map.entry( "modifiers", transformModifiers( function.getModifiers() ) ),
@@ -239,11 +241,11 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 	 * Transform a top-level function declaration as a hoisted UDF registration (original behavior).
 	 */
 	private Node transformTopLevelFunction( BoxFunctionDeclaration function, TransformerContext context ) {
-		BoxAccessModifier		access			= function.getAccessModifier();
-		String					className		= transpiler.getProperty( "classname" );
-		BoxReturnType			boxReturnType	= function.getType();
-		BoxType					returnType		= BoxType.Any;
-		String					fqn				= null;
+		BoxAccessModifier	access			= function.getAccessModifier();
+		String				className		= transpiler.getProperty( "classname" );
+		BoxReturnType		boxReturnType	= function.getType();
+		BoxType				returnType		= BoxType.Any;
+		String				fqn				= null;
 		if ( boxReturnType != null ) {
 			returnType = boxReturnType.getType();
 			if ( returnType.equals( BoxType.Fqn ) ) {

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/transformer/statement/BoxFunctionDeclarationTransformer.java
@@ -38,6 +38,8 @@ import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
 import ortus.boxlang.compiler.ast.BoxStatement;
 import ortus.boxlang.compiler.ast.BoxTemplate;
+import ortus.boxlang.compiler.ast.expression.BoxClosure;
+import ortus.boxlang.compiler.ast.expression.BoxLambda;
 import ortus.boxlang.compiler.ast.statement.BoxAccessModifier;
 import ortus.boxlang.compiler.ast.statement.BoxFunctionDeclaration;
 import ortus.boxlang.compiler.ast.statement.BoxMethodDeclarationModifier;
@@ -54,7 +56,9 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.util.Pair;
 
 /**
- * Transform a Function Declaration in the equivalent Java Parser AST nodes
+ * Transform a Function Declaration in the equivalent Java Parser AST nodes.
+ * Supports both top-level UDF declarations (hoisted) and nested function declarations
+ * inside other functions/closures (compiled as closures and assigned to the local scope).
  */
 public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 
@@ -79,6 +83,23 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 			
  	""";
 
+	private String nestedInstantiationTemplate = """
+		new ClosureDefinition(
+			${functionName},
+			null,
+			"${returnType}",
+			Function.Access.${access},
+			null,
+			null,
+			List.of( ${modifiers} ),
+			${defaultOutput},
+			imports,
+			sourceType,
+			path,
+			${className}::${invokerMethodName}
+		)
+ 	""";
+
 	private String invokerTemplate = """
 		private static Object ${invokerMethodName}( FunctionBoxContext context ) {
 			ClassLocator classLocator = ClassLocator.getInstance();
@@ -86,13 +107,138 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		}
  	""";
 
+	private String nestedRegistrationTemplate =
+		"${contextName}.getScopeNearby( LocalScope.name, false ).put( ${functionName}, closures.get(${closureIndex}).newInstance(${contextName}) );";
+
 	public BoxFunctionDeclarationTransformer(JavaTranspiler transpiler) {
     	super(transpiler);
     }
 	// @formatter:on
 	@Override
 	public Node transform( BoxNode node, TransformerContext context ) throws IllegalStateException {
-		BoxFunctionDeclaration	function		= ( BoxFunctionDeclaration ) node;
+		BoxFunctionDeclaration function = ( BoxFunctionDeclaration ) node;
+
+		if ( isNestedFunction( function ) ) {
+			return transformNestedFunction( function, context );
+		}
+
+		return transformTopLevelFunction( function, context );
+	}
+
+	/**
+	 * Detect if this function declaration is nested inside another function, closure, or lambda body.
+	 */
+	private boolean isNestedFunction( BoxFunctionDeclaration function ) {
+		return function.getFirstAncestorOfType( BoxFunctionDeclaration.class ) != null
+		    || function.getFirstAncestorOfType( BoxClosure.class ) != null
+		    || function.getFirstAncestorOfType( BoxLambda.class ) != null;
+	}
+
+	/**
+	 * Transform a nested function declaration as a named closure assigned to the parent's local scope.
+	 * The function is compiled as a ClosureDefinition and at runtime, a new Closure instance is
+	 * created (capturing the declaring context) and placed into the local scope under the function's name.
+	 */
+	private Node transformNestedFunction( BoxFunctionDeclaration function, TransformerContext context ) {
+		BoxAccessModifier	access			= function.getAccessModifier();
+		String				className		= transpiler.getProperty( "classname" );
+		BoxReturnType		boxReturnType	= function.getType();
+		BoxType				returnType		= BoxType.Any;
+		String				fqn				= null;
+		if ( boxReturnType != null ) {
+			returnType = boxReturnType.getType();
+			if ( returnType.equals( BoxType.Fqn ) ) {
+				fqn = boxReturnType.getFqn();
+			}
+		}
+		if ( access == null ) {
+			access = BoxAccessModifier.Public;
+		}
+
+		@SuppressWarnings( "unchecked" )
+		BoxNode				ancestor		= function.getFirstNodeOfTypes( BoxTemplate.class, BoxScript.class, BoxExpression.class, BoxScriptIsland.class,
+		    BoxTemplateIsland.class );
+		boolean				defaultOutput	= ancestor == null || !Set.of( BoxTemplate.class, BoxTemplateIsland.class ).contains( ancestor.getClass() );
+
+		int											closureIndex		= transpiler.incrementAndGetClosureCounter();
+		String										invokerMethodName	= "invokeClosure_" + closureIndex;
+
+		List<Pair<MethodDeclaration, Expression>>	closureInvokers		= ( ( JavaTranspiler ) transpiler ).getClosureInvokers();
+		int											mySlot				= closureInvokers.size();
+		closureInvokers.add( null );
+
+		Map<String, String>	values			= Map.ofEntries(
+		    Map.entry( "className", className ),
+		    Map.entry( "access", access.toString().toUpperCase() ),
+		    Map.entry( "modifiers", transformModifiers( function.getModifiers() ) ),
+		    Map.entry( "functionName", createKey( function.getName() ).toString() ),
+		    Map.entry( "invokerMethodName", invokerMethodName ),
+		    Map.entry( "returnType", returnType.equals( BoxType.Fqn ) ? fqn : returnType.name() ),
+		    Map.entry( "defaultOutput", String.valueOf( defaultOutput ) ),
+		    Map.entry( "closureIndex", String.valueOf( mySlot ) ),
+		    Map.entry( "contextName", transpiler.peekContextName() )
+		);
+
+		// ********************** Invoker method (function body) **********************
+
+		String							code	= PlaceholderHelper.resolve( invokerTemplate, values );
+		ParseResult<MethodDeclaration>	result;
+		try {
+			result = javaParser.parseMethodDeclaration( code );
+		} catch ( Exception e ) {
+			throw new BoxRuntimeException( code, e );
+		}
+		if ( !result.isSuccessful() ) {
+			throw new BoxRuntimeException( result + "\n" + code );
+		}
+
+		MethodDeclaration invokeMethod = result.getResult().orElseThrow();
+
+		transpiler.pushContextName( "context" );
+		transpiler.pushfunctionBodyCounter();
+		int componentCounter = transpiler.getComponentCounter();
+		transpiler.setComponentCounter( 0 );
+		for ( BoxStatement statement : function.getBody() ) {
+			Node javaStmt = transpiler.transform( statement );
+			if ( javaStmt instanceof BlockStmt stmt ) {
+				stmt.getStatements().forEach( it -> invokeMethod.getBody().get().addStatement( it ) );
+			} else {
+				invokeMethod.getBody().get().addStatement( ( Statement ) javaStmt );
+			}
+		}
+		transpiler.setComponentCounter( componentCounter );
+		transpiler.popfunctionBodyCounter();
+		invokeMethod.getBody().get().addStatement( new ReturnStmt( new NullLiteralExpr() ) );
+		transpiler.popContextName();
+
+		// ********************** ClosureDefinition instantiation **********************
+
+		ObjectCreationExpr		instantiationExpr	= ( ObjectCreationExpr ) parseExpression( nestedInstantiationTemplate, values );
+
+		ArrayInitializerExpr	argInitializer		= new ArrayInitializerExpr();
+		function.getArgs().forEach( arg -> {
+			Expression argument = ( Expression ) transpiler.transform( arg );
+			argInitializer.getValues().add( argument );
+		} );
+		ArrayCreationExpr argumentsArray = new ArrayCreationExpr()
+		    .setElementType( "Argument" )
+		    .setInitializer( argInitializer );
+		instantiationExpr.setArgument( 1, argumentsArray );
+
+		instantiationExpr.setArgument( 4, transformAnnotations( function.getAnnotations() ) );
+		instantiationExpr.setArgument( 5, transformDocumentation( function.getDocumentation() ) );
+
+		closureInvokers.set( mySlot, Pair.of( invokeMethod, instantiationExpr ) );
+
+		// ********************** Inline registration to local scope **********************
+
+		return parseStatement( nestedRegistrationTemplate, values );
+	}
+
+	/**
+	 * Transform a top-level function declaration as a hoisted UDF registration (original behavior).
+	 */
+	private Node transformTopLevelFunction( BoxFunctionDeclaration function, TransformerContext context ) {
 		BoxAccessModifier		access			= function.getAccessModifier();
 		String					className		= transpiler.getProperty( "classname" );
 		BoxReturnType			boxReturnType	= function.getType();
@@ -108,7 +254,6 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 			access = BoxAccessModifier.Public;
 		}
 
-		// If the closest ancestor is a script, then the default output is true
 		@SuppressWarnings( "unchecked" )
 		BoxNode				ancestor		= function.getFirstNodeOfTypes( BoxTemplate.class, BoxScript.class, BoxExpression.class, BoxScriptIsland.class,
 		    BoxTemplateIsland.class );
@@ -125,18 +270,14 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		);
 		transpiler.pushContextName( "context" );
 
-		// ********************** Registration template **********************
-
 		String							code	= PlaceholderHelper.resolve( invokerTemplate, values );
 		ParseResult<MethodDeclaration>	result;
 		try {
 			result = javaParser.parseMethodDeclaration( code );
 		} catch ( Exception e ) {
-			// Temp debugging to see generated Java code
 			throw new BoxRuntimeException( code, e );
 		}
 		if ( !result.isSuccessful() ) {
-			// Temp debugging to see generated Java code
 			throw new BoxRuntimeException( result + "\n" + code );
 		}
 
@@ -155,15 +296,11 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		}
 		transpiler.setComponentCounter( componentCounter );
 		transpiler.popfunctionBodyCounter();
-		// Ensure we have a return statement
 		invokeMethod.getBody().get().addStatement( new ReturnStmt( new NullLiteralExpr() ) );
 		transpiler.popContextName();
 
-		// ********************** UDF Instantiation template **********************
-
 		ObjectCreationExpr		instantiationExpr	= ( ObjectCreationExpr ) parseExpression( instantiationTemplate, values );
 
-		/* Transform the arguments creating the initialization values */
 		ArrayInitializerExpr	argInitializer		= new ArrayInitializerExpr();
 		function.getArgs().forEach( arg -> {
 			Expression argument = ( Expression ) transpiler.transform( arg );
@@ -174,28 +311,18 @@ public class BoxFunctionDeclarationTransformer extends AbstractTransformer {
 		    .setInitializer( argInitializer );
 		instantiationExpr.setArgument( 1, argumentsArray );
 
-		/* Transform the annotations creating the initialization value */
 		instantiationExpr.setArgument( 4, transformAnnotations( function.getAnnotations() ) );
-
-		/* Transform the documentation creating the initialization value */
 		instantiationExpr.setArgument( 5, transformDocumentation( function.getDocumentation() ) );
 
 		( ( JavaTranspiler ) transpiler ).getUDFInvokers().put( Key.of( function.getName() ), Pair.of( invokeMethod, instantiationExpr ) );
 
-		// ********************** Registration template **********************
-
 		Statement javaStmt = parseStatement( registrationTemplate, values );
-		// logger.trace( node.getSourceText() + " -> " + javaStmt );
-		// commenting this out to prevent BoxFunctionDeclarationTransformer nodes in the SourceMaps
-		// This caused the debugger's stepping behavior to hit locations it shouldn't be stopping on
-		// addIndex( javaStmt, node );
 		if ( function.getModifiers().contains( BoxMethodDeclarationModifier.STATIC ) ) {
 			( ( JavaTranspiler ) transpiler ).getStaticUDFDeclarations().add( javaStmt );
 		} else {
 			( ( JavaTranspiler ) transpiler ).getUDFDeclarations().add( javaStmt );
 		}
 
-		// The actual declaration is hoisted to the top, so I just need a dummy node to return here
 		return new EmptyStmt();
 	}
 

--- a/src/test/java/TestCases/phase2/NestedFunctionTest.java
+++ b/src/test/java/TestCases/phase2/NestedFunctionTest.java
@@ -1,0 +1,284 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package TestCases.phase2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.Closure;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+public class NestedFunctionTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "basic nested function declaration and invocation" )
+	@Test
+	public void testBasicNestedFunction() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        function inner() {
+		            return "from inner";
+		        }
+		        return inner();
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "from inner" );
+	}
+
+	@DisplayName( "nested function with arguments" )
+	@Test
+	public void testNestedFunctionWithArguments() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        function addSomething( var1, var2 ) {
+		            var1 &= "inside something";
+		            return var1;
+		        }
+		        var xml = "Outside ";
+		        return addSomething( xml, 2 );
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "Outside inside something" );
+	}
+
+	@DisplayName( "nested function can access parent local variables (closure behavior)" )
+	@Test
+	public void testNestedFunctionClosureAccess() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        var outerVar = "hello from outer";
+		        function inner() {
+		            return outerVar;
+		        }
+		        return inner();
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "hello from outer" );
+	}
+
+	@DisplayName( "nested function sees updated parent variables" )
+	@Test
+	public void testNestedFunctionSeesUpdatedVars() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        var x = "initial";
+		        function inner() {
+		            return x;
+		        }
+		        x = "updated";
+		        return inner();
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "updated" );
+	}
+
+	@DisplayName( "nested function accessible via local scope" )
+	@Test
+	public void testNestedFunctionInLocalScope() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        function inner() {
+		            return "hi";
+		        }
+		        return local.inner;
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( Closure.class );
+	}
+
+	@DisplayName( "nested function is not visible outside parent" )
+	@Test
+	public void testNestedFunctionNotVisibleOutside() {
+		assertThrows( BoxRuntimeException.class, () -> {
+			instance.executeSource(
+			    """
+			    function outer() {
+			        function inner() {
+			            return "hi";
+			        }
+			    }
+			    outer();
+			    inner();
+			    """,
+			    context );
+		} );
+	}
+
+	@DisplayName( "multiple nested functions" )
+	@Test
+	public void testMultipleNestedFunctions() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        function add( a, b ) {
+		            return a + b;
+		        }
+		        function multiply( a, b ) {
+		            return a * b;
+		        }
+		        return add( 3, 4 ) & ":" & multiply( 3, 4 );
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "7:12" );
+	}
+
+	@DisplayName( "doubly nested functions" )
+	@Test
+	public void testDoublyNestedFunctions() {
+		instance.executeSource(
+		    """
+		    function outer() {
+		        var x = "A";
+		        function middle() {
+		            var y = "B";
+		            function inner() {
+		                return x & y;
+		            }
+		            return inner();
+		        }
+		        return middle();
+		    }
+		    result = outer();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "AB" );
+	}
+
+	@DisplayName( "each call to parent creates independent inner function" )
+	@Test
+	public void testIndependentPerInvocation() {
+		instance.executeSource(
+		    """
+		    function makeCounter( start ) {
+		        var count = start;
+		        function increment() {
+		            count++;
+		            return count;
+		        }
+		        return increment();
+		    }
+		    result = makeCounter( 10 );
+		    result2 = makeCounter( 20 );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( 11 );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isEqualTo( 21 );
+	}
+
+	@DisplayName( "Jira example: function inception" )
+	@Test
+	public void testJiraExample() {
+		instance.executeSource(
+		    """
+		    function test() {
+		        var xml = "Outside ";
+
+		        function addSomething( var1, var2 ) {
+		            var1 &= "inside something";
+		            return var1;
+		        }
+
+		        variables.result2 = local.addSomething;
+		        variables.result = addSomething( xml, 2 );
+		    }
+		    test();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "Outside inside something" );
+		assertThat( variables.get( Key.of( "result2" ) ) ).isInstanceOf( Closure.class );
+	}
+
+	@DisplayName( "nested function inside closure" )
+	@Test
+	public void testNestedFunctionInsideClosure() {
+		instance.executeSource(
+		    """
+		    myClosure = function() {
+		        var prefix = "Hello ";
+		        function greet( name ) {
+		            return prefix & name;
+		        }
+		        return greet( "World" );
+		    };
+		    result = myClosure();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "Hello World" );
+	}
+
+	@DisplayName( "nested function inside arrow function" )
+	@Test
+	public void testNestedFunctionInsideArrow() {
+		instance.executeSource(
+		    """
+		    myArrow = () => {
+		        var prefix = "Hi ";
+		        function greet( name ) {
+		            return prefix & name;
+		        }
+		        return greet( "There" );
+		    };
+		    result = myArrow();
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isEqualTo( "Hi There" );
+	}
+}


### PR DESCRIPTION
# Description

**Summary**
- Implemented support for nested function declarations in BoxLang so that functions defined inside other functions/closures/arrows behave correctly. 
-  Added JUnit tests in **NestedFunctionTest.java** to cover basic invocation, closures, visibility, and interactions with closures and arrow functions.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL-1961

## Type of change

Please delete options that are not relevant.



- [x] New Feature

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Contributors from Florida International University**
@Mario-Recondo - Core implementation, research and testing.
@fabianneO82 - Core implementation, research and testing.

[Boxlang BL-1961 PR Doc.pdf](https://github.com/user-attachments/files/25978841/Boxlang.BL-1961.PR.Doc.pdf)
