### PR TITLE
JDBC - Allow user config to override enableNestedTransactions setting

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/ConnectionManager.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/ConnectionManager.java
@@ -78,6 +78,7 @@ public class ConnectionManager {
 	 * The DatasourceService instance
 	 */
 	private DatasourceService			datasourceService				= BoxRuntime.getInstance().getDataSourceService();
+
 	/**
 	 * Enable or disable support for nested transactions.
 	 */

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -414,7 +414,6 @@
 			//     // BoxLang class path that implements onEvent( eventStruct )
 			//     "listener": "app.listeners.HotReloadListener"
 			// },
-
 			// ----- Example 2: multiple paths with all options shown -----
 			// "asset-pipeline": {
 			//     "paths": [
@@ -448,10 +447,10 @@
 		// 	  "database": "test"
 		// }
 	},
-	// If enabled, this will treat nested transactional operations as savepoints on the parent transaction.
-	// If disabled, nested transactions will be ignored and all commits and rollbacks will apply to the entire transaction.
-	// Defaults to true, handled in the Transaction component.
-	// "enableNestedTransactions": true,
+	// If true, this will treat nested transactional operations as savepoints on the parent transaction.
+	// If false, nested transactions will be ignored and all commits and rollbacks will apply to the entire transaction.
+	// Defaulted to true in the Transaction component, or false with bx-compat installed.
+	"enableNestedTransactions": null,
 	// The default return format for class invocations via web runtimes
 	"defaultRemoteMethodReturnFormat": "json",
 	/**

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -450,7 +450,8 @@
 	},
 	// If enabled, this will treat nested transactional operations as savepoints on the parent transaction.
 	// If disabled, nested transactions will be ignored and all commits and rollbacks will apply to the entire transaction.
-	"enableNestedTransactions": true,
+	// Defaults to true, handled in the Transaction component.
+	// "enableNestedTransactions": true,
 	// The default return format for class invocations via web runtimes
 	"defaultRemoteMethodReturnFormat": "json",
 	/**


### PR DESCRIPTION
Set to `null` by default, apply default only if null. Then `bx-compat` will also only apply override if no other override set.