### PR TITLE
BL-2374 - Evict cache upon negative-length cache timeout

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -580,10 +580,14 @@ public class PendingQuery {
 	 * @see ExecutedQuery
 	 */
 	public @NonNull ExecutedQuery execute( ConnectionManager connectionManager, IBoxContext context ) {
-		// We do an early cache check here to avoid the overhead of creating a
-		// connection if we already have a matching cached query.
-		if ( isCacheable() ) {
-
+		if ( shouldEvictFromCache() ) {
+			if ( logger.isDebugEnabled() ) {
+				logger.debug( "Evicting cache for query: {} due to negative cache timeout", this.cacheKey );
+			}
+			this.cacheProvider.clear( this.cacheKey );
+		} else if ( isCacheable() ) {
+			// We do an early cache check here to avoid the overhead of creating a
+			// connection if we already have a matching cached query.
 			if ( logger.isDebugEnabled() ) {
 				logger.debug( "Checking cache for query: {}", this.cacheKey );
 			}
@@ -625,7 +629,12 @@ public class PendingQuery {
 	 */
 	public @NonNull ExecutedQuery execute( BoxConnection connection, IBoxContext context ) {
 		this.datasource = connection.getDataSource();
-		if ( isCacheable() ) {
+		if ( shouldEvictFromCache() ) {
+			if ( logger.isDebugEnabled() ) {
+				logger.debug( "Evicting cache for query: {} due to negative cache timeout", this.cacheKey );
+			}
+			this.cacheProvider.clear( this.cacheKey );
+		} else if ( isCacheable() ) {
 			// we use separate get() and set() calls over a .getOrSet() so we can run
 			// `.setIsCached()` on discovered/cached results.
 			Attempt<Object> cachedQuery = this.cacheProvider.get( this.cacheKey );
@@ -978,5 +987,13 @@ public class PendingQuery {
 	private Boolean isCacheable() {
 		return Boolean.TRUE.equals( this.queryOptions.cache )
 		    && ( this.queryOptions.cacheTimeout == null || !this.queryOptions.cacheTimeout.isNegative() );
+	}
+
+	/**
+	 * Check if the query should be evicted from cache, which is the case when
+	 * `cacheTimeout` is negative.
+	 */
+	private boolean shouldEvictFromCache() {
+		return this.queryOptions.cacheTimeout != null && this.queryOptions.cacheTimeout.isNegative();
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -794,6 +794,7 @@ public class PendingQuery {
 		// We set the metadata on the results to indicate this was a cached query
 		Query	results		= cachedQuery
 		    .getResults()
+		    .duplicate( context )
 		    .setMetadata( cacheMeta );
 
 		// Return a new ExecutedQuery instance with the cached results and generated key

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -788,6 +788,107 @@ public class QueryExecuteTest extends BaseJDBCTest {
 		assertThat( variables.getAsStruct( result ).getAsBoolean( Key.cached ) ).isEqualTo( false );
 	}
 
+	@DisplayName( "It clears cache entries on negative timeout" )
+	@Test
+	public void testNegativeCacheTimeoutClearsCache() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			result = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+				"cache"       : true,
+				"cacheTimeout": createTimespan( 0, 0, 0, 1 ),
+				"result"      : "queryMeta"
+			} );
+
+			// second query with positive timeout - is cached, returns cached result
+			result2 = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+				"cache"       : true,
+				"cacheTimeout": createTimespan( 0, 0, 0, 1 ),
+				"result"      : "queryMeta2"
+			} );
+
+			// third query with zero timeout - is cached, returns cached result (zero timeout treated as infinite)
+			result3 = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+				"cache"       : true,
+				"cacheTimeout": createTimespan( 0, 0, 0, 0 ),
+				"result"      : "zeroTimeoutQueryMeta"
+			} );
+
+			// fourth query with negative timeout - cache is cleared, result is not cached
+			result4 = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+				"cache"       : true,
+				"cacheTimeout": createTimespan( 0, 0, 0, -1 ),
+				"result"      : "negativeTimeoutQueryMeta"
+			} );
+
+            // fifth query with positive timeout - first hit since negative timeout cleared the cache
+            result5 = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+                "cache"       : true,
+                "cacheTimeout": createTimespan( 0, 0, 0, 1 ),
+                "result"      : "queryMeta5"
+            } );
+
+            // sixth query with positive timeout - first hit since negative timeout cleared the cache
+            result6 = queryExecute( "SELECT CURRENT_TIMESTAMP as timestamp FROM developers", [], {
+                "cache"       : true,
+                "cacheTimeout": createTimespan( 0, 0, 0, 1 ),
+                "result"      : "queryMeta6"
+            } );
+           """,
+        context );
+    // @formatter:on
+
+		IStruct	queryMeta1	= variables.getAsStruct( Key.of( "queryMeta" ) );
+		IStruct	queryMeta2	= variables.getAsStruct( Key.of( "queryMeta2" ) );
+		IStruct	queryMeta3	= variables.getAsStruct( Key.of( "zeroTimeoutQueryMeta" ) );
+		IStruct	queryMeta4	= variables.getAsStruct( Key.of( "negativeTimeoutQueryMeta" ) );
+		IStruct	queryMeta5	= variables.getAsStruct( Key.of( "queryMeta5" ) );
+		IStruct	queryMeta6	= variables.getAsStruct( Key.of( "queryMeta6" ) );
+
+		Key		timestamp	= Key.of( "timestamp" );
+		Key		result2		= Key.of( "result2" );
+		Key		result3		= Key.of( "result3" );
+		Key		result4		= Key.of( "result4" );
+		Key		result5		= Key.of( "result5" );
+		Key		result6		= Key.of( "result6" );
+
+		Object	date1		= variables.getAsQuery( result ).getRowAsStruct( 0 ).get( timestamp );
+		Object	date2		= variables.getAsQuery( result2 ).getRowAsStruct( 0 ).get( timestamp );
+		Object	date3		= variables.getAsQuery( result3 ).getRowAsStruct( 0 ).get( timestamp );
+		Object	date4		= variables.getAsQuery( result4 ).getRowAsStruct( 0 ).get( timestamp );
+		Object	date5		= variables.getAsQuery( result5 ).getRowAsStruct( 0 ).get( timestamp );
+		Object	date6		= variables.getAsQuery( result6 ).getRowAsStruct( 0 ).get( timestamp );
+
+		// first query - cached (cold hit)
+		// This SHOULD be working, even without the negative timeout clearing cache entries. Seems broken in core.
+		assertThat( queryMeta1.getAsBoolean( Key.cached ) ).isFalse();
+
+		// second query with positive timeout - is cached, returns cached result
+		assertThat( queryMeta2.getAsBoolean( Key.cached ) ).isTrue();
+		assertThat( date2 ).isEqualTo( date1 );
+
+		// third query with zero timeout - is cached, returns cached result (zero timeout treated as infinite)
+		assertThat( queryMeta3.getAsBoolean( Key.cached ) ).isTrue();
+		assertThat( date3 ).isEqualTo( date2 );
+		assertThat( date3 ).isEqualTo( date1 );
+
+		// fourth query with negative timeout - not cached, cache entry cleared
+		assertThat( queryMeta4.getAsBoolean( Key.cached ) ).isFalse();
+		// assertThat( date4 ).isNotEqualTo( date3 );
+
+		// fifth query with positive timeout - not cached (first hit since negative timeout cleared the cache)
+		// This asserts the previously cache entry is REMOVED when the negative timeout is encountered.
+		assertThat( queryMeta5.getAsBoolean( Key.cached ) ).isFalse();
+		// assertThat( date5 ).isNotEqualTo( date4 );
+		// should have a different time from the ORIGINAL cached query
+		// assertThat( date5 ).isNotEqualTo( date1 );
+
+		// sixth query with positive timeout - second hit since negative timeout cleared the cache
+		assertThat( queryMeta6.getAsBoolean( Key.cached ) ).isTrue();
+		// assertThat( date6 ).isNotEqualTo( date5 );
+		// assertThat( date6 ).isNotEqualTo( date1 );
+	}
+
 	@DisplayName( "It can properly handle duplicate column names in the result set" )
 	@Test
 	public void testDuplicateColumnResultSets() {

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -712,35 +712,57 @@ public class QueryExecuteTest extends BaseJDBCTest {
 	@DisplayName( "It properly sets query results with cache metadata" )
 	@Test
 	public void testCacheResultMeta() {
+		// @formatter:off
 		instance.executeSource(
 		    """
-		    queryExecute(
-		    	"SELECT * FROM developers WHERE role = ?",
-		    	[ 'Admin' ],
-		    	{ "cache" : true, "cacheProvider" : "default", "cacheKey": "adminDevs", "cacheTimeout": createTimespan( 0, 1, 0, 0 ), "cacheLastAccessTimeout": createTimespan( 0, 0, 30, 0 ) }
-		    );
-		    result = queryExecute(
-		    	"SELECT * FROM developers WHERE role = ?",
-		    	[ 'Admin' ],
-		    	 { "result": "queryResults", "cache" : true, "cacheProvider" : "default", "cacheKey": "adminDevs", "cacheTimeout": createTimespan( 0, 1, 0, 0 ), "cacheLastAccessTimeout": createTimespan( 0, 0, 30, 0 ) }
-		    );
-		    """,
+		     result = queryExecute(
+		      	"SELECT * FROM developers WHERE role = ?",
+		      	[ 'Admin' ],
+		      	{
+					"cache"                 : true,
+					"cacheProvider"         : "default",
+					"cacheKey"              : "adminDevs",
+					"cacheTimeout"          : createTimespan( 0, 1, 0, 0 ),
+					"cacheLastAccessTimeout": createTimespan( 0, 0, 30, 0 ),
+					"result"                : "queryMeta"
+				}
+		      );
+		      result2 = queryExecute(
+		      	"SELECT * FROM developers WHERE role = ?",
+		      	[ 'Admin' ],
+				{
+					"cache"                 : true,
+					"cacheProvider"         : "default",
+					"cacheKey"              : "adminDevs",
+					"cacheTimeout"          : createTimespan( 0, 1, 0, 0 ),
+					"cacheLastAccessTimeout": createTimespan( 0, 0, 30, 0 ),
+					"result"                : "queryMeta2"
+				}
+		      );
+		      """,
 		    context );
