### PR TITLE
Use IntegerCaster in query options constructor

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
@@ -22,6 +22,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
+import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.CacheService;
@@ -178,7 +179,7 @@ public class QueryOptions {
 		this.resultVariableName		= options.getAsString( Key.result );
 		this.username				= options.getAsString( Key.username );
 		this.password				= options.getAsString( Key.password );
-		this.queryTimeout			= options.getAsInteger( Key.timeout );
+		this.queryTimeout			= IntegerCaster.cast( options.get( Key.timeout ), false );
 		this.datasource				= options.get( Key.datasource );
 		this.fetchSize				= ( Integer ) options.getOrDefault( Key.fetchSize, 0 );
 
@@ -189,9 +190,8 @@ public class QueryOptions {
 		this.cacheLastAccessTimeout	= ( Duration ) options.getOrDefault( Key.cacheLastAccessTimeout, null );
 		this.cacheProvider			= ( String ) options.getOrDefault( Key.cacheProvider, cacheService.getDefaultCache().getName().toString() );
 
-		Integer intMaxRows = options.getAsInteger( Key.maxRows );
-		this.maxRows	= Long.valueOf( intMaxRows != null ? intMaxRows : -1 );
-		this.dbtype		= options.getAsString( Key.dbtype );
+		this.maxRows				= Long.valueOf( IntegerCaster.attempt( options.get( Key.maxRows ), false ).orElse( -1 ) );
+		this.dbtype					= options.getAsString( Key.dbtype );
 
 		determineReturnType();
 

--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
@@ -181,7 +181,7 @@ public class QueryOptions {
 		this.password				= options.getAsString( Key.password );
 		this.queryTimeout			= IntegerCaster.cast( options.get( Key.timeout ), false );
 		this.datasource				= options.get( Key.datasource );
-		this.fetchSize				= ( Integer ) options.getOrDefault( Key.fetchSize, 0 );
+		this.fetchSize				= IntegerCaster.attempt( options.get( Key.fetchSize ), false ).orElse( 0 );
 
 		// Caching options
 		this.cache					= BooleanCaster.attempt( options.get( Key.cache ) ).getOrDefault( false );

--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryOptions.java
@@ -23,6 +23,7 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
+import ortus.boxlang.runtime.dynamic.casters.LongCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.CacheService;
@@ -176,22 +177,22 @@ public class QueryOptions {
 		CacheService cacheService = BoxRuntime.getInstance().getCacheService();
 
 		this.options				= options;
-		this.resultVariableName		= options.getAsString( Key.result );
-		this.username				= options.getAsString( Key.username );
-		this.password				= options.getAsString( Key.password );
+		this.resultVariableName		= StringCaster.attempt( options.get( Key.result ) ).orElse( null );
+		this.username				= StringCaster.attempt( options.get( Key.username ) ).orElse( null );
+		this.password				= StringCaster.attempt( options.get( Key.password ) ).orElse( null );
 		this.queryTimeout			= IntegerCaster.cast( options.get( Key.timeout ), false );
 		this.datasource				= options.get( Key.datasource );
 		this.fetchSize				= IntegerCaster.attempt( options.get( Key.fetchSize ), false ).orElse( 0 );
 
 		// Caching options
 		this.cache					= BooleanCaster.attempt( options.get( Key.cache ) ).getOrDefault( false );
-		this.cacheKey				= options.getAsString( Key.cacheKey );
+		this.cacheKey				= StringCaster.attempt( options.get( Key.cacheKey ) ).orElse( null );
 		this.cacheTimeout			= ( Duration ) options.getOrDefault( Key.cacheTimeout, null );
 		this.cacheLastAccessTimeout	= ( Duration ) options.getOrDefault( Key.cacheLastAccessTimeout, null );
-		this.cacheProvider			= ( String ) options.getOrDefault( Key.cacheProvider, cacheService.getDefaultCache().getName().toString() );
+		this.cacheProvider			= StringCaster.attempt( options.get( Key.cacheProvider ) ).orElse( cacheService.getDefaultCache().getName().toString() );
 
-		this.maxRows				= Long.valueOf( IntegerCaster.attempt( options.get( Key.maxRows ), false ).orElse( -1 ) );
-		this.dbtype					= options.getAsString( Key.dbtype );
+		this.maxRows				= LongCaster.attempt( options.get( Key.maxRows ), false ).orElse( -1L );
+		this.dbtype					= StringCaster.attempt( options.get( Key.dbtype ) ).orElse( null );
 
 		determineReturnType();
 

--- a/src/test/java/ortus/boxlang/runtime/jdbc/QueryOptionsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/QueryOptionsTest.java
@@ -65,4 +65,24 @@ public class QueryOptionsTest {
 		assertThat( options4.cache ).isFalse();
 	}
 
+	@DisplayName( "Test string property casters" )
+	@Test
+	public void testStringCasting() {
+		Struct optionsStruct = new Struct();
+		optionsStruct.put( Key.password, 12345 );
+		optionsStruct.put( Key.dbtype, 50.5 );
+		optionsStruct.put( Key.username, true );
+		optionsStruct.put( Key.result, 999 );
+		optionsStruct.put( Key.cacheKey, 1000 );
+		optionsStruct.put( Key.returnType, "array" );
+
+		QueryOptions options = new QueryOptions( optionsStruct );
+
+		assertThat( options.password ).isEqualTo( "12345" );
+		assertThat( options.dbtype ).isEqualTo( "50.5" );
+		assertThat( options.username ).isEqualTo( "true" );
+		assertThat( options.resultVariableName ).isEqualTo( "999" );
+		assertThat( options.cacheKey ).isEqualTo( "1000" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/jdbc/QueryOptionsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/QueryOptionsTest.java
@@ -1,0 +1,68 @@
+package ortus.boxlang.runtime.jdbc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Struct;
+
+public class QueryOptionsTest {
+
+	@DisplayName( "Test empty struct defaults" )
+	@Test
+	public void testEmptyStructDefaults() {
+		QueryOptions options = new QueryOptions( new Struct() );
+
+		assertThat( options.datasource ).isNull();
+		assertThat( options.resultVariableName ).isNull();
+		assertThat( options.getReturnType() ).isEqualTo( "query" );
+		assertThat( options.username ).isNull();
+		assertThat( options.password ).isNull();
+		assertThat( options.queryTimeout ).isNull();
+		assertThat( options.maxRows ).isEqualTo( -1L );
+		assertThat( options.fetchSize ).isEqualTo( 0 );
+		assertThat( options.cache ).isFalse();
+		assertThat( options.cacheKey ).isNull();
+		assertThat( options.cacheTimeout ).isNull();
+		assertThat( options.cacheLastAccessTimeout ).isNull();
+	}
+
+	@DisplayName( "Test numeric property casters" )
+	@Test
+	public void testCastingNumbers() {
+		Struct optionsStruct = new Struct();
+		optionsStruct.put( Key.timeout, "7" );
+		optionsStruct.put( Key.maxRows, "2.0" );
+		optionsStruct.put( Key.fetchSize, "100" );
+
+		QueryOptions options = new QueryOptions( optionsStruct );
+
+		assertThat( options.queryTimeout ).isEqualTo( 7 );
+		assertThat( options.maxRows ).isEqualTo( 2L );
+		assertThat( options.fetchSize ).isEqualTo( 100 );
+	}
+
+	@DisplayName( "Test 'cache' property boolean cast" )
+	@Test
+	public void testCacheBooleanCast() {
+		Struct optionsStruct = new Struct();
+		optionsStruct.put( Key.cache, "true" );
+		QueryOptions options1 = new QueryOptions( optionsStruct );
+		assertThat( options1.cache ).isTrue();
+
+		optionsStruct.put( Key.cache, "yes" );
+		QueryOptions options2 = new QueryOptions( optionsStruct );
+		assertThat( options2.cache ).isTrue();
+
+		optionsStruct.put( Key.cache, 1 );
+		QueryOptions options3 = new QueryOptions( optionsStruct );
+		assertThat( options3.cache ).isTrue();
+
+		optionsStruct.put( Key.cache, "false" );
+		QueryOptions options4 = new QueryOptions( optionsStruct );
+		assertThat( options4.cache ).isFalse();
+	}
+
+}


### PR DESCRIPTION
# Description

Use IntegerCaster in `QueryOptions` constructor.

Fixes this error in internal tests:

```
java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
	at ortus.boxlang.runtime.types.IStruct.getAsInteger(IStruct.java:349)
	at ortus.boxlang.runtime.jdbc.QueryOptions.<init>(QueryOptions.java:192)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at ortus.boxlang.runtime.interop.DynamicInteropService.invokeConstructor(DynamicInteropService.java:404)
	at ortus.boxlang.runtime.interop.DynamicObject.invokeConstructor(DynamicObject.java:226)
	at boxgenerated.boxclass.src.main.bx.interceptors.Querycompat$bx.invokeFunction_onQueryBuild(D:\a\bx-compat-cfml\bx-compat-cfml\src\main\bx\interceptors\QueryCompat.bx:118)
	at ortus.boxlang.runtime.types.CompiledFunction._invoke(CompiledFunction.java:251)
	at ortus.boxlang.runtime.types.Function.invoke(Function.java:306)
	at ortus.boxlang.runtime.runnables.BoxClassSupport.dereferenceAndInvoke(BoxClassSupport.java:544)
	at ortus.boxlang.runtime.runnables.BoxClassSupport.dereferenceAndInvoke(BoxClassSupport.java:467)
	at boxgenerated.boxclass.src.main.bx.interceptors.Querycompat$bx.dereferenceAndInvoke(D:\a\bx-compat-cfml\bx-compat-cfml\src\main\bx\interceptors\QueryCompat.bx)
	at ortus.boxlang.runtime.interop.DynamicInteropService.dereferenceAndInvoke(DynamicInteropService.java:2327)
	at ortus.boxlang.runtime.interop.DynamicInteropService.dereferenceAndInvoke(DynamicInteropService.java:2296)
	at ortus.boxlang.runtime.dynamic.Referencer.getAndInvoke(Referencer.java:89)
	at boxgenerated.scripts.Script__1a5038a1198e7089d7123202f50f65b3._invoke(unknown:9)
	at ortus.boxlang.runtime.runnables.BoxScript.invoke(BoxScript.java:67)
	at ortus.boxlang.runtime.BoxRuntime.executeSource(BoxRuntime.java:1730)
	at ortus.boxlang.runtime.BoxRuntime.executeSource(BoxRuntime.java:1688)
	at ortus.boxlang.modules.compat.interceptors.QueryCompatTest.testZeroCacheTimeout(QueryCompatTest.java:14)
```

## Type of change

- [x] Bug Fix
- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

