### PR TITLE
Documentation fixes: correct @argument annotations and remove ACF references

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayFilter.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayFilter.java
@@ -70,7 +70,7 @@ public class ArrayFilter extends BIF {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayFirst.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayFirst.java
@@ -47,6 +47,8 @@ public class ArrayFirst extends BIF {
 	 * @param arguments Argument scope for the BIF.
 	 *
 	 * @argument.array The array to get the first item from.
+	 *
+	 * @argument.defaultValue The value to return when the array is empty. If omitted, an exception is thrown for an empty array.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array	actualArray		= arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayPop.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayPop.java
@@ -46,6 +46,8 @@ public class ArrayPop extends BIF {
 	 * @param arguments Argument scope for the BIF.
 	 *
 	 * @argument.array The array to get the last
+	 *
+	 * @argument.defaultValue The value to return when the array is empty. If omitted, an exception is thrown for an empty array.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array actualArray = arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayReject.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayReject.java
@@ -77,7 +77,7 @@ public class ArrayReject extends BIF {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 *
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayShift.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayShift.java
@@ -49,6 +49,8 @@ public class ArrayShift extends BIF {
 	 * @param arguments Argument scope for the BIF.
 	 *
 	 * @argument.array The array to shift
+	 *
+	 * @argument.defaultValue The value to return when the array is empty. If omitted, an exception is thrown for an empty array.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array	actualObj		= arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hash.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hash.java
@@ -80,7 +80,7 @@ public class Hash extends BIF {
 	 *
 	 * @argument.encoding Applicable to strings ( default "utf-8" )
 	 *
-	 * @argument.iterations The number of iterations to re-digest the object ( default 1 );
+	 * @argument.numIterations The number of iterations to re-digest the object ( default 1 );
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Object	hashItem			= arguments.get( Key.input );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
@@ -64,7 +64,7 @@ public class Hmac extends BIF {
 	 *
 	 * @argument.encoding Applicable to strings ( default "utf-8" )
 	 *
-	 * @argument.iterations The number of iterations to re-digest the object ( default 1 );
+	 * @argument.numIterations The number of iterations to re-digest the object ( default 1 );
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Object	hashItem	= arguments.get( Key.input );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
@@ -60,6 +60,8 @@ public class Hmac extends BIF {
 	 *
 	 * @argument.input The item to be hashed
 	 *
+	 * @argument.key The secret key used to generate the HMAC. Can be a string or a binary value.
+	 *
 	 * @argument.algorithm The supported {@link java.security.MessageDigest } algorithm (case-insensitive)
 	 *
 	 * @argument.encoding Applicable to strings ( default "utf-8" )

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListEvery.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListEvery.java
@@ -79,7 +79,7 @@ public class ListEvery extends ArrayEvery {
 	 * @argument.maxThreads The maximum number of threads to use when running in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		arguments.put(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListFilter.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListFilter.java
@@ -84,7 +84,7 @@ public class ListFilter extends BIF {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListMap.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListMap.java
@@ -80,7 +80,7 @@ public class ListMap extends ArrayMap {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		arguments.put(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListNone.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListNone.java
@@ -81,7 +81,7 @@ public class ListNone extends ListSome {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return !BooleanCaster.cast( super._invoke( context, arguments ) );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListSome.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListSome.java
@@ -79,7 +79,7 @@ public class ListSome extends ArraySome {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		arguments.put(

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructMap.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructMap.java
@@ -75,7 +75,7 @@ public class StructMap extends BIF {
 	 * @argument.maxThreads The maximum number of threads to use when running the filter in parallel. If not passed it will use the default number of threads for the ForkJoinPool.
 	 *                      If parallel is false, this argument is ignored. If a boolean is provided it will be assigned to the virtual argument instead.
 	 * 
-	 * @argument.virtual ( BoxLang only) If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
+	 * @argument.virtual If true, the function will be invoked using virtual threads. Defaults to false. Ignored if parallel is false.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Object maxThreads = arguments.get( Key.maxThreads );

--- a/workbench/samples/bifs/array/ArrayPop.md
+++ b/workbench/samples/bifs/array/ArrayPop.md
@@ -19,7 +19,7 @@ Result: 42
 
 ### Member function version.
 
-Using the member function. This version also works in ACF2018.
+Using the member function.
 
 <a href="https://try.boxlang.io/?code=eJxLLCpSsFWIVuDiNNTh4jQCYhMjrlhrrgKgaGJRkV5BfoGGpjVXeVFmSap%2FaUlBaYmGQoECUAQAf3kOiw%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/array/ArrayPush.md
+++ b/workbench/samples/bifs/array/ArrayPush.md
@@ -19,7 +19,7 @@ Result: This array has 4 elements.
 
 ### Member function version.
 
-Using the member function. This version also works in ACF2018.
+Using the member function.
 
 <a href="https://try.boxlang.io/?code=eJxLLCpSsFWIVuDiNNTh4jQCYmOuWGuuxBygaGJRkV5BaXGGhoKJkYKmNVd5UWZJqn9pSUFpiYaCUkhGZjFISWKlQkZisYKSgpoCUJcakJGak5qbmldSrKcE0gUA358aew%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/array/ArraySlice.md
+++ b/workbench/samples/bifs/array/ArraySlice.md
@@ -72,7 +72,7 @@ Result: [4,5,6]
 
 ### Slice an array using member function
 
-CF11+ calling the slice member function on an array.
+Calling the slice member function on an array.
 
 <a href="https://try.boxlang.io/?code=eJxLLCpKrFSwVYhW4OI01OHiNAJiYyA2AWJTIDYDYnMgtuCKtebKSy13hKpPBNF6xTmZyakaCkY6CsYKmtZc5UWZJakppbkFGgpwpUBhAFFlGN4%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/list/ListAppend.md
+++ b/workbench/samples/bifs/list/ListAppend.md
@@ -30,7 +30,7 @@ Result: bar,bar2|foo
 
 ### Simple listAppend Example with Empty Fields On
 
-CF2018+ Add 'foo,,' to the end of this list using includeEmptyFields as true
+Add 'foo,,' to the end of this list using includeEmptyFields as true
 
 <a href="https://try.boxlang.io/?code=eJzLz0nxySwuUbBVUEpKLNIBYiMla6681HKoaA6QciwoSM1L0VDIh6jVUVBKy8%2FX0VECMkBESVFpqoKmNVd5UWZJqn9pSUFpCVytgpqCkq6unRKQhpkJVAkAiv8jwQ%3D%3D" target="_blank">Run Example</a>
 
@@ -45,7 +45,7 @@ Result: bar,bar2,foo,,
 
 ### Simple listAppend Example with Empty Fields Off
 
-CF2018+ Add 'foo' to the end of this list using includeEmptyFields as false
+Add 'foo' to the end of this list using includeEmptyFields as false
 
 <a href="https://try.boxlang.io/?code=eJzLz0nxySwuUbBVUEpKLNIBYiMla6681HKoaA6QciwoSM1L0VDIh6jVUVBKy8%2FX0VECMkBEWmJOcaqCpjVXeVFmSap%2FaUlBaQlcsYKagpKurp0SkIYZClQJAK6NJAw%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/list/ListPrepend.md
+++ b/workbench/samples/bifs/list/ListPrepend.md
@@ -30,7 +30,7 @@ Result: "0-1-2-3-4"
 
 ### Prepend to a List with Empty Fields On
 
-CF2018+
+
 
 <a href="https://try.boxlang.io/?code=eJwrzs9N9cksLlGwVVByS03S8U0s0nEsKFKy5ipGyOQAqYCi1ILUvBQNBZi4joKSjo5XYp4SiAEkSopKUxU0rbnKizJLUv1LSwpKSxCKQRIAUHoiJw%3D%3D" target="_blank">Run Example</a>
 
@@ -45,7 +45,7 @@ Result: ",,Jan,Feb,Mar,Apr"
 
 ### Prepend to a List with Empty Fields Off
 
-CF2018+
+
 
 <a href="https://try.boxlang.io/?code=eJwrzs9N9cksLlGwVVByS03S8U0s0nEsKFKy5ipGyOQAqYCi1ILUvBQNBZi4joKSjo5XYp6OjhKICSTSEnOKUxU0rbnKizJLUv1LSwpKSxDqQRIArBoiyg%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/math/IncrementValue.md
+++ b/workbench/samples/bifs/math/IncrementValue.md
@@ -13,7 +13,7 @@ Result: 8
 
 ### Increment 7.5
 
-There is a difference between BL engines. ACF will return the integer incremented removing the decimal part. Boxlang will increment the integer part but return both.
+BoxLang increments the integer part of the number but returns the full value, including the decimal part.
 
 <a href="https://try.boxlang.io/?code=eJzLzEsuSs1NzSsJS8wpTdVQMNczVdC05gIAZrYHMw%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/query/QueryAddRow.md
+++ b/workbench/samples/bifs/query/QueryAddRow.md
@@ -1,6 +1,6 @@
 ### Builds a simple query using queryNew and queryAddRow
 
-CF10+ Pass in row data directly to queryAddRow argument.
+Pass in row data directly to queryAddRow argument.
 
 <a href="https://try.boxlang.io/?code=eJwljLEKAjEQRGvzFctWCtvYKhbC1RbiDwQzasCLurcxHOK%2Fu%2Bd1M8N7U9AG2tGrQscD2pI4J7Fsd7B4LoYrVN5Rz7eoTKtt%2BKP7lI4Pp4vrQp%2BwcI1pQ2vxOOveuEPDSAkXRBvopLWPhcN3ummaDV3tn%2FPJNP0AXTYr0A%3D%3D" target="_blank">Run Example</a>
 
@@ -17,7 +17,7 @@ writeDump( news );
 
 ### Builds a simple query using queryNew and queryAddRow member syntax
 
-CF10+ Pass in row data directly to queryAddRow argument.
+Pass in row data directly to queryAddRow argument.
 
 <a href="https://try.boxlang.io/?code=eJwljMEKwjAQRM%2FmK5Y9VQiCV8Vbzx6kPxCaUQM26nZjKMV%2Fd4O3mWHey6gznehdIMsZtSNO0WvSB9hbzoobxH%2BCjPcgTNujy0bsQoyXp71XtzGA6UB7b%2FEPWuMeFQtFXBF0pkHKFDK7bxNUSYq%2BTK%2BOmqtNPzgHKZw%3D" target="_blank">Run Example</a>
 
@@ -71,7 +71,7 @@ writeDump( news );
 
 ### Builds a simple query using queryNew queryAddRow with multiple rows as an array
 
-CF10+ The example above could be simplified even more this way:
+The example above could be simplified even more this way:
 
 <a href="https://try.boxlang.io/?code=eJxdjrEOwjAMROfkK6xMIHmBEcSA1LUMiA0xRMRAReuAmxBViH8naSfYzqd7vmNKPWzgGUmGHaUZmMZhaEJLBrPmQFcSfFk536wYmK%2F1GN06t%2Fc5zRlHOGr11kpl1MAKFlj09COfpqJEAzi6kA09HCR2lo1WH%2Fyhln9UTQzJtnfwDLX3I6FPZUCSJlAVu8dUX6wvBTs49A%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/query/QueryNew.md
+++ b/workbench/samples/bifs/query/QueryNew.md
@@ -36,7 +36,7 @@ Using BL Tags with the queryAddRow querySetCell functions to populate the query.
 
 ### Creating and Populating a query using an array rowData in queryNew
 
-CF10+ Passes an array of structs to create a new query.
+Passes an array of structs to create a new query.
 
 <a href="https://try.boxlang.io/?code=eJxdjjELwjAUhOfkVxyZKmTRUXHrWic3cXjYpwbbtL4khiL%2Bd1OddLs7vg%2FOcw7Y4p5Yph3nCsa1NrrYsbEl%2B8gXFvsgOV1JynSAVk%2BtVMEM1ljaOX%2F5Uk3NmSe0fGaKAXtJPXmj1cv%2BWKs%2FqyGPTN0tYPBohuGj6CMWG53FRa5TP1bw89UyvQEwGzJ5" target="_blank">Run Example</a>
 
@@ -58,7 +58,7 @@ writeDump( news );
 
 ### Creating and Populating a single row query using rowData in queryNew
 
-CF10+ If you only need one row you can pass a single struct instead of an array into the rowData argument.
+If you only need one row you can pass a single struct instead of an array into the rowData argument.
 
 <a href="https://try.boxlang.io/?code=eJwljbEKwkAQRGvvK4atIlxjq9iltvIHDjPRA3PoZi9HEP%2FdDXZvHg%2BmsM04412p64Wtg%2BQhWrYnJToX450al6S3R1JXH4SdJ4IjDtHxn%2FqSno0rBo5MNuOqdUpFwhf7U2iajX2dXh3K9ufqB%2BGSJOY%3D" target="_blank">Run Example</a>
 
@@ -74,7 +74,7 @@ writeDump( news );
 
 ### Creating and populating a query with an array of structs
 
-CF2018u5+ Directly assigns columns and values with an array of structs.
+Directly assigns columns and values with an array of structs.
 
 <a href="https://try.boxlang.io/?code=eJzLSy0vVrBVKCxNLar0Sy3XUIhW4OKs5uLkVMpMUVKwUjDUAbFLMktyUkFcJZfU8tRKhZTUtNTEkmKFkKLS3MQ8JS7OWh0UXUZounwT8xTKE3OyixXy8xR88%2FPBWrhiFTStucqLMktSXUpzCzQU8kBuAQoBAJfXKD0%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/string/ReFind.md
+++ b/workbench/samples/bifs/string/ReFind.md
@@ -13,7 +13,7 @@ Result: 2
 
 ### Script Syntax
 
-CF2016+ example with all optional arguments
+Example with all optional arguments
 
 <a href="https://try.boxlang.io/?code=eJzzCvb3C04tykzMyaxK1VAoSnXLzEvxy3dOLAbylFyVdBSUSlKLSxQMjYwVgRxDHYWSotJUoKijj4%2BSgqaCpjUXAMLsEn0%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/string/Right.md
+++ b/workbench/samples/bifs/string/Right.md
@@ -13,7 +13,7 @@ Result: lazy dog
 
 ### Using right() with a negative count on a string
 
-In this example we'll use a negative count right() to return part of a string. CF2018+
+In this example we'll use a negative count right() to return part of a string.
 
 <a href="https://try.boxlang.io/?code=eJwrL8osSfUvLSkoLdFQKMpMzwBSSiEZqQqFpZnJ2QpJRfnleQpp%2BRUKWaW5BakpCvllqUUKJUD5nMSqSoWU%2FHQlHQVdYyMFTQVNay4APN0Zkw%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/struct/StructFindKey.md
+++ b/workbench/samples/bifs/struct/StructFindKey.md
@@ -77,7 +77,7 @@ Result: [{"path":".PERSON3.LASTNAME","owner":{"LASTNAME":"Harrison","FIRSTNAME":
 
 ### Find first match for a nested struct key using member function
 
-CF11+ calling the findKey member function on a struct.
+Calling the findKey member function on a struct.
 
 <a href="https://try.boxlang.io/?code=eJxl0MsKwjAQBdB18xVDVhVE8LVRXNT3s0rrD0QdNVATSVOkiv%2FuFBGr2Q2XcOZm%2Bihsgin04AHM24yieB3WoQMP5nmzIQ31Kk3jWRRvw2A1ooDP9VnxIl0G33CJSmnFmfesfphGmWk4zEZkicOs9gNhrML8R2qWpaYjTVCbEzrWVBgj079S7TLVdqhgt6Pd%2F1KkxeFHaZWVlqNEUp20o8SWChUMe3bZJV9gTlfvv%2B9fO0p1oMQHnojUhuJC%2FwGuFXKodNnNSIvrzF4z68OcCsRopEjkHX14S5Xi2QuE5nL8" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/struct/StructFindValue.md
+++ b/workbench/samples/bifs/struct/StructFindValue.md
@@ -60,7 +60,7 @@ Result: [{"path":".E","owner":{"A":2,"B":4,"C":8,"D":10,"E":12,"F":12,"MYSECONDS
 
 ### Find first match for a nested struct value using member function
 
-CF11+ calling the findValue member function on a struct.
+Calling the findValue member function on a struct.
 
 <a href="https://try.boxlang.io/?code=eJzLrQwuKSpNLlGwVahW4OJ0VLBSMNLh4nQC0iZA2hlIWwBpFyBtaABkuIIYIBVuYAZXrTVXLtQIPd%2FIYFdnfz%2BX4JCgUOcQkIlAAw2B6kxBOh2NCOkAckM8PINQ9DsZwix0Auk3M4XoD0vMKU0FqoCblJaZlwIW1FBQMjRS0lFQys9LVVLQtOYKL8osSfUvLSkoLdFQ8Ar29wtOLcpMzMmsAiqFGaQJUggA0rZF7A%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/struct/StructKeyExists.md
+++ b/workbench/samples/bifs/struct/StructKeyExists.md
@@ -13,7 +13,7 @@ Result: true
 
 ### Check if server struct has OS key using member function
 
-CF11+ calling the keyExists member function on a struct.
+Calling the keyExists member function on a struct.
 
 <a href="https://try.boxlang.io/?code=eJwrTi0qSy3Sy06tdK3ILC4p1lBQyi9WUtC05gIAhJEIiw%3D%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/struct/StructNew.md
+++ b/workbench/samples/bifs/struct/StructNew.md
@@ -33,7 +33,7 @@ writeDump( unordered );
 
 ### New ordered struct using literal notation
 
-CF2016+ Creates an ordered struct. Note the square brackets.
+Creates an ordered struct. Note the square brackets.
 
 <a href="https://try.boxlang.io/?code=eJzLL0pJLUpNUbBViFbg4nRUsFIw1OHidALSRkDaGUgbc8Vac5UXZZakupTmFmgo5EN1aFpzAQDI2Q9h" target="_blank">Run Example</a>
 
@@ -81,7 +81,7 @@ writeDump( ordered );
 
 ### New case-sensitive struct using function
 
-CF2021+ Creates a case-sensitive struct.
+Creates a case-sensitive struct.
 
 <a href="https://try.boxlang.io/?code=eJxLTixOLU7NK84sySxLVbBVKC4pKk0u8Ust11BQSkaWU1LQtOZCEdFzBKo3RBd0AgoaoQs6AwWNrbnKizJLUl1Kcws0FFDkQUYDAPspLu4%3D" target="_blank">Run Example</a>
 
@@ -97,7 +97,7 @@ writeDump( casesensitive );
 
 ### New case-sensitive struct using literal notation
 
-CF2021+ Creates a case-sensitive struct.
+Creates a case-sensitive struct.
 
 
 ```java
@@ -114,7 +114,7 @@ writeDump( casesensitive );
 
 ### New ordered and case-sensitive struct using function
 
-CF2021+ Creates a case-sensitive struct.
+Creates a case-sensitive struct.
 
 <a href="https://try.boxlang.io/?code=eJwrzs9NDS4pKk0uUbBVKAYz%2FFLLNRSU8otSUotSU3STE4tTi1PzijNLMstSlRQ0rbmK4Vr0nIGajFFEnIAiRigijkARQ2uu8qLMklSX0twCDQWEJMg4AJpRK88%3D" target="_blank">Run Example</a>
 
@@ -130,7 +130,7 @@ writeDump( someStruct );
 
 ### New ordered and case-sensitive struct using literal notation
 
-CF2021+ Creates an ordered and case-sensitive struct.
+Creates an ordered and case-sensitive struct.
 
 
 ```java

--- a/workbench/samples/bifs/system/GetFunctionList.md
+++ b/workbench/samples/bifs/system/GetFunctionList.md
@@ -1,6 +1,6 @@
 ### Check to see if a function exists
 
-CF11+ Uses the member function of structKeyExists.
+Uses the member function of structKeyExists.
 
 <a href="https://try.boxlang.io/?code=eJxLTy1xK81LLsnMz%2FPJLC7R0NTLTq10rQAyizUUlIpSfRNLkjOUFDStuQBPYQ5J" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/system/WriteOutput.md
+++ b/workbench/samples/bifs/system/WriteOutput.md
@@ -25,7 +25,7 @@ writeOutput( greeting );
 
 ### Using the encodeFor argument
 
-CF2016+ Passing in `html` to the `encodeFor` argument wraps the result with a call to encodeForHTML.
+Passing in `html` to the `encodeFor` argument wraps the result with a call to encodeForHTML.
 
 <a href="https://try.boxlang.io/?code=eJzLS8xNVbBVUApILUlVsuYqL8osSfUvLSkoLdFQUPJIzcnJV1BSUFPIAyrTUVDKKMnNUVLQtOYCAOVaEGw%3D" target="_blank">Run Example</a>
 

--- a/workbench/samples/bifs/type/GetMetaData.md
+++ b/workbench/samples/bifs/type/GetMetaData.md
@@ -1,6 +1,5 @@
 ### Dump Metadata of CFC Instance
 
-CF9+
 
 
 ```java

--- a/workbench/samples/components/async/Thread.md
+++ b/workbench/samples/components/async/Thread.md
@@ -1,6 +1,5 @@
 ### Script Syntax
 
-CF9+
 
 
 ```java

--- a/workbench/samples/components/io/File.md
+++ b/workbench/samples/components/io/File.md
@@ -186,7 +186,7 @@ Upload the file contained in the myFile field. Always upload to a directory outs
 
 ### Tag Syntax (action=upload) with accept
 
-CF10+ Checks file extensions against a whitelist of allowed file extensions. You must set `strict=false` when specifying a file extension list.
+Checks file extensions against a whitelist of allowed file extensions. You must set `strict=false` when specifying a file extension list.
 
 
 ```java


### PR DESCRIPTION
This PR is documentation-only. It corrects JavaDoc `@argument` tags on several BIFs so the generated docs match the parameters the code actually declares, and removes ACF engine/version references from the per-BIF sample docs. No engine code, behaviour, or example logic is changed.

### 1. `@argument` tag corrections (Java BIFs)

Some BIFs declared parameters that weren't documented, or documented them under a name that didn't match the declared argument (so the parameter was effectively undocumented in the generated docs).

- **`Hash`** — renamed `@argument.iterations` → `@argument.numIterations` to match the declared argument
- **`Hmac`** — renamed `@argument.iterations` → `@argument.numIterations`, and added the missing `@argument.key`
- **`ArrayFirst`, `ArrayPop`, `ArrayShift`** — added the missing `@argument.defaultValue` (the value returned when the array is empty)

### 2. Remove ACF references from sample docs

BoxLang is its own language and shouldn't present its docs in terms of other CFML engines. 

The per-BIF example docs under `workbench/samples/` carried ACF version annotations (e.g. `CF10+`) inherited from their CFDocs origins, plus one note comparing BoxLang behaviour to ACF. 

**Deliberately left unchanged:**

- Example *data* that incidentally contains these words; editing them would no longer match the encoded "Run Example" URLs
- `CFML`/`cfml` references, which are correct since BoxLang natively supports CFML
