### PR TITLE
Add missing @argument annotations for documentation

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayNone.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayNone.java
@@ -66,6 +66,8 @@ public class ArrayNone extends ArraySome {
 	 *
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored.
+	 *
+	 * @argument.virtual (BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return !( Boolean ) super._invoke( context, arguments );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListChangeDelims.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListChangeDelims.java
@@ -63,6 +63,8 @@ public class ListChangeDelims extends BIF {
 	 * @argument.delimiter string the old list delimiter
 	 *
 	 * @argument.includeEmptyFields boolean whether to include empty fields in the returned result
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return ListUtil.asString(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListFind.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListFind.java
@@ -68,6 +68,8 @@ public class ListFind extends ArrayFind {
 	 * @argument.delimiter The list delimiter(s)
 	 *
 	 * @argument.includeEmptyFields Whether to include empty fields in the search
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	@Override
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListIndexExists.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListIndexExists.java
@@ -58,6 +58,8 @@ public class ListIndexExists extends BIF {
 	 * @argument.delimiter string the list delimiter
 	 *
 	 * @argument.includeEmptyFields boolean whether to include empty fields in the returned result
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		int index = arguments.getAsInteger( Key.index );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListItemTrim.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListItemTrim.java
@@ -64,6 +64,8 @@ public class ListItemTrim extends BIF {
 	 * @argument.delimiter string the list delimiter
 	 *
 	 * @argument.includeEmptyFields boolean whether to include empty fields in the returned result
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		String delimiter = arguments.getAsString( Key.delimiter );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListLen.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListLen.java
@@ -60,6 +60,8 @@ public class ListLen extends BIF {
 	 * @argument.delimiter string the list delimiter
 	 *
 	 * @argument.includeEmptyFields boolean whether to include empty fields in the returned result
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return ListUtil

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListMap.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListMap.java
@@ -73,6 +73,8 @@ public class ListMap extends ArrayMap {
 	 *
 	 * @argument.includeEmptyFields boolean whether to include empty fields in the returned result
 	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
+	 *
 	 * @argument.parallel Whether to run the filter in parallel. Defaults to false. If true, the filter will be run in parallel using a ForkJoinPool.
 	 *
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListQualify.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListQualify.java
@@ -74,6 +74,8 @@ public class ListQualify extends BIF {
 	 * @argument.elements The elements to qualify. If set to "char", only elements that are all alphabetic characters will be qualified.
 	 *
 	 * @argument.includeEmptyFields If true, empty fields will be qualified.
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		String	elements			= arguments.getAsString( Key.elements );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListRemoveDuplicates.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListRemoveDuplicates.java
@@ -57,6 +57,8 @@ public class ListRemoveDuplicates extends BIF {
 	 * @argument.delimiter The delimiter of the list
 	 *
 	 * @argument.ignoreCase Whether case should be ignored or not during deduplication - defaults to false
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return ListUtil.asDelimitedList(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListValueCount.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListValueCount.java
@@ -70,6 +70,8 @@ public class ListValueCount extends BIF {
 	 * @argument.delimiter The list delimiter(s)
 	 *
 	 * @argument.includeEmptyFields Whether to include empty fields in the search
+	 *
+	 * @argument.multiCharacterDelimiter boolean whether the delimiter is multi-character
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Key					bifMethodKey	= arguments.getAsKey( BIF.__functionName );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructFilter.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructFilter.java
@@ -73,6 +73,8 @@ public class StructFilter extends BIF {
 	 *
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored.
+	 *
+	 * @argument.virtual (BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Object maxThreads = arguments.get( Key.maxThreads );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructNew.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructNew.java
@@ -75,6 +75,8 @@ public class StructNew extends BIF {
 	 *
 	 * @argument.sortOrder The sort order applicable to the sortType argument
 	 *
+	 * @argument.localeSensitive Sort based on local rules
+	 *
 	 * @argument.callback An optional callback to use as the sorting function. You can alternatively pass a Java Comparator.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructToSorted.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructToSorted.java
@@ -63,6 +63,8 @@ public class StructToSorted extends BIF {
 	 *
 	 * @argument.sortOrder The sort order applicable to the sortType argument
 	 *
+	 * @argument.localeSensitive Sort based on local rules
+	 *
 	 * @argument.callback An optional callback to use as the sorting function. You can alternatively pass a Java Comparator.
 	 *
 	 */


### PR DESCRIPTION
Here's the template filled in:

---

# Description

This is documentation only (JavaDoc comments); there are no behaviour or code changes and no new dependencies.

Several built-in functions (BIFs) declare parameters that aren't documented in their JavaDoc `@argument` tags — the tags from which the public documentation is generated. This adds the missing tags so the generated docs match what the code actually supports, reusing the wording already used by sibling functions for consistency.

**Parameters documented (13 functions):**

- `multiCharacterDelimiter` → `ListLen`, `ListChangeDelims`, `ListFind`, `ListIndexExists`, `ListItemTrim`, `ListMap`, `ListQualify`, `ListRemoveDuplicates`, `ListValueCount`
- `virtual` → `ArrayNone`, `StructFilter`
- `localeSensitive` → `StructNew`, `StructToSorted`

## Type of change

- [x] Improvement
- [x] This change requires a documentation update
