### PR TITLE
fix(formatter): preserve required semicolons when semicolons config is false

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/prettyprint/ComponentPrinter.java
+++ b/src/main/java/ortus/boxlang/compiler/prettyprint/ComponentPrinter.java
@@ -107,7 +107,7 @@ public class ComponentPrinter {
 		if ( hasBody ) {
 			visitor.helperPrinter.printBlock( node, node.getBody() );
 		} else {
-			visitor.printSemicolon();
+			visitor.print( ";" );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/prettyprint/Visitor.java
+++ b/src/main/java/ortus/boxlang/compiler/prettyprint/Visitor.java
@@ -124,6 +124,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 public class Visitor extends VoidBoxVisitor {
 
 	private Stack<BoxSourceType>	currentSourceType				= new Stack<>();
+	private BoxSourceType			rootSourceType;
 	private Stack<Doc>				docStack						= new Stack<>();
 
 	Config							config;
@@ -148,7 +149,8 @@ public class Visitor extends VoidBoxVisitor {
 	 * @param config     The configuration for printing
 	 */
 	public Visitor( BoxSourceType sourceType, Config config ) {
-		this.config = config;
+		this.rootSourceType	= sourceType;
+		this.config			= config;
 		currentSourceType.push( sourceType );
 		pushDoc( DocType.ARRAY );
 
@@ -178,6 +180,10 @@ public class Visitor extends VoidBoxVisitor {
 			case BOXTEMPLATE, CFTEMPLATE -> true;
 			default -> false;
 		};
+	}
+
+	boolean isCF() {
+		return rootSourceType.isCFType();
 	}
 
 	Doc getCurrentDoc() {
@@ -1242,7 +1248,11 @@ public class Visitor extends VoidBoxVisitor {
 				print( " " );
 				print( node.getLabel() );
 			}
-			printSemicolon();
+			if ( isCF() ) {
+				print( ";" );
+			} else {
+				printSemicolon();
+			}
 		}
 		printPostComments( node );
 	}
@@ -1268,7 +1278,11 @@ public class Visitor extends VoidBoxVisitor {
 				print( " " );
 				print( node.getLabel() );
 			}
-			printSemicolon();
+			if ( isCF() ) {
+				print( ";" );
+			} else {
+				printSemicolon();
+			}
 		}
 		printPostComments( node );
 	}
@@ -1500,9 +1514,7 @@ public class Visitor extends VoidBoxVisitor {
 					anno.getValue().accept( this );
 				}
 			}
-			if ( config.getSemicolons() ) {
-				propDoc.append( ";" );
-			}
+			propDoc.append( ";" );
 
 			if ( multiline ) {
 				popDoc();

--- a/src/test/resources/prettyprint/semicolons/semicolons_false_input.bx
+++ b/src/test/resources/prettyprint/semicolons/semicolons_false_input.bx
@@ -4,6 +4,7 @@ class {
 	function init() {
 		var x = 1;
 		import java.util.List;
+		bx:include template="header.bx";
 		return this;
 	}
 

--- a/src/test/resources/prettyprint/semicolons/semicolons_false_input.cfs
+++ b/src/test/resources/prettyprint/semicolons/semicolons_false_input.cfs
@@ -1,0 +1,4 @@
+var x = 1;
+break;
+continue;
+return this;

--- a/src/test/resources/prettyprint/semicolons/semicolons_false_output.bx
+++ b/src/test/resources/prettyprint/semicolons/semicolons_false_output.bx
@@ -4,6 +4,7 @@ class {
 	function init() {
 		var x = 1
 		import java.util.List
+		bx:include template="header.bx";
 		return this
 	}
 

--- a/src/test/resources/prettyprint/semicolons/semicolons_false_output.cfs
+++ b/src/test/resources/prettyprint/semicolons/semicolons_false_output.cfs
@@ -1,0 +1,4 @@
+var x = 1
+break;
+continue;
+return this

--- a/src/test/resources/prettyprint/semicolons/semicolons_true_input.bx
+++ b/src/test/resources/prettyprint/semicolons/semicolons_true_input.bx
@@ -4,6 +4,7 @@ class {
 	function init() {
 		var x = 1;
 		import java.util.List;
+		bx:include template="header.bx";
 		return this;
 	}
 

--- a/src/test/resources/prettyprint/semicolons/semicolons_true_input.cfs
+++ b/src/test/resources/prettyprint/semicolons/semicolons_true_input.cfs
@@ -1,0 +1,4 @@
+var x = 1;
+break;
+continue;
+return this;

--- a/src/test/resources/prettyprint/semicolons/semicolons_true_output.bx
+++ b/src/test/resources/prettyprint/semicolons/semicolons_true_output.bx
@@ -4,6 +4,7 @@ class {
 	function init() {
 		var x = 1;
 		import java.util.List;
+		bx:include template="header.bx";
 		return this;
 	}
 

--- a/src/test/resources/prettyprint/semicolons/semicolons_true_output.cfs
+++ b/src/test/resources/prettyprint/semicolons/semicolons_true_output.cfs
@@ -1,0 +1,4 @@
+var x = 1;
+break;
+continue;
+return this;


### PR DESCRIPTION
When `semicolons: false`, the formatter was too aggressively stripping
semicolons from syntactically required positions:

- Property definitions require SEMICOLON+ per the ANTLR grammar
  (`property: preAnnotation* PROPERTY postAnnotation* SEMICOLON+`)
- Script-mode component terminators require a semicolon as the
  alternative to a body block
  (`component: ... (normalStatementBlock | SEMICOLON)`)
- `break` and `continue` in CF files (.cfc/.cfs/.cfm) must retain
  semicolons for Lucee/Adobe CF engine compatibility

Changes:
- Add `rootSourceType` field and `isCF()` helper in Visitor to detect
  CF source files regardless of source-type stack overrides inside
  lambdas/closures
- Always emit `;` in `visit(BoxProperty)` — required by grammar
- Always emit `;` in ComponentPrinter for components without a body —
  required by grammar as the only alternative to a statement block
- Emit required `;` in `visit(BoxBreak)` and `visit(BoxContinue)` when
  the root source is a CF type (CFSCRIPT/CFTEMPLATE)
- Update test fixtures: add `bx:include` component terminator to the
  .bx test, and add .cfs test files covering CF break/continue behavior

Resolves: https://ortussolutions.atlassian.net/browse/BL-2462