### PR TITLE
fix: --bx-printAST uses correct source type for template files

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -35,10 +35,14 @@ import org.apache.commons.lang3.Strings;
 
 import com.fasterxml.jackson.jr.ob.JSONObjectException;
 
+import java.io.File;
+
 import ortus.boxlang.compiler.BXCompiler;
 import ortus.boxlang.compiler.CFTranspiler;
 import ortus.boxlang.compiler.DiskClassUtil;
 import ortus.boxlang.compiler.FeatureAudit;
+import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.prettyprint.PrettyPrint;
 import ortus.boxlang.runtime.application.BaseApplicationListener;
 import ortus.boxlang.runtime.async.tasks.BoxScheduler;
@@ -176,15 +180,16 @@ public class BoxRunner {
 			}
 			// Print AST
 			else if ( options.printAST() ) {
-				String source;
 				// If --bx-code is present, use inline code
 				if ( options.code() != null ) {
-					source = options.code();
+					boxRuntime.printSourceAST( options.code() );
 				}
-				// If a file path argument is present, read the file
+				// If a file path argument is present, detect the source type from the extension
 				else if ( options.templatePath() != null ) {
+					File			templateFile	= new File( options.templatePath() );
+					BoxSourceType	sourceType		= Parser.detectFile( templateFile );
 					try {
-						source = Files.readString( Paths.get( options.templatePath() ) );
+						boxRuntime.printSourceAST( Files.readString( templateFile.toPath() ), sourceType );
 					} catch ( IOException e ) {
 						throw new BoxRuntimeException( "Failed to read file: " + options.templatePath(), e );
 					}
@@ -192,12 +197,11 @@ public class BoxRunner {
 				// Otherwise, read from STDIN
 				else {
 					try {
-						source = new String( System.in.readAllBytes() );
+						boxRuntime.printSourceAST( new String( System.in.readAllBytes() ) );
 					} catch ( IOException e ) {
 						throw new BoxRuntimeException( "Failed to read from STDIN", e );
 					}
 				}
-				boxRuntime.printSourceAST( source );
 			}
 			// Transpile to Java
 			else if ( options.transpile() ) {

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -1826,13 +1826,24 @@ public class BoxRuntime implements java.io.Closeable {
 	}
 
 	/**
-	 * Parse source string and print AST as JSON
+	 * Parse source string and print AST as JSON, defaulting to BoxScript source type.
 	 *
 	 * @param source A string of source to parse and print AST for
 	 *
 	 */
 	public void printSourceAST( String source ) {
-		ParsingResult result = RunnableLoader.getInstance().getBoxpiler().parseOrFail( source, BoxSourceType.BOXSCRIPT, false );
+		printSourceAST( source, BoxSourceType.BOXSCRIPT );
+	}
+
+	/**
+	 * Parse source string and print AST as JSON using the given source type.
+	 *
+	 * @param source     A string of source to parse and print AST for
+	 * @param sourceType The BoxSourceType of the source (BOXSCRIPT, BOXTEMPLATE, CFSCRIPT, CFTEMPLATE, etc.)
+	 *
+	 */
+	public void printSourceAST( String source, BoxSourceType sourceType ) {
+		ParsingResult result = RunnableLoader.getInstance().getBoxpiler().parseOrFail( source, sourceType, false );
 		System.out.println( result.getRoot().toJSON() );
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/BoxRunnerTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRunnerTest.java
@@ -17,11 +17,17 @@
  */
 package ortus.boxlang.runtime;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.compiler.parser.BoxSourceType;
 
 class BoxRunnerTest {
 
@@ -57,6 +63,58 @@ class BoxRunnerTest {
 		String[]	args			= { testTemplate, "hola", "luis" };
 
 		BoxRunner.main( args );
+	}
+
+	@DisplayName( "printSourceAST defaults to BoxScript for inline code" )
+	@Test
+	public void testPrintASTDefaultsToBoxScript() {
+		BoxRuntime				runtime		= BoxRuntime.getInstance( true );
+		PrintStream				original	= System.out;
+		ByteArrayOutputStream	capture		= new ByteArrayOutputStream();
+		System.setOut( new PrintStream( capture ) );
+		try {
+			assertDoesNotThrow( () -> runtime.printSourceAST( "x = 1 + 2" ) );
+		} finally {
+			System.setOut( original );
+		}
+		String output = capture.toString();
+		assertThat( output ).contains( "BoxScript" );
+	}
+
+	@DisplayName( "printSourceAST parses a .bxm template correctly" )
+	@Test
+	public void testPrintASTForBxmTemplate() {
+		BoxRuntime				runtime		= BoxRuntime.getInstance( true );
+		String					source		= "<bx:output>Hello World</bx:output>";
+		PrintStream				original	= System.out;
+		ByteArrayOutputStream	capture		= new ByteArrayOutputStream();
+		System.setOut( new PrintStream( capture ) );
+		try {
+			assertDoesNotThrow( () -> runtime.printSourceAST( source, BoxSourceType.BOXTEMPLATE ) );
+		} finally {
+			System.setOut( original );
+		}
+		String output = capture.toString();
+		assertThat( output ).isNotEmpty();
+		assertThat( output ).contains( "BoxTemplate" );
+	}
+
+	@DisplayName( "printSourceAST parses a .cfm template correctly" )
+	@Test
+	public void testPrintASTForCfmTemplate() {
+		BoxRuntime				runtime		= BoxRuntime.getInstance( true );
+		String					source		= "<cfoutput>Hello World</cfoutput>";
+		PrintStream				original	= System.out;
+		ByteArrayOutputStream	capture		= new ByteArrayOutputStream();
+		System.setOut( new PrintStream( capture ) );
+		try {
+			assertDoesNotThrow( () -> runtime.printSourceAST( source, BoxSourceType.CFTEMPLATE ) );
+		} finally {
+			System.setOut( original );
+		}
+		String output = capture.toString();
+		assertThat( output ).isNotEmpty();
+		assertThat( output ).contains( "BoxTemplate" );
 	}
 
 }


### PR DESCRIPTION
When printing the AST for .bxm or .cfm/.cfml files, the parser was
always using BoxSourceType.BOXSCRIPT, causing template files to be
parsed with the wrong lexer mode and grammar rules.

The fix adds a BoxSourceType overload to BoxRuntime.printSourceAST()
and updates BoxRunner to detect the source type from the file extension
via Parser.detectFile() before invoking the parser.

https://claude.ai/code/session_0113GvZX9abVcqLeqJQX2Eer