-		Object resultObject = variables.get( Key.of( "queryResults" ) );
+		// @formatter:on
+		Object	resultObject	= variables.get( Key.of( "queryMeta" ) );
+		Object	resultObject2	= variables.get( Key.of( "queryMeta2" ) );
 		assertInstanceOf( IStruct.class, resultObject );
-		IStruct result = ( IStruct ) resultObject;
+		assertInstanceOf( IStruct.class, resultObject2 );
 
-		assertThat( result ).containsKey( Key.cached );
-		assertThat( result ).containsKey( Key.cacheProvider );
-		assertThat( result ).containsKey( Key.cacheKey );
-		assertThat( result ).containsKey( Key.cacheTimeout );
-		assertThat( result ).containsKey( Key.cacheLastAccessTimeout );
+		IStruct	result	= ( IStruct ) resultObject;
+		IStruct	result2	= ( IStruct ) resultObject2;
+		assertThat( result.getAsBoolean( Key.cached ) ).isFalse();
+		assertThat( result2.getAsBoolean( Key.cached ) ).isTrue();
 
-		assertThat( result.getAsBoolean( Key.cached ) ).isEqualTo( true );
-		assertThat( result.getAsString( Key.cacheProvider ) ).isEqualTo( "default" );
-		assertThat( result.getAsString( Key.cacheKey ) ).isEqualTo( "adminDevs" );
-		assertThat( result.get( Key.cacheTimeout ) ).isEqualTo( Duration.ofHours( 1 ) );
-		assertThat( result.get( Key.cacheLastAccessTimeout ) ).isEqualTo( Duration.ofMinutes( 30 ) );
+		assertThat( result2 ).containsKey( Key.cached );
+		assertThat( result2 ).containsKey( Key.cacheProvider );
+		assertThat( result2 ).containsKey( Key.cacheKey );
+		assertThat( result2 ).containsKey( Key.cacheTimeout );
+		assertThat( result2 ).containsKey( Key.cacheLastAccessTimeout );
+
+		assertThat( result2.getAsBoolean( Key.cached ) ).isEqualTo( true );
+		assertThat( result2.getAsString( Key.cacheProvider ) ).isEqualTo( "default" );
+		assertThat( result2.getAsString( Key.cacheKey ) ).isEqualTo( "adminDevs" );
+		assertThat( result2.get( Key.cacheTimeout ) ).isEqualTo( Duration.ofHours( 1 ) );
+		assertThat( result2.get( Key.cacheLastAccessTimeout ) ).isEqualTo( Duration.ofMinutes( 30 ) );
 	}
 
 	@DisplayName( "It caches zero timeout as infinite" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -896,19 +896,19 @@ public class QueryExecuteTest extends BaseJDBCTest {
 
 		// fourth query with negative timeout - not cached, cache entry cleared
 		assertThat( queryMeta4.getAsBoolean( Key.cached ) ).isFalse();
-		assertThat( date4 ).isNotEqualTo( date3 );
+		// assertThat( date4 ).isNotEqualTo( date3 );
 
 		// fifth query with positive timeout - not cached (first hit since negative timeout cleared the cache)
 		// This asserts the previously cache entry is REMOVED when the negative timeout is encountered.
 		assertThat( queryMeta5.getAsBoolean( Key.cached ) ).isFalse();
-		assertThat( date5 ).isNotEqualTo( date4 );
+		// assertThat( date5 ).isNotEqualTo( date4 );
 		// should have a different time from the ORIGINAL cached query
-		assertThat( date5 ).isNotEqualTo( date1 );
+		// assertThat( date5 ).isNotEqualTo( date1 );
 
 		// sixth query with positive timeout - second hit since negative timeout cleared the cache
 		assertThat( queryMeta6.getAsBoolean( Key.cached ) ).isTrue();
 		assertThat( date6 ).isEqualTo( date5 );
-		assertThat( date6 ).isNotEqualTo( date1 );
+		// assertThat( date6 ).isNotEqualTo( date1 );
 	}
 
 	@DisplayName( "It can properly handle duplicate column names in the result set" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -896,19 +896,19 @@ public class QueryExecuteTest extends BaseJDBCTest {
 
 		// fourth query with negative timeout - not cached, cache entry cleared
 		assertThat( queryMeta4.getAsBoolean( Key.cached ) ).isFalse();
-		// assertThat( date4 ).isNotEqualTo( date3 );
+		assertThat( date4 ).isNotEqualTo( date3 );
 
 		// fifth query with positive timeout - not cached (first hit since negative timeout cleared the cache)
 		// This asserts the previously cache entry is REMOVED when the negative timeout is encountered.
 		assertThat( queryMeta5.getAsBoolean( Key.cached ) ).isFalse();
-		// assertThat( date5 ).isNotEqualTo( date4 );
+		assertThat( date5 ).isNotEqualTo( date4 );
 		// should have a different time from the ORIGINAL cached query
-		// assertThat( date5 ).isNotEqualTo( date1 );
+		assertThat( date5 ).isNotEqualTo( date1 );
 
 		// sixth query with positive timeout - second hit since negative timeout cleared the cache
 		assertThat( queryMeta6.getAsBoolean( Key.cached ) ).isTrue();
-		// assertThat( date6 ).isNotEqualTo( date5 );
-		// assertThat( date6 ).isNotEqualTo( date1 );
+		assertThat( date6 ).isEqualTo( date5 );
+		assertThat( date6 ).isNotEqualTo( date1 );
 	}
 
 	@DisplayName( "It can properly handle duplicate column names in the result set" )


### PR DESCRIPTION
# Description

* Fix [BL-2374](https://ortussolutions.atlassian.net/browse/BL-2374)
* Fix [BL-2392](https://ortussolutions.atlassian.net/browse/BL-2392)

## Jira Issues

* [BL-2374](https://ortussolutions.atlassian.net/browse/BL-2374)
* [BL-2392](https://ortussolutions.atlassian.net/browse/BL-2392)

## Type of change

- [x] Improvement


[BL-2374]: https://ortussolutions.atlassian.net/browse/BL-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-2392]: https://ortussolutions.atlassian.net/browse/BL-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-2374]: https://ortussolutions.atlassian.net/browse/BL-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-2392]: https://ortussolutions.atlassian.net/browse/BL-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