### PR TITLE
Fix query timeout bug: use direct field access instead of struct round-trip

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/PendingQuery.java
@@ -946,29 +946,23 @@ public class PendingQuery {
 	 * @throws SQLException If an error occurs while applying the options.
 	 */
 	private void applyStatementOptions( Statement statement ) throws SQLException {
-		IStruct options = this.queryOptions.toStruct();
-
-		if ( options.containsKey( Key.queryTimeout ) ) {
-			Integer queryTimeout = ( Integer ) options.getOrDefault( Key.queryTimeout, 0 );
-			if ( queryTimeout > 0 ) {
-				statement.setQueryTimeout( queryTimeout );
-			}
+		// Apply query timeout directly from the normalized field
+		if ( this.queryOptions.queryTimeout != null && this.queryOptions.queryTimeout > 0 ) {
+			statement.setQueryTimeout( this.queryOptions.queryTimeout );
 		}
 
-		if ( options.containsKey( Key.maxRows ) ) {
-			Integer maxRows = ( Integer ) options.getOrDefault( Key.maxRows, 0 );
-			if ( maxRows > 0 ) {
-				statement.setLargeMaxRows( maxRows );
-			}
+		// Apply max rows directly from the normalized field
+		if ( this.queryOptions.maxRows != null && this.queryOptions.maxRows > 0 ) {
+			statement.setLargeMaxRows( this.queryOptions.maxRows );
 		}
 
-		if ( options.containsKey( Key.fetchSize ) ) {
-			Integer fetchSize = ( Integer ) options.getOrDefault( Key.fetchSize, 0 );
-			if ( fetchSize > 0 ) {
-				statement.setFetchSize( fetchSize );
-			}
+		// Apply fetch size directly from the normalized field
+		if ( this.queryOptions.fetchSize != null && this.queryOptions.fetchSize > 0 ) {
+			statement.setFetchSize( this.queryOptions.fetchSize );
 		}
+
 		// This is an alias for fetchSize. (CF compat) Not handling via transpiler since apps like MASA specify as attributeCollection.
+		IStruct options = this.queryOptions.toStruct();
 		if ( options.containsKey( Key.blockfactor ) ) {
 			Integer blockFactor = ( Integer ) options.getOrDefault( Key.blockfactor, 0 );
 			if ( blockFactor > 0 ) {

--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
@@ -290,8 +290,8 @@ public class QueryOptions {
 		IStruct result = new Struct( this.options );
 		// Overwrite any options that were set in the constructor, as we want to return the actual values used
 		result.put( "fetchSize", this.fetchSize );
-		result.put( "setQueryTimeout", this.queryTimeout );
-		result.put( "setMaxRows", this.maxRows );
+		result.put( "queryTimeout", this.queryTimeout );
+		result.put( "maxRows", this.maxRows );
 		result.put( "dbtype", this.dbtype );
 		return result;
 	}

--- a/src/test/java/ortus/boxlang/runtime/jdbc/QueryTimeoutTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/QueryTimeoutTest.java
@@ -1,0 +1,145 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.jdbc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.bifs.global.jdbc.BaseJDBCTest;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+
+public class QueryTimeoutTest extends BaseJDBCTest {
+
+	@DisplayName( "It stores query timeout in QueryOptions from the public timeout key" )
+	@Test
+	public void testQueryTimeoutStorage() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, 30,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+
+		assertThat( queryOptions.queryTimeout ).isEqualTo( 30 );
+	}
+
+	@DisplayName( "It returns null for query timeout when not specified" )
+	@Test
+	public void testQueryTimeoutNull() {
+		IStruct			options			= Struct.of(
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+
+		assertNull( queryOptions.queryTimeout );
+	}
+
+	@DisplayName( "It exports queryTimeout with the correct key in toStruct()" )
+	@Test
+	public void testQueryTimeoutExportKey() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, 45,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+		IStruct			exported		= queryOptions.toStruct();
+
+		assertThat( exported.containsKey( Key.of( "queryTimeout" ) ) ).isTrue();
+		assertThat( exported.getAsInteger( Key.of( "queryTimeout" ) ) ).isEqualTo( 45 );
+	}
+
+	@DisplayName( "It does not export setQueryTimeout in toStruct()" )
+	@Test
+	public void testNoSetQueryTimeoutKey() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, 60,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+		IStruct			exported		= queryOptions.toStruct();
+
+		assertThat( exported.containsKey( Key.of( "setQueryTimeout" ) ) ).isFalse();
+	}
+
+	@DisplayName( "It exports maxRows with the correct key in toStruct()" )
+	@Test
+	public void testMaxRowsExportKey() {
+		IStruct			options			= Struct.of(
+		    Key.maxRows, 100,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+		IStruct			exported		= queryOptions.toStruct();
+
+		assertThat( exported.containsKey( Key.of( "maxRows" ) ) ).isTrue();
+		assertThat( ( Long ) exported.get( Key.of( "maxRows" ) ) ).isEqualTo( 100L );
+	}
+
+	@DisplayName( "It does not export setMaxRows in toStruct()" )
+	@Test
+	public void testNoSetMaxRowsKey() {
+		IStruct			options			= Struct.of(
+		    Key.maxRows, 100,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+		IStruct			exported		= queryOptions.toStruct();
+
+		assertThat( exported.containsKey( Key.of( "setMaxRows" ) ) ).isFalse();
+	}
+
+	@DisplayName( "It handles zero timeout values" )
+	@Test
+	public void testZeroTimeout() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, 0,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+
+		assertThat( queryOptions.queryTimeout ).isEqualTo( 0 );
+	}
+
+	@DisplayName( "It handles negative timeout values" )
+	@Test
+	public void testNegativeTimeout() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, -1,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+
+		assertThat( queryOptions.queryTimeout ).isEqualTo( -1 );
+	}
+
+	@DisplayName( "It handles large timeout values" )
+	@Test
+	public void testLargeTimeout() {
+		IStruct			options			= Struct.of(
+		    Key.timeout, 3600,
+		    Key.datasource, datasource
+		);
+		QueryOptions	queryOptions	= new QueryOptions( options );
+
+		assertThat( queryOptions.queryTimeout ).isEqualTo( 3600 );
+	}
+}


### PR DESCRIPTION
The query timeout feature documented as { timeout: 20 } in queryExecute() was
never applied to JDBC statements due to inconsistent key naming:

- Public API uses 'timeout' key
- QueryOptions stores as queryTimeout field
- applyStatementOptions() incorrectly looked for 'queryTimeout' key in toStruct()
- But toStruct() exported as 'setQueryTimeout'

This creates a key mismatch preventing the timeout from ever being applied.

Changes:
1. PendingQuery.applyStatementOptions(): Use direct field access from QueryOptions
   instead of deserializing through toStruct(). This eliminates the struct
   round-trip and uses the normalized field values directly.

2. QueryOptions.toStruct(): Fix key names for consistency
   - Changed 'setQueryTimeout' to 'queryTimeout'
   - Changed 'setMaxRows' to 'maxRows'

3. Added comprehensive QueryTimeoutTest with coverage for:
   - Query timeout storage and export
   - Null and zero value handling
   - Consistent key naming in toStruct()

https://claude.ai/code/session_01DivxrwinJqKJUFHG689Uxg