### PR TITLE
Add or corrects JavaDoc `@argument` annotations

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayDelete.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayDelete.java
@@ -56,6 +56,8 @@ public class ArrayDelete extends BIF {
 	 * @argument.array The array to be deleted from.
 	 *
 	 * @argument.value The value to deleted.
+	 *
+	 * @argument.scope Which matches to delete: "one" (default) deletes the first matching value, "all" deletes every matching value.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array	actualArray		= arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayNew.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayNew.java
@@ -42,7 +42,7 @@ public class ArrayNew extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.dimension The dimension of the array to create (currently only 1 is supported).
+	 * @argument.dimensions The dimension of the array to create (currently only 1 is supported).
 	 *
 	 * @argument.isSynchronized Whether the array should be thread-safe (synchronized). Default is false.
 	 */

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySet.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySet.java
@@ -59,7 +59,7 @@ public class ArraySet extends BIF {
 	 *
 	 * @argument.end The ending index
 	 *
-	 * @arguent.value The value to set
+	 * @argument.value The value to set
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array	actualObj	= arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySlice.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySlice.java
@@ -47,6 +47,12 @@ public class ArraySlice extends BIF {
 	 *
 	 * @param context
 	 * @param arguments Argument scope defining the array.
+	 *
+	 * @argument.array The array to slice.
+	 *
+	 * @argument.start The position to start the slice from. Negative values count from the end of the array.
+	 *
+	 * @argument.length The number of elements to return. 0 (default) returns all elements from start to the end of the array.
 	 */
 	public Array _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array	actualArray	= arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySum.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySum.java
@@ -45,6 +45,8 @@ public class ArraySum extends BIF {
 	 *
 	 * @param context
 	 * @param arguments Argument scope defining the array.
+	 *
+	 * @argument.array The array to sum the values of.
 	 */
 	public Number _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Array actualArray = arguments.getAsArray( Key.array );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySwap.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArraySwap.java
@@ -46,6 +46,8 @@ public class ArraySwap extends BIF {
 	 * @param context
 	 * @param arguments Argument scope defining the array.
 	 *
+	 * @argument.array The array containing the elements to swap.
+	 *
 	 * @arguments.position1 The first position to swap
 	 *
 	 * @arguments.position2 The second position to swap

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayUnique.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/array/ArrayUnique.java
@@ -54,6 +54,7 @@ public class ArrayUnique extends BIF {
 	 *
 	 * @argument.array The array to remove duplicate entries from
 	 *
+	 * @argument.caseSensitive Whether string element comparisons are case-sensitive. Defaults to false.
 	 */
 	@Override
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/math/Floor.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/math/Floor.java
@@ -41,12 +41,12 @@ public class Floor extends BIF {
 	}
 
 	/**
-	 * Returns the absolute value of a number
+	 * Round a number down to the nearest integer
 	 * 
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 * 
-	 * @argument.value The number to return the absolute value of
+	 * @argument.number The number to round down to the nearest integer
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		return _invoke( arguments.getAsNumber( Key.number ) );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseN.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseN.java
@@ -35,6 +35,10 @@ public class FormatBaseN extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 * 
+	 * @argument.number The number to convert to the specified base.
+	 *
+	 * @argument.radix The base to convert the number to, in the range 2-36.
+	 *
 	 * @return A string representation of the number in the specified base.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/math/RandRange.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/math/RandRange.java
@@ -46,6 +46,12 @@ public class RandRange extends BIF {
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @argument.number1 The lower bound of the range.
+	 *
+	 * @argument.number2 The upper bound of the range.
+	 *
+	 * @argument.algorithm The algorithm to use to generate the random number.
 	 */
 	public Number _invoke( IBoxContext context, ArgumentsScope arguments ) {
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyArray.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyArray.java
@@ -45,6 +45,8 @@ public class StructKeyArray extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 * 
+	 * @argument.structure The struct whose keys are returned.
+	 *
 	 * @return An array containing the keys of the structure.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyList.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructKeyList.java
@@ -45,6 +45,10 @@ public class StructKeyList extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
+	 * @argument.structure The struct whose keys are returned.
+	 *
+	 * @argument.delimiter The delimiter to use between the keys in the returned list. Defaults to a comma.
+	 *
 	 * @return A string containing the keys of the structure, delimited by the specified delimiter (or a default delimiter comma if not provided).
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructSort.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/struct/StructSort.java
@@ -65,6 +65,8 @@ public class StructSort extends BIF {
 	 *
 	 * @argument.sortOrder The sort order applicable to the sortType argument
 	 *
+	 * @argument.path An optional key path used to sort by a nested value within each struct entry (e.g. "address.city").
+	 *
 	 * @argument.callback An optional callback to use as the sorting function. You can alternatively pass a Java Comparator.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateDateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateDateTime.java
@@ -68,6 +68,10 @@ public class CreateDateTime extends BIF {
 	 * @argument.minute The minute of the date-time object.
 	 *
 	 * @argument.second The second of the date-time object.
+	 *
+	 * @argument.millisecond The millisecond of the date-time object.
+	 *
+	 * @argument.timezone The timezone to apply to the date-time object. Defaults to the system default timezone.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		ZoneId timezone = LocalizationUtil.parseZoneId( arguments.getAsString( Key.timezone ), context );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTime.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/CreateTime.java
@@ -57,6 +57,8 @@ public class CreateTime extends BIF {
 	 * @argument.second The second of the date-time object.
 	 * 
 	 * @argument.millisecond The millisecond of the date-time object.
+	 *
+	 * @argument.timezone The timezone to apply to the date-time object. Defaults to the system default timezone.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		ZoneId timezone = LocalizationUtil.parseZoneId( arguments.getAsString( Key.timezone ), context );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompare.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompare.java
@@ -73,6 +73,8 @@ public class DateCompare extends BIF {
 	 * @argument.date1 The reference date object
 	 *
 	 * @argument.date2 The date which to compare against date1
+	 *
+	 * @argument.datepart The precision to compare down to. Accepts y, yyyy, m, d, h, n, s (default).
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		String		datePart	= arguments.getAsString( Key.datepart );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateDiff.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateDiff.java
@@ -76,6 +76,8 @@ public class DateDiff extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
+	 * @argument.datepart The datepart code in which to express the difference (yyyy, q, m, d, y, w, ww, wd, h, n, s, l).
+	 *
 	 * @argument.date1 The reference date object
 	 *
 	 * @argument.date2 The date which to compare against date1


### PR DESCRIPTION
# Description

Adds or corrects JavaDoc `@argument` annotations across several BIF packages so the generated documentation matches the parameters each function actually declares. These annotations are the source for the public docs generation.

Documentation only - JavaDoc comments. No behaviour, signatures, or logic changed.
