### PR TITLE
BL-2484 - Disable chatty Hikari in dev mode

### DIFF
--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -316,6 +316,15 @@
 				"additive": false,
 				// Add class/package names here to silence them
 				"categories": []
+			},
+			"hikari": {
+				"level": "WARN",
+				"appender": "file",
+				"encoder": "text",
+				"additive": false,
+				"categories": [
+					"com.zaxxer.hikari"
+				]
 			}
 		}
 	},


### PR DESCRIPTION
# Description

Set boxlang logging config to disable DEBUG and INFO messages from hikari, even in debug mode.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-2484

## Type of change

- [x] Improvement

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
