### PR TITLE
feat(schedule): add reload action to bx:schedule component

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -138,7 +138,7 @@ public class Schedule extends Component {
 		super();
 		declaredAttributes = new Attribute[] {
 		    new Attribute( Key.action, "string", Set.of( Validator.REQUIRED,
-		        Validator.valueOneOf( "create", "update", "modify", "delete", "run", "pause", "resume", "list", "pauseall", "resumeall" )
+		        Validator.valueOneOf( "create", "update", "modify", "delete", "run", "pause", "resume", "list", "pauseall", "resumeall", "reload" )
 		    ) ),
 		    new Attribute( Key.task, "string" ),
 		    new Attribute( Key.scheduler, "string", DEFAULT_SCHEDULER_NAME ),
@@ -192,8 +192,8 @@ public class Schedule extends Component {
 			action = "update";
 		}
 
-		// All actions except list/pauseall/resumeall require a task name
-		if ( !action.equals( "list" ) && !action.equals( "pauseall" ) && !action.equals( "resumeall" ) ) {
+		// All actions except list/pauseall/resumeall/reload require a task name
+		if ( !action.equals( "list" ) && !action.equals( "pauseall" ) && !action.equals( "resumeall" ) && !action.equals( "reload" ) ) {
 			requireTaskName( attributes );
 		}
 
@@ -225,6 +225,9 @@ public class Schedule extends Component {
 			case "resumeall" :
 				doResumeAll( context, attributes );
 				break;
+			case "reload" :
+				doReload( context, attributes );
+				break;
 			default :
 				throw new BoxRuntimeException( "Invalid schedule action [" + action + "]" );
 		}
@@ -234,7 +237,8 @@ public class Schedule extends Component {
 		// executor is created with all tasks already in place.
 		// - Already-running schedulers: startupScheduler() is a no-op (guards against double-start).
 		// - Read-only "list" action is excluded to avoid unintended side effects.
-		if ( !action.equals( "list" ) ) {
+		// - "reload" is excluded because reloadSchedulerFromDisk() already calls startupScheduler().
+		if ( !action.equals( "list" ) && !action.equals( "reload" ) ) {
 			String				schedulerName	= attributes.getAsString( Key.scheduler );
 			SchedulerService	svc				= runtime.getSchedulerService();
 			var					scheduler		= svc.getScheduler( Key.of( schedulerName ) );
@@ -485,6 +489,15 @@ public class Schedule extends Component {
 			}
 		}
 		svc.updateAllTasksPausedState( schedulerName, group, false );
+	}
+
+	/**
+	 * Reload a scheduler by shutting it down and re-registering all of its tasks
+	 * from the persisted tasks.json file, then restarting the scheduler.
+	 */
+	private void doReload( IBoxContext context, IStruct attributes ) {
+		String schedulerName = attributes.getAsString( Key.scheduler );
+		runtime.getSchedulerService().reloadSchedulerFromDisk( Key.of( schedulerName ), false, SchedulerService.DEFAULT_SHUTDOWN_TIMEOUT );
 	}
 
 	// --------------------------------------------------------------------------

--- a/src/main/java/ortus/boxlang/runtime/config/segments/SchedulerConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/SchedulerConfig.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime.config.segments;
 
 import ortus.boxlang.runtime.config.util.PropertyHelper;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
@@ -34,26 +35,34 @@ public class SchedulerConfig implements IConfigSegment {
 	 * Ex: "executor": "scheduled-tasks"
 	 * PLEASE REMEMBER TO REGISTER THE EXECUTOR IN THE RUNTIME CONFIGURATION
 	 */
-	public String	executor	= "scheduled-tasks";
+	public String	executor		= "scheduled-tasks";
 
 	/**
 	 * The name of the cache to use for server fixation and clustering.
 	 * Ex: "cache": "default"
 	 * PLEASE REMEMBER TO REGISTER THE CACHE IN THE RUNTIME CONFIGURATION
 	 */
-	public String	cacheName	= "default";
+	public String	cacheName		= "default";
 
 	/**
 	 * The array of schedulers to startup once the runtime starts up
 	 */
-	public Array	schedulers	= new Array();
+	public Array	schedulers		= new Array();
 
 	/**
 	 * The path to the JSON file where bx:schedule tasks are persisted.
 	 * Supports ${boxlang-home} and other placeholder variables.
 	 * Defaults to ${boxlang-home}/config/tasks.json.
 	 */
-	public String	tasksFile	= "${boxlang-home}/config/tasks.json";
+	public String	tasksFile		= "${boxlang-home}/config/tasks.json";
+
+	/**
+	 * When true, the scheduler service watches tasks.json for external changes and automatically
+	 * reloads all affected schedulers whenever the file is modified outside of BoxLang.
+	 * Self-writes (from bx:schedule actions) are suppressed via a grace window.
+	 * Defaults to false.
+	 */
+	public Boolean	reloadOnChange	= false;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -80,6 +89,9 @@ public class SchedulerConfig implements IConfigSegment {
 		PropertyHelper.processString( config, Key.cacheName, this.cacheName );
 		PropertyHelper.processStringOrArrayToArray( config, Key.schedulers, this.schedulers );
 		this.tasksFile = PropertyHelper.processString( config, Key.tasksFile, this.tasksFile );
+		if ( config.containsKey( Key.reloadOnChange ) ) {
+			this.reloadOnChange = BooleanCaster.cast( config.get( Key.reloadOnChange ) );
+		}
 
 		return this;
 	}
@@ -93,7 +105,8 @@ public class SchedulerConfig implements IConfigSegment {
 		    Key.executor, this.executor,
 		    Key.cacheName, this.cacheName,
 		    Key.schedulers, Array.fromList( this.schedulers ),
-		    Key.tasksFile, this.tasksFile
+		    Key.tasksFile, this.tasksFile,
+		    Key.reloadOnChange, this.reloadOnChange
 		);
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
@@ -17,12 +17,20 @@
  */
 package ortus.boxlang.runtime.services;
 
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.time.ZoneId;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import ortus.boxlang.runtime.BoxRuntime;
@@ -98,6 +106,30 @@ public class SchedulerService extends BaseService {
 	private volatile String			tasksEncryptionKey			= null;
 
 	/**
+	 * Background thread that watches tasks.json for external changes.
+	 * Non-null only when reloadOnChange=true and the watcher started successfully.
+	 */
+	private Thread					watchThread					= null;
+
+	/**
+	 * The Java NIO WatchService used by the tasks.json watcher thread.
+	 */
+	private WatchService			watchService				= null;
+
+	/**
+	 * Epoch-millisecond timestamp of the most recent self-write to tasks.json.
+	 * Used to suppress watcher events triggered by the service's own writes.
+	 */
+	private volatile long			lastSelfWriteMs				= 0;
+
+	/**
+	 * Watcher events arriving within this many milliseconds after a self-write are
+	 * suppressed to avoid a reload loop caused by the service's own persistence calls.
+	 * Set to 5 seconds to give schedulers time to finish in-flight changes.
+	 */
+	private static final long		SELF_WRITE_GRACE_MS			= 5_000;
+
+	/**
 	 * --------------------------------------------------------------------------
 	 * Constructors
 	 * --------------------------------------------------------------------------
@@ -143,6 +175,11 @@ public class SchedulerService extends BaseService {
 
 		// Startup all the schedulers
 		startupRegisteredSchedulers();
+
+		// Start tasks.json file watcher if reloadOnChange is enabled
+		if ( Boolean.TRUE.equals( runtime.getConfiguration().scheduler.reloadOnChange ) ) {
+			startTasksFileWatcher();
+		}
 
 		// Announce it
 		announce(
@@ -269,6 +306,9 @@ public class SchedulerService extends BaseService {
 		    BoxEvent.ON_SCHEDULER_SERVICE_SHUTDOWN,
 		    Struct.of( "schedulerService", this )
 		);
+		// Stop the tasks.json file watcher if running
+		stopTasksFileWatcher();
+
 		// Call shutdown on each scheduler in parallel
 		schedulers.values()
 		    .parallelStream()
@@ -811,6 +851,8 @@ public class SchedulerService extends BaseService {
 	 * @param tasks The array of task definition structs to persist.
 	 */
 	public void saveTasksToDisk( Array tasks ) {
+		// Stamp before writing so the watcher grace window starts before the OS event fires.
+		this.lastSelfWriteMs = System.currentTimeMillis();
 		Path tasksFile = getTasksFilePath();
 		try {
 			String json = JSONUtil.getJSONBuilder( true ).asString( tasks );
@@ -950,6 +992,125 @@ public class SchedulerService extends BaseService {
 				}
 			}
 			saveTasksToDisk( tasks );
+		}
+	}
+
+	// --------------------------------------------------------------------------
+	// Tasks-file watcher methods (reloadOnChange support)
+	// --------------------------------------------------------------------------
+
+	/**
+	 * Start a daemon thread that watches tasks.json for external modifications.
+	 * When a change is detected outside the self-write grace window, all affected
+	 * schedulers are reloaded from disk via {@link #reloadSchedulerFromDisk}.
+	 */
+	private void startTasksFileWatcher() {
+		Path	tasksFilePath	= getTasksFilePath().toAbsolutePath().normalize();
+		Path	watchDir		= tasksFilePath.getParent();
+
+		try {
+			Files.createDirectories( watchDir );
+			this.watchService = FileSystems.getDefault().newWatchService();
+			watchDir.register( this.watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE );
+		} catch ( Exception e ) {
+			this.logger.error( "Failed to start tasks.json reload-on-change watcher: {}", e.getMessage() );
+			return;
+		}
+
+		String finalFileName = tasksFilePath.getFileName().toString();
+		this.watchThread = new Thread( () -> {
+			while ( !Thread.currentThread().isInterrupted() ) {
+				WatchKey key;
+				try {
+					key = this.watchService.take();
+				} catch ( InterruptedException e ) {
+					Thread.currentThread().interrupt();
+					break;
+				} catch ( ClosedWatchServiceException e ) {
+					break;
+				}
+
+				for ( WatchEvent<?> event : key.pollEvents() ) {
+					if ( event.kind() == StandardWatchEventKinds.OVERFLOW ) {
+						continue;
+					}
+					@SuppressWarnings( "unchecked" )
+					Path changed = ( ( WatchEvent<Path> ) event ).context();
+					if ( finalFileName.equals( changed.getFileName().toString() ) ) {
+						onTasksFileChanged();
+					}
+				}
+
+				key.reset();
+			}
+		}, "bxschedule-tasks-watcher" );
+		this.watchThread.setDaemon( true );
+		this.watchThread.start();
+
+		this.logger.info( "+ Scheduler Service tasks.json reload-on-change watcher started for [{}]", tasksFilePath );
+	}
+
+	/**
+	 * Called by the watcher thread when tasks.json changes on disk.
+	 * Suppresses events caused by the service's own writes (within the grace window),
+	 * then reloads all affected schedulers.
+	 */
+	private void onTasksFileChanged() {
+		if ( System.currentTimeMillis() - this.lastSelfWriteMs < SELF_WRITE_GRACE_MS ) {
+			this.logger.debug( "+ tasks.json changed (self-write within grace window) — suppressing reload-on-change" );
+			return;
+		}
+
+		this.logger.info( "+ tasks.json changed externally — reloading affected schedulers..." );
+
+		// Collect scheduler names: union of currently registered BaseSchedulers and names in the new file
+		Set<String> schedulerNames = new HashSet<>();
+
+		for ( Map.Entry<Key, IScheduler> entry : this.schedulers.entrySet() ) {
+			if ( entry.getValue() instanceof BaseScheduler ) {
+				schedulerNames.add( entry.getKey().getName() );
+			}
+		}
+
+		try {
+			Array tasks = loadTasksFromDisk();
+			for ( Object entry : tasks ) {
+				if ( entry instanceof IStruct ) {
+					IStruct	taskDef			= ( IStruct ) entry;
+					Object	schedulerField	= taskDef.get( Key.scheduler );
+					String	schedulerName	= schedulerField != null ? schedulerField.toString() : DEFAULT_SCHEDULER_NAME;
+					schedulerNames.add( schedulerName );
+				}
+			}
+		} catch ( Exception e ) {
+			this.logger.error( "Failed to read tasks.json during reload-on-change: {}", e.getMessage() );
+			return;
+		}
+
+		for ( String name : schedulerNames ) {
+			try {
+				reloadSchedulerFromDisk( Key.of( name ), false, DEFAULT_SHUTDOWN_TIMEOUT );
+			} catch ( Exception e ) {
+				this.logger.error( "Failed to reload scheduler [{}] on tasks.json change: {}", name, e.getMessage() );
+			}
+		}
+	}
+
+	/**
+	 * Stop and clean up the tasks.json watcher thread and WatchService.
+	 */
+	private void stopTasksFileWatcher() {
+		if ( this.watchThread != null ) {
+			this.watchThread.interrupt();
+			this.watchThread = null;
+		}
+		if ( this.watchService != null ) {
+			try {
+				this.watchService.close();
+			} catch ( Exception e ) {
+				// ignore — we're shutting down
+			}
+			this.watchService = null;
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
 import ortus.boxlang.runtime.async.tasks.BoxScheduler;
 import ortus.boxlang.runtime.async.tasks.IScheduler;
+import ortus.boxlang.runtime.async.tasks.ScheduledTask;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
@@ -629,6 +630,100 @@ public class SchedulerService extends BaseService {
 	 */
 	public SchedulerService restartScheduler( Key name ) {
 		return restartScheduler( name, false, 0 );
+	}
+
+	/**
+	 * Reload a scheduler from disk: shuts it down, removes it, re-reads
+	 * tasks.json for tasks belonging to this scheduler, then starts the
+	 * fresh scheduler. Useful when tasks.json has been modified externally
+	 * or when the bx:schedule action="reload" is invoked.
+	 *
+	 * @param schedulerName The key of the scheduler to reload
+	 * @param force         If true, force-kills running tasks during shutdown
+	 * @param timeout       Graceful shutdown timeout in seconds
+	 *
+	 * @return This service for chaining
+	 */
+	public SchedulerService reloadSchedulerFromDisk( Key schedulerName, boolean force, long timeout ) {
+		String name = schedulerName.getName();
+		this.logger.info( "+ Reloading scheduler [{}] from disk...", name );
+
+		// Shutdown and remove the existing scheduler
+		if ( hasScheduler( schedulerName ) ) {
+			removeScheduler( schedulerName, force, timeout );
+		}
+
+		// Re-load tasks from tasks.json for this scheduler only
+		Path		tasksFilePath	= getTasksFilePath();
+		IBoxContext	runtimeContext	= runtime.getRuntimeContext();
+
+		if ( java.nio.file.Files.exists( tasksFilePath ) ) {
+			Array tasks;
+			try {
+				tasks = loadTasksFromDisk();
+			} catch ( Exception e ) {
+				this.logger.error( "Failed to reload tasks for scheduler [{}] — scheduler will start empty: {}", name, e.getMessage() );
+				tasks = new Array();
+			}
+
+			for ( Object entry : tasks ) {
+				if ( ! ( entry instanceof IStruct ) ) {
+					continue;
+				}
+				IStruct	taskDef			= ( IStruct ) entry;
+
+				// Only process tasks belonging to this scheduler
+				Object	schedulerField	= taskDef.get( Key.scheduler );
+				String	taskScheduler	= schedulerField != null ? schedulerField.toString() : DEFAULT_SCHEDULER_NAME;
+				if ( !name.equalsIgnoreCase( taskScheduler ) ) {
+					continue;
+				}
+
+				String taskName = taskDef.getAsString( Key.task );
+				if ( taskName == null || taskName.isBlank() ) {
+					this.logger.warn( "Skipping persisted task with no name during reload of scheduler [{}]", name );
+					continue;
+				}
+
+				boolean paused = BooleanCaster.cast( taskDef.getOrDefault( Key.paused, false ) );
+
+				// Get or create the (now-empty) scheduler
+				if ( !hasScheduler( schedulerName ) ) {
+					BaseScheduler s = new BaseScheduler( name, runtimeContext );
+					registerScheduler( s, false );
+				}
+				BaseScheduler scheduler = ( BaseScheduler ) getScheduler( schedulerName );
+
+				decryptTaskCredentials( taskDef );
+
+				Runnable		callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
+				String			group			= taskDef.getAsString( Key.group );
+				ScheduledTask	scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+
+				ortus.boxlang.runtime.components.async.Schedule.applyTaskConfiguration( scheduledTask, callable, taskDef, runtimeContext );
+
+				if ( paused ) {
+					scheduledTask.disable();
+				}
+
+				this.logger.info( "  + Reloaded task [{}] in scheduler [{}]", taskName, name );
+			}
+		} else {
+			this.logger.info( "+ No tasks.json found — scheduler [{}] will start empty after reload", name );
+		}
+
+		// Start the scheduler if tasks were found and a scheduler was created
+		IScheduler scheduler = getScheduler( schedulerName );
+		if ( scheduler != null ) {
+			startupScheduler( scheduler );
+			announce(
+			    BoxEvent.ON_SCHEDULER_RESTART,
+			    Struct.of( "scheduler", scheduler, "force", force, "timeout", timeout )
+			);
+			this.logger.info( "+ Scheduler [{}] reloaded from disk", name );
+		}
+
+		return this;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
@@ -17,21 +17,19 @@
  */
 package ortus.boxlang.runtime.services;
 
-import java.nio.file.ClosedWatchServiceException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
 import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import ortus.boxlang.runtime.async.watchers.WatcherEvent;
+import ortus.boxlang.runtime.async.watchers.WatcherInstance;
+import ortus.boxlang.runtime.async.watchers.listeners.IWatcherListener;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
@@ -106,21 +104,16 @@ public class SchedulerService extends BaseService {
 	private volatile String			tasksEncryptionKey			= null;
 
 	/**
-	 * Background thread that watches tasks.json for external changes.
+	 * WatcherInstance that monitors tasks.json for external changes.
 	 * Non-null only when reloadOnChange=true and the watcher started successfully.
 	 */
-	private Thread					watchThread					= null;
-
-	/**
-	 * The Java NIO WatchService used by the tasks.json watcher thread.
-	 */
-	private WatchService			watchService				= null;
+	private WatcherInstance			tasksFileWatcher			= null;
 
 	/**
 	 * Epoch-millisecond timestamp of the most recent self-write to tasks.json.
 	 * Used to suppress watcher events triggered by the service's own writes.
 	 */
-	private volatile long			lastSelfWriteMs				= 0;
+	volatile long					lastSelfWriteMs				= 0;
 
 	/**
 	 * Watcher events arriving within this many milliseconds after a self-write are
@@ -1000,62 +993,50 @@ public class SchedulerService extends BaseService {
 	// --------------------------------------------------------------------------
 
 	/**
-	 * Start a daemon thread that watches tasks.json for external modifications.
-	 * When a change is detected outside the self-write grace window, all affected
-	 * schedulers are reloaded from disk via {@link #reloadSchedulerFromDisk}.
+	 * Starts a {@link WatcherInstance} that monitors the tasks.json parent directory for
+	 * external modifications. When a relevant change arrives outside the self-write grace
+	 * window, {@link #onTasksFileChanged()} is called to reload affected schedulers.
 	 */
 	private void startTasksFileWatcher() {
 		Path	tasksFilePath	= getTasksFilePath().toAbsolutePath().normalize();
 		Path	watchDir		= tasksFilePath.getParent();
+		String	fileName		= tasksFilePath.getFileName().toString();
 
 		try {
 			Files.createDirectories( watchDir );
-			this.watchService = FileSystems.getDefault().newWatchService();
-			watchDir.register( this.watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE );
 		} catch ( Exception e ) {
-			this.logger.error( "Failed to start tasks.json reload-on-change watcher: {}", e.getMessage() );
+			this.logger.error( "Cannot create tasks directory for reload-on-change: {}", e.getMessage() );
 			return;
 		}
 
-		String finalFileName = tasksFilePath.getFileName().toString();
-		this.watchThread = new Thread( () -> {
-			while ( !Thread.currentThread().isInterrupted() ) {
-				WatchKey key;
-				try {
-					key = this.watchService.take();
-				} catch ( InterruptedException e ) {
-					Thread.currentThread().interrupt();
-					break;
-				} catch ( ClosedWatchServiceException e ) {
-					break;
-				}
-
-				for ( WatchEvent<?> event : key.pollEvents() ) {
-					if ( event.kind() == StandardWatchEventKinds.OVERFLOW ) {
-						continue;
-					}
-					@SuppressWarnings( "unchecked" )
-					Path changed = ( ( WatchEvent<Path> ) event ).context();
-					if ( finalFileName.equals( changed.getFileName().toString() ) ) {
-						onTasksFileChanged();
-					}
-				}
-
-				key.reset();
+		IWatcherListener watcherListener = ( event, ctx ) -> {
+			if ( ( event.getKind() == WatcherEvent.Kind.MODIFIED || event.getKind() == WatcherEvent.Kind.CREATED )
+			    && event.getPath() != null
+			    && fileName.equals( event.getPath().getFileName().toString() ) ) {
+				onTasksFileChanged();
 			}
-		}, "bxschedule-tasks-watcher" );
-		this.watchThread.setDaemon( true );
-		this.watchThread.start();
+		};
+
+		this.tasksFileWatcher = WatcherInstance.builder( Key.of( "bxschedule-tasks-watcher" ) )
+		    .addPath( watchDir.toString() )
+		    .recursive( false )
+		    .debounce( 500 )
+		    .atomicWrites( true )
+		    .errorThreshold( 5 )
+		    .parentContext( runtime.getRuntimeContext() )
+		    .listener( watcherListener )
+		    .build()
+		    .start();
 
 		this.logger.info( "+ Scheduler Service tasks.json reload-on-change watcher started for [{}]", tasksFilePath );
 	}
 
 	/**
-	 * Called by the watcher thread when tasks.json changes on disk.
+	 * Called when tasks.json changes on disk.
 	 * Suppresses events caused by the service's own writes (within the grace window),
 	 * then reloads all affected schedulers.
 	 */
-	private void onTasksFileChanged() {
+	void onTasksFileChanged() {
 		if ( System.currentTimeMillis() - this.lastSelfWriteMs < SELF_WRITE_GRACE_MS ) {
 			this.logger.debug( "+ tasks.json changed (self-write within grace window) — suppressing reload-on-change" );
 			return;
@@ -1097,20 +1078,12 @@ public class SchedulerService extends BaseService {
 	}
 
 	/**
-	 * Stop and clean up the tasks.json watcher thread and WatchService.
+	 * Stop and clean up the tasks.json WatcherInstance.
 	 */
 	private void stopTasksFileWatcher() {
-		if ( this.watchThread != null ) {
-			this.watchThread.interrupt();
-			this.watchThread = null;
-		}
-		if ( this.watchService != null ) {
-			try {
-				this.watchService.close();
-			} catch ( Exception e ) {
-				// ignore — we're shutting down
-			}
-			this.watchService = null;
+		if ( this.tasksFileWatcher != null && this.tasksFileWatcher.isRunning() ) {
+			this.tasksFileWatcher.stop( true );
+			this.tasksFileWatcher = null;
 		}
 	}
 

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -376,7 +376,10 @@
 		"schedulers": [],
 		// The path to the JSON file where bx:schedule tasks are persisted across restarts.
 		// Supports ${boxlang-home} and other placeholder variables.
-		"tasksFile": "${boxlang-home}/config/tasks.json"
+		"tasksFile": "${boxlang-home}/config/tasks.json",
+		// When true, the scheduler service watches tasks.json for external changes and automatically
+		// reloads all affected schedulers. Self-writes from bx:schedule actions are suppressed.
+		"reloadOnChange": false
 	},
 	// BoxLang Watcher Service
 	// Manages filesystem watchers that fire BoxLang listeners whenever files change.

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
@@ -649,4 +649,65 @@ public class ScheduleTest {
 		assertThat( paused ).isNotNull();
 		assertThat( paused.toString() ).isEqualTo( "false" );
 	}
+
+	// --------------------------------------------------------------------------
+	// Reload action tests
+	// --------------------------------------------------------------------------
+
+	@DisplayName( "reload shuts down the scheduler and reloads tasks from disk" )
+	@Test
+	public void testReloadReloadsTasksFromDisk() {
+		// Create two tasks — they are persisted to tasks.json
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="reloadTask1" url="http://localhost/test" interval="120">
+		    <bx:schedule action="update" task="reloadTask2" url="http://localhost/test" interval="120">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		// Remove the in-memory scheduler to simulate a fresh state
+		svc.removeScheduler( SCHEDULER_KEY, true, 5 );
+		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+
+		// reload should restore the scheduler from tasks.json
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="reload">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isTrue();
+		BaseScheduler scheduler = ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		assertThat( scheduler.hasTask( "reloadTask1" ) ).isTrue();
+		assertThat( scheduler.hasTask( "reloadTask2" ) ).isTrue();
+	}
+
+	@DisplayName( "reload with no tasks.json starts an empty scheduler without error" )
+	@Test
+	public void testReloadWithNoTasksOnDisk() {
+		// Ensure no tasks.json exists
+		Path tasksFile = instance.getRuntimeHome().resolve( "config/tasks.json" );
+		try {
+			java.nio.file.Files.deleteIfExists( tasksFile );
+		} catch ( Exception e ) {
+			// ignore
+		}
+
+		// reload must not throw even when tasks.json is absent
+		instance.executeSource(
+		    """
+		    <bx:schedule action="reload">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+
+		// No scheduler is created when there is nothing to load
+		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/services/SchedulerServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/SchedulerServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,8 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
 import ortus.boxlang.runtime.async.tasks.IScheduler;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class SchedulerServiceTest {
@@ -48,6 +51,12 @@ public class SchedulerServiceTest {
 	@AfterAll
 	public static void tearDownAfterAll() {
 		// runtime.shutdown( true );
+	}
+
+	@AfterEach
+	public void tearDownEach() {
+		schedulerService.removeScheduler( Key.of( "bxschedule-watcher-test" ), true, 0L );
+		schedulerService.removeScheduler( Key.of( "bxschedule-grace-test" ), true, 0L );
 	}
 
 	@DisplayName( "Test it can get an instance of the service" )
@@ -147,5 +156,105 @@ public class SchedulerServiceTest {
 		assertThrows( BoxRuntimeException.class, () -> {
 			schedulerService.newScheduler( "testDup", null, null, false );
 		} );
+	}
+
+	// --------------------------------------------------------------------------
+	// onTasksFileChanged tests (reloadOnChange watcher)
+	// --------------------------------------------------------------------------
+
+	@Test
+	@DisplayName( "When tasks.json changes externally (outside the 5s grace window), onTasksFileChanged reloads the affected scheduler" )
+	void testExternalFileChangeTriggerReload() {
+		Key		testSchedulerKey	= Key.of( "bxschedule-watcher-test" );
+		String	schedulerName		= testSchedulerKey.getName();
+
+		// Build a minimal task definition for the test scheduler
+		Array	tasks				= new Array();
+		tasks.add( Struct.ofNonConcurrent(
+		    "task", "watcherTestTask",
+		    "scheduler", schedulerName,
+		    "url", "http://localhost/watcher-test",
+		    "interval", "3600",
+		    "cronTime", "",
+		    "startDate", "", "startTime", "",
+		    "endDate", "", "endTime", "",
+		    "repeat", 0,
+		    "exclude", "",
+		    "port", 80,
+		    "username", "", "password", "",
+		    "proxyServer", "", "proxyPort", 0,
+		    "proxyUser", "", "proxyPassword", "",
+		    "publish", false,
+		    "path", "", "file", "",
+		    "overwrite", true, "resolveURL", false,
+		    "retryCount", 0,
+		    "onException", "", "oncomplete", "", "eventhandler", "",
+		    "cluster", false, "isDaily", false, "paused", false,
+		    "group", ""
+		) );
+
+		// Write tasks to disk — saveTasksToDisk stamps lastSelfWriteMs to now
+		schedulerService.saveTasksToDisk( tasks );
+
+		// Simulate grace window elapsed by zeroing the self-write timestamp
+		schedulerService.lastSelfWriteMs = 0;
+
+		// Trigger the reload handler directly (no actual file watcher needed)
+		schedulerService.onTasksFileChanged();
+
+		// The scheduler should now be registered and started
+		assertThat( schedulerService.hasScheduler( testSchedulerKey ) ).isTrue();
+		assertThat( ( ( BaseScheduler ) schedulerService.getScheduler( testSchedulerKey ) ).hasTask( "watcherTestTask" ) ).isTrue();
+
+		// Cleanup: remove test tasks from disk
+		schedulerService.lastSelfWriteMs = 0;
+		schedulerService.saveTasksToDisk( new Array() );
+	}
+
+	@Test
+	@DisplayName( "When tasks.json changes within the 5s self-write grace window, onTasksFileChanged suppresses the reload" )
+	void testSelfWriteGracePreventsReload() {
+		Key		testSchedulerKey	= Key.of( "bxschedule-grace-test" );
+		String	schedulerName		= testSchedulerKey.getName();
+
+		// Ensure no pre-existing scheduler
+		schedulerService.removeScheduler( testSchedulerKey, true, 0L );
+
+		// Write tasks to disk — saveTasksToDisk stamps lastSelfWriteMs to now (within grace)
+		Array tasks = new Array();
+		tasks.add( Struct.ofNonConcurrent(
+		    "task", "graceTestTask",
+		    "scheduler", schedulerName,
+		    "url", "http://localhost/grace-test",
+		    "interval", "3600",
+		    "cronTime", "",
+		    "startDate", "", "startTime", "",
+		    "endDate", "", "endTime", "",
+		    "repeat", 0,
+		    "exclude", "",
+		    "port", 80,
+		    "username", "", "password", "",
+		    "proxyServer", "", "proxyPort", 0,
+		    "proxyUser", "", "proxyPassword", "",
+		    "publish", false,
+		    "path", "", "file", "",
+		    "overwrite", true, "resolveURL", false,
+		    "retryCount", 0,
+		    "onException", "", "oncomplete", "", "eventhandler", "",
+		    "cluster", false, "isDaily", false, "paused", false,
+		    "group", ""
+		) );
+		schedulerService.saveTasksToDisk( tasks );
+
+		// lastSelfWriteMs is now set to System.currentTimeMillis() — within the 5s grace window
+		// Trigger the reload handler: the event should be suppressed
+		schedulerService.onTasksFileChanged();
+
+		// The scheduler must NOT have been registered (reload was suppressed)
+		assertThat( schedulerService.hasScheduler( testSchedulerKey ) ).isFalse();
+
+		// Cleanup: remove test tasks from disk
+		schedulerService.lastSelfWriteMs = 0;
+		schedulerService.saveTasksToDisk( new Array() );
 	}
 }


### PR DESCRIPTION
Adds action="reload" to the bx:schedule component, which shuts down the
named scheduler, discards its in-memory tasks, re-reads tasks.json for that
scheduler's tasks, and restarts it — a hot-reload without restarting the runtime.

- Schedule.java: register reload as a valid action; exclude it from the
  task-name requirement and the post-switch startup guard; delegate to
  SchedulerService.reloadSchedulerFromDisk()
- SchedulerService.java: add reloadSchedulerFromDisk() which shuts down,
  removes, re-registers from disk, and announces ON_SCHEDULER_RESTART
- ScheduleTest.java: two new tests covering reload-with-tasks and
  reload-with-no-tasks-on-disk

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJfiN9ooDRZnY2H8XryZhy