### PR TITLE
feat: pluggable class-loader factory for the runtime and modules

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -63,7 +63,8 @@ import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.loader.ClassLocator;
-import ortus.boxlang.runtime.loader.DynamicClassLoader;
+import ortus.boxlang.runtime.loader.DynamicClassLoaderFactory;
+import ortus.boxlang.runtime.loader.IClassLoaderFactory;
 import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.runnables.BoxScript;
 import ortus.boxlang.runtime.runnables.BoxTemplate;
@@ -180,9 +181,18 @@ public class BoxRuntime implements java.io.Closeable {
 	private Set<String>							runtimeFileExtensions	= new HashSet<>( Arrays.asList( ".bx", ".bxm", ".bxs" ) );
 
 	/**
-	 * The runtime class loader
+	 * The runtime class loader. Typed as {@link ClassLoader} so deployment targets can supply
+	 * a non-{@code URLClassLoader} implementation via {@link #setClassLoaderFactory}.
 	 */
-	private DynamicClassLoader					runtimeLoader;
+	private ClassLoader							runtimeLoader;
+
+	/**
+	 * The factory used to build the runtime + module class loaders. Defaults to the standard
+	 * JVM {@link DynamicClassLoaderFactory}. Must be set BEFORE the runtime is booted
+	 * ({@code getInstance(...)}); alternative targets (e.g. Android) swap it to avoid the
+	 * JVM-only {@code URLClassLoader}.
+	 */
+	private static IClassLoaderFactory			classLoaderFactory		= new DynamicClassLoaderFactory();
 
 	/**
 	 * The CLI Options that where used to start the runtime, if any.
@@ -513,12 +523,9 @@ public class BoxRuntime implements java.io.Closeable {
 		// Ensure home assets
 		ensureHomeAssets();
 
-		// Load the Dynamic Class Loader for the runtime
-		this.runtimeLoader = new DynamicClassLoader(
-		    Key.runtime,
-		    getConfiguration().getJavaLibraryPaths(),
-		    this.getClass().getClassLoader(),
-		    true );
+		// Build the runtime class loader via the configured factory (default = DynamicClassLoader).
+		// Targets that cannot use URLClassLoader (e.g. Android) install a factory before boot.
+		this.runtimeLoader = classLoaderFactory.createRuntimeClassLoader( this, this.getClass().getClassLoader() );
 
 		// Announce it to the services
 		this.interceptorService.onConfigurationLoad();
@@ -874,10 +881,32 @@ public class BoxRuntime implements java.io.Closeable {
 	/**
 	 * Get runtime class loader
 	 *
-	 * @return {@link DynamicClassLoader} or null if the runtime has not started
+	 * @return The runtime {@link ClassLoader} or null if the runtime has not started
 	 */
-	public DynamicClassLoader getRuntimeLoader() {
+	public ClassLoader getRuntimeLoader() {
 		return instance.runtimeLoader;
+	}
+
+	/**
+	 * Get the factory used to build the runtime + module class loaders.
+	 *
+	 * @return the class loader factory
+	 */
+	public IClassLoaderFactory getClassLoaderFactory() {
+		return classLoaderFactory;
+	}
+
+	/**
+	 * Set the factory used to build the runtime + module class loaders. MUST be called BEFORE
+	 * the runtime is booted ({@code getInstance(...)}) for the runtime loader to honor it; it
+	 * has no effect on an already-built runtime loader. Alternative deployment targets (e.g.
+	 * Android) install their own factory here at boot to avoid the JVM-only
+	 * {@code URLClassLoader}.
+	 *
+	 * @param factory the factory to use
+	 */
+	public static void setClassLoaderFactory( IClassLoaderFactory factory ) {
+		classLoaderFactory = factory;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -906,7 +906,7 @@ public class BoxRuntime implements java.io.Closeable {
 	 * @param factory the factory to use
 	 */
 	public static void setClassLoaderFactory( IClassLoaderFactory factory ) {
-		classLoaderFactory = factory;
+		classLoaderFactory = java.util.Objects.requireNonNull( factory, "ClassLoaderFactory cannot be null" );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRuntime.java
@@ -192,7 +192,7 @@ public class BoxRuntime implements java.io.Closeable {
 	 * ({@code getInstance(...)}); alternative targets (e.g. Android) swap it to avoid the
 	 * JVM-only {@code URLClassLoader}.
 	 */
-	private static IClassLoaderFactory			classLoaderFactory		= new DynamicClassLoaderFactory();
+	private static volatile IClassLoaderFactory			classLoaderFactory		= new DynamicClassLoaderFactory();
 
 	/**
 	 * The CLI Options that where used to start the runtime, if any.

--- a/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
@@ -348,16 +348,16 @@ public abstract class BaseApplicationListener {
 	 *
 	 * @return The request class loader
 	 */
-	public DynamicClassLoader getRequestClassLoader( RequestBoxContext context ) {
+	public ClassLoader getRequestClassLoader( RequestBoxContext context ) {
 		// If the application is null, return the default
 		if ( this.application == null ) {
 			return BoxRuntime.getInstance().getRuntimeLoader();
 		}
 
 		// We are in app mode
-		URL[]				loadPathsUrls	= getJavaSettingsLoadPaths( context );
-		String				loaderCacheKey	= EncryptionUtil.hash( Arrays.toString( loadPathsUrls ) );
-		DynamicClassLoader	target			= this.application.getClassLoader( loaderCacheKey );
+		URL[]		loadPathsUrls	= getJavaSettingsLoadPaths( context );
+		String		loaderCacheKey	= EncryptionUtil.hash( Arrays.toString( loadPathsUrls ) );
+		ClassLoader	target			= this.application.getClassLoader( loaderCacheKey );
 		if ( target == null ) {
 			target = BoxRuntime.getInstance().getRuntimeLoader();
 		}

--- a/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
@@ -32,7 +32,6 @@ import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.jdbc.ConnectionManager;
-import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.ThreadScope;
@@ -79,7 +78,7 @@ public abstract class RequestBoxContext extends BaseBoxContext implements IJDBCC
 	/**
 	 * The request class loader
 	 */
-	private DynamicClassLoader									requestClassLoader		= null;
+	private ClassLoader											requestClassLoader		= null;
 
 	/**
 	 * Flag to enforce explicit output
@@ -281,7 +280,7 @@ public abstract class RequestBoxContext extends BaseBoxContext implements IJDBCC
 	 *
 	 * @return The class loader
 	 */
-	public DynamicClassLoader getRequestClassLoader() {
+	public ClassLoader getRequestClassLoader() {
 		if ( this.requestClassLoader != null ) {
 			return this.requestClassLoader;
 		}

--- a/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
@@ -46,7 +46,7 @@ import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.exceptions.BoxIOException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
-public class DynamicClassLoader extends URLClassLoader {
+public class DynamicClassLoader extends URLClassLoader implements IModuleClassLoader {
 
 	/**
 	 * The name of the class loader as a {@link Key}
@@ -162,6 +162,16 @@ public class DynamicClassLoader extends URLClassLoader {
 	 */
 	public Key getNameAsKey() {
 		return this.nameAsKey;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return This loader as a {@link ClassLoader}
+	 */
+	@Override
+	public ClassLoader toClassLoader() {
+		return this;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoaderFactory.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoaderFactory.java
@@ -1,0 +1,78 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.loader;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.modules.ModuleRecord;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.services.ModuleService;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+/**
+ * The default, standard-JVM class loader factory.
+ * <p>
+ * Builds {@link DynamicClassLoader}s ({@code URLClassLoader}s) for both the runtime loader and
+ * each module loader, reproducing the behavior that previously lived inline in the
+ * {@link BoxRuntime} constructor and {@code ModuleRecord.register()}.
+ */
+public class DynamicClassLoaderFactory implements IClassLoaderFactory {
+
+	@Override
+	public ClassLoader createRuntimeClassLoader( BoxRuntime runtime, ClassLoader appParent ) {
+		return new DynamicClassLoader(
+		    Key.runtime,
+		    runtime.getConfiguration().getJavaLibraryPaths(),
+		    appParent,
+		    true
+		);
+	}
+
+	@Override
+	public IModuleClassLoader createModuleClassLoader( ModuleRecord record, ClassLoader parent ) {
+		DynamicClassLoader classLoader;
+		try {
+			// Load *.class files under the `modules.<name>` package prefix from the module dir.
+			classLoader = new DynamicClassLoader(
+			    record.name,
+			    record.physicalPath.toUri().toURL(),
+			    parent,
+			    false
+			);
+		} catch ( MalformedURLException e ) {
+			throw new BoxRuntimeException( "Error creating module [" + record.name + "] class loader", e );
+		}
+
+		// Seed the loader with the module's libs/*.jar dependencies (jars ONLY).
+		Path libsPath = record.physicalPath.resolve( ModuleService.MODULE_LIBS );
+		if ( Files.exists( libsPath ) && Files.isDirectory( libsPath ) ) {
+			try {
+				classLoader.addURLs( DynamicClassLoader.getJarURLs( libsPath ) );
+			} catch ( IOException e ) {
+				throw new BoxRuntimeException(
+				    "Error while seeding the module [" + record.name + "] class loader with the libs folder", e );
+			}
+		}
+
+		return classLoader;
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/loader/IClassLoaderFactory.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/IClassLoaderFactory.java
@@ -1,0 +1,61 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.loader;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.modules.ModuleRecord;
+
+/**
+ * Factory for the runtime's class loaders — both the root runtime loader and each module's
+ * isolated loader.
+ * <p>
+ * A single factory governs all class-loader construction so a deployment target can swap the
+ * whole strategy in one place, without forking {@link BoxRuntime}, {@code ModuleService}, or
+ * {@code ModuleRecord}. The default {@link DynamicClassLoaderFactory} builds
+ * {@link DynamicClassLoader}s ({@code URLClassLoader}s). Targets that cannot use
+ * {@code URLClassLoader} or runtime {@code defineClass} (e.g. Android) provide their own — the
+ * runtime loader can simply be the application class loader, and modules can be
+ * {@code DexClassLoader}-backed.
+ * <p>
+ * Install via {@link BoxRuntime#setClassLoaderFactory(IClassLoaderFactory)} <b>before the
+ * runtime is booted</b> ({@code getInstance(...)}), because the runtime loader is built during
+ * construction.
+ */
+public interface IClassLoaderFactory {
+
+	/**
+	 * Create the runtime's root class loader (parent of all module loaders, used for
+	 * runtime-level Java interop / dynamic lookups). Consumed purely as a {@link ClassLoader}.
+	 *
+	 * @param runtime   The runtime being booted (provides configuration such as javaLibraryPaths)
+	 * @param appParent The application/system class loader to parent to
+	 *
+	 * @return The runtime class loader
+	 */
+	ClassLoader createRuntimeClassLoader( BoxRuntime runtime, ClassLoader appParent );
+
+	/**
+	 * Create a module's isolated class loader.
+	 *
+	 * @param record The module record (provides name, physical path, libs location, etc.)
+	 * @param parent The parent class loader (typically the runtime loader)
+	 *
+	 * @return The module's class loader
+	 */
+	IModuleClassLoader createModuleClassLoader( ModuleRecord record, ClassLoader parent );
+}

--- a/src/main/java/ortus/boxlang/runtime/loader/IModuleClassLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/IModuleClassLoader.java
@@ -1,0 +1,63 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.loader;
+
+import java.io.Closeable;
+
+import ortus.boxlang.runtime.scopes.Key;
+
+/**
+ * The contract a BoxLang module class loader must satisfy.
+ * <p>
+ * Modules are loaded in isolation: each module gets its own class loader, parented to the
+ * runtime loader, so module dependencies don't clash and modules can't see each other except
+ * through the runtime. On the standard JVM this is fulfilled by {@link DynamicClassLoader}
+ * (a {@code URLClassLoader}). Other deployment targets can provide a different implementation
+ * — for example Android, where {@code URLClassLoader} is unavailable and runtime
+ * {@code defineClass} of JVM bytecode is forbidden, can supply a {@code DexClassLoader}-backed
+ * loader. The implementation is selected per-runtime via an
+ * {@link IClassLoaderFactory}.
+ * <p>
+ * <b>Implementations MUST be a {@link java.lang.ClassLoader}</b> (so they can be passed to
+ * {@link java.util.ServiceLoader}); {@link #toClassLoader()} exposes that view.
+ */
+public interface IModuleClassLoader extends Closeable {
+
+	/**
+	 * Find a class in this module loader.
+	 *
+	 * @param className   The fully-qualified class name
+	 * @param safe        When {@code true}, return {@code null} instead of throwing if not found
+	 * @param checkParent When {@code true}, delegate to the parent loader if not found locally
+	 *
+	 * @return The loaded class, or {@code null} when {@code safe} and not found
+	 *
+	 * @throws ClassNotFoundException If the class cannot be found and {@code safe} is {@code false}
+	 */
+	Class<?> findClass( String className, Boolean safe, boolean checkParent ) throws ClassNotFoundException;
+
+	/**
+	 * @return The unique name of this loader as a {@link Key}
+	 */
+	Key getNameAsKey();
+
+	/**
+	 * @return This loader viewed as a {@link ClassLoader} (for {@code ServiceLoader} and interop)
+	 */
+	ClassLoader toClassLoader();
+}

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/BaseResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/BaseResolver.java
@@ -30,7 +30,6 @@ import ortus.boxlang.runtime.config.Configuration;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.loader.ClassLocation;
 import ortus.boxlang.runtime.loader.ClassLocator;
-import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.loader.ImportDefinition;
 import ortus.boxlang.runtime.loader.util.ClassDiscovery;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
@@ -306,7 +305,7 @@ public class BaseResolver implements IClassResolver {
 	 *
 	 * @return The BL system class loader
 	 */
-	protected static DynamicClassLoader getSystemClassLoader() {
+	protected static ClassLoader getSystemClassLoader() {
 		return BoxRuntime.getInstance().getRuntimeLoader();
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/JavaResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/JavaResolver.java
@@ -31,7 +31,6 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.RequestBoxContext;
 import ortus.boxlang.runtime.loader.ClassLocation;
 import ortus.boxlang.runtime.loader.ClassLocator;
-import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.loader.ImportDefinition;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ModuleService;
@@ -247,7 +246,7 @@ public class JavaResolver extends BaseResolver {
 	public Optional<ClassLocation> findFromSystem( String fullyQualifiedName, List<ImportDefinition> imports, IBoxContext context ) {
 		// Let's see if we get the request box context, so we can get the current request class loader
 		RequestBoxContext	requestContext	= context.getRequestContext();
-		DynamicClassLoader	classLoader		= ( requestContext == null ? getSystemClassLoader() : requestContext.getRequestClassLoader() );
+		ClassLoader			classLoader		= ( requestContext == null ? getSystemClassLoader() : requestContext.getRequestClassLoader() );
 
 		Class<?>			clazz;
 		try {

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -19,7 +19,6 @@ package ortus.boxlang.runtime.modules;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -56,7 +55,7 @@ import ortus.boxlang.runtime.events.IInterceptor;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.jdbc.drivers.DriverShim;
 import ortus.boxlang.runtime.jdbc.drivers.IJDBCDriver;
-import ortus.boxlang.runtime.loader.DynamicClassLoader;
+import ortus.boxlang.runtime.loader.IModuleClassLoader;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.runnables.RunnableLoader;
@@ -219,9 +218,11 @@ public class ModuleRecord {
 	public long						activationTime				= 0;
 
 	/**
-	 * The Dynamic class loader for the module
+	 * The class loader for the module (isolated, parented to the runtime loader). The concrete
+	 * implementation is chosen by the runtime's
+	 * {@link ortus.boxlang.runtime.loader.IClassLoaderFactory}.
 	 */
-	public DynamicClassLoader		classLoader					= null;
+	public IModuleClassLoader		classLoader					= null;
 
 	/**
 	 * The descriptor for the module
@@ -426,36 +427,12 @@ public class ModuleRecord {
 		this.runtime.getConfiguration().registerMapping( this.mapping );
 		this.runtime.getConfiguration().registerMapping( this.publicMapping );
 
-		// Create the module class loader and seed it with the physical path to the
-		// module
-		// This traverses the module and looks for *.class files to load (NOT JARs)
-		// Using the `modules.{module_name}` package prefix
-		// This is important for module developers to include this as their package
-		// prefix.
-		try {
-			this.classLoader = new DynamicClassLoader(
-			    this.name,
-			    this.physicalPath.toUri().toURL(),
-			    this.runtime.getRuntimeLoader(),
-			    false );
-		} catch ( MalformedURLException e ) {
-			this.logger.error( "Error creating module [{}] class loader.", this.name, e );
-			throw new BoxRuntimeException( "Error creating module [" + this.name + "] class loader", e );
-		}
-
-		// Do we have libs to add to the class loader? These are jars ONLY
-		// All dependencies on Java libs must be on this folder as JARs
-		Path libsPath = this.physicalPath.resolve( ModuleService.MODULE_LIBS );
-		if ( Files.exists( libsPath ) && Files.isDirectory( libsPath ) ) {
-			try {
-				this.classLoader.addURLs( DynamicClassLoader.getJarURLs( libsPath ) );
-			} catch ( IOException e ) {
-				this.logger.error( "Error while seeding the module [{}] class loader with the libs folder.", this.name,
-				    e );
-				throw new BoxRuntimeException(
-				    "Error while seeding the module [" + this.name + "] class loader with the libs folder", e );
-			}
-		}
+		// Create the module's (isolated) class loader via the runtime's configured factory.
+		// The default JVM factory builds a DynamicClassLoader over the module directory
+		// (loading *.class under the `modules.{module_name}` prefix) seeded with libs/*.jar;
+		// other targets (e.g. Android) supply a different loader without forking this class.
+		this.classLoader = this.runtime.getClassLoaderFactory()
+		    .createModuleClassLoader( this, this.runtime.getRuntimeLoader() );
 
 		// Call the configure() method if it exists in the descriptor
 		if ( thisScope.containsKey( Key.configure ) ) {
@@ -505,13 +482,13 @@ public class ModuleRecord {
 		}
 
 		// Register any global services
-		ServiceLoader.load( IService.class, this.classLoader )
+		ServiceLoader.load( IService.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( service -> this.runtime.putGlobalService( service.getName(), service ) );
 
 		// Load any JDBC drivers into the JVM
-		ServiceLoader.load( Driver.class, this.classLoader )
+		ServiceLoader.load( Driver.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( driver -> {
@@ -525,39 +502,39 @@ public class ModuleRecord {
 		    } );
 
 		// Load any BoxLang IJDBC Driver classes
-		ServiceLoader.load( IJDBCDriver.class, this.classLoader )
+		ServiceLoader.load( IJDBCDriver.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( driver -> this.runtime.getDataSourceService().registerDriver( driver ) );
 
 		// Do we have any Java BIFs to load?
-		ServiceLoader.load( BIF.class, this.classLoader )
+		ServiceLoader.load( BIF.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::type )
 		    .forEach( clazz -> functionService.processBIFRegistration( clazz, null, this.name.getName() ) );
 
 		// Do we have any Java Component Tags to load?
-		ServiceLoader.load( Component.class, this.classLoader )
+		ServiceLoader.load( Component.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::type )
 		    .forEach( targetClass -> componentService.registerComponent( targetClass, null, this.name.getName() ) );
 
 		// Do we have any Java Schedulers to register in the SchedulerService
-		ServiceLoader.load( IScheduler.class, this.classLoader )
+		ServiceLoader.load( IScheduler.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( scheduler -> this.runtime.getSchedulerService()
 		        .loadScheduler( Key.of( scheduler.getSchedulerName() + "@" + this.name ), scheduler ) );
 
 		// Do we have any Java ICacheProviders to register in the CacheService
-		ServiceLoader.load( ICacheProvider.class, this.classLoader )
+		ServiceLoader.load( ICacheProvider.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::type )
 		    .forEach( provider -> this.runtime.getCacheService().registerProvider( Key.of( provider.getSimpleName() ),
 		        provider ) );
 
 		// Do we have any Java IInterceptor to register in the InterceptorService
-		ServiceLoader.load( IInterceptor.class, this.classLoader )
+		ServiceLoader.load( IInterceptor.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    // Only load interceptors that are set to auto-load by default or by
 		    // configuration
@@ -626,13 +603,13 @@ public class ModuleRecord {
 		InterceptorService interceptorService = this.runtime.getInterceptorService();
 
 		// Unregister any global services
-		ServiceLoader.load( IService.class, this.classLoader )
+		ServiceLoader.load( IService.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( service -> this.runtime.removeGlobalService( service.getName() ) );
 
 		// Unload JDBC drivers from the JVM
-		ServiceLoader.load( Driver.class, this.classLoader )
+		ServiceLoader.load( Driver.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( driver -> {
@@ -646,7 +623,7 @@ public class ModuleRecord {
 		    } );
 
 		// Unregister JDBC drivers from the datasource service
-		ServiceLoader.load( IJDBCDriver.class, this.classLoader )
+		ServiceLoader.load( IJDBCDriver.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( driver -> this.runtime.getDataSourceService().removeDriver( driver.getName() ) );
@@ -657,20 +634,20 @@ public class ModuleRecord {
 		// @TODO: Unregister components; we're lacking an unregisterComponent method in the ComponentService
 
 		// unregister schedulers
-		ServiceLoader.load( IScheduler.class, this.classLoader )
+		ServiceLoader.load( IScheduler.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::get )
 		    .forEach( scheduler -> this.runtime.getSchedulerService()
 		        .removeScheduler( Key.of( scheduler.getSchedulerName() + "@" + this.name ), true, 500 ) );
 
 		// Unregister cache providers
-		ServiceLoader.load( ICacheProvider.class, this.classLoader )
+		ServiceLoader.load( ICacheProvider.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    .map( ServiceLoader.Provider::type )
 		    .forEach( provider -> this.runtime.getCacheService().removeProvider( Key.of( provider.getSimpleName() ) ) );
 
 		// Unregister java interceptors
-		ServiceLoader.load( IInterceptor.class, this.classLoader )
+		ServiceLoader.load( IInterceptor.class, this.classLoader.toClassLoader() )
 		    .stream()
 		    // Only load interceptors that are set to auto-load by default or by
 		    // configuration

--- a/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
@@ -130,4 +130,6 @@ class ClassLoaderFactoryTest {
 				moduleRecord.unload( context );
 			}
 		}
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
@@ -115,14 +115,19 @@ class ClassLoaderFactoryTest {
 
 		IBoxContext		context			= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
 		String			physicalPath	= Paths.get( "./modules/test" ).toAbsolutePath().toString();
-		ModuleRecord	moduleRecord	= new ModuleRecord( physicalPath )
-		    .loadDescriptor( context )
-		    .register( context );
 
-		assertThat( seenModule.get() ).isEqualTo( moduleRecord.name.getName() );
-		assertThat( moduleRecord.classLoader ).isInstanceOf( IModuleClassLoader.class );
-		assertThat( moduleRecord.classLoader.toClassLoader() ).isNotNull();
+		ModuleRecord	moduleRecord	= null;
+		try {
+			moduleRecord = new ModuleRecord( physicalPath )
+			    .loadDescriptor( context )
+			    .register( context );
 
-		moduleRecord.unregister( context );
-	}
+			assertThat( seenModule.get() ).isEqualTo( moduleRecord.name.getName() );
+			assertThat( moduleRecord.classLoader ).isNotNull();
+			assertThat( moduleRecord.classLoader.toClassLoader() ).isNotNull();
+		} finally {
+			if ( moduleRecord != null ) {
+				moduleRecord.unload( context );
+			}
+		}
 }

--- a/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
@@ -1,0 +1,128 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.loader;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.modules.ModuleRecord;
+
+/**
+ * Verifies the single, consolidated {@link IClassLoaderFactory} seam that governs BOTH the
+ * runtime root loader and each module's isolated loader. The default reproduces the standard
+ * JVM {@link DynamicClassLoader} behavior; swapping the factory (installed at boot via
+ * {@link BoxRuntime#setClassLoaderFactory}) lets a target change all class-loader construction
+ * in one place — without forking {@code BoxRuntime}/{@code ModuleService}/{@code ModuleRecord}.
+ */
+class ClassLoaderFactoryTest {
+
+	static BoxRuntime	runtime;
+	IClassLoaderFactory	original;
+
+	@BeforeAll
+	static void setUpClass() {
+		runtime = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	void saveFactory() {
+		original = runtime.getClassLoaderFactory();
+	}
+
+	@AfterEach
+	void restoreFactory() {
+		BoxRuntime.setClassLoaderFactory( original );
+	}
+
+	@DisplayName( "The default class loader factory is the standard JVM factory" )
+	@Test
+	void testDefaultFactory() {
+		assertThat( original ).isInstanceOf( DynamicClassLoaderFactory.class );
+	}
+
+	@DisplayName( "The booted runtime loader was built by the factory (a DynamicClassLoader)" )
+	@Test
+	void testBootedRuntimeLoader() {
+		assertThat( runtime.getRuntimeLoader() ).isInstanceOf( DynamicClassLoader.class );
+	}
+
+	@DisplayName( "The factory builds a runtime loader parented to the app loader" )
+	@Test
+	void testCreateRuntimeClassLoader() {
+		ClassLoader created = new DynamicClassLoaderFactory().createRuntimeClassLoader( runtime, getClass().getClassLoader() );
+		assertThat( created ).isInstanceOf( DynamicClassLoader.class );
+	}
+
+	@DisplayName( "A swapped factory yields a non-DynamicClassLoader runtime loader" )
+	@Test
+	void testSwapRuntimeFactory() {
+		ClassLoader appParent = getClass().getClassLoader();
+		// A target like Android returns the app loader directly (no URLClassLoader).
+		BoxRuntime.setClassLoaderFactory( new DynamicClassLoaderFactory() {
+
+			@Override
+			public ClassLoader createRuntimeClassLoader( BoxRuntime rt, ClassLoader parent ) {
+				return parent;
+			}
+		} );
+
+		ClassLoader created = runtime.getClassLoaderFactory().createRuntimeClassLoader( runtime, appParent );
+		assertThat( created ).isSameInstanceAs( appParent );
+		assertThat( created ).isNotInstanceOf( DynamicClassLoader.class );
+	}
+
+	@DisplayName( "ModuleRecord.register builds the module loader through the factory" )
+	@Test
+	void testModuleLoaderUsesFactory() {
+		AtomicReference<String>	seenModule	= new AtomicReference<>();
+
+		// Delegating factory: record the module loader request, then defer to default behavior.
+		IClassLoaderFactory		original	= runtime.getClassLoaderFactory();
+		BoxRuntime.setClassLoaderFactory( new DynamicClassLoaderFactory() {
+
+			@Override
+			public IModuleClassLoader createModuleClassLoader( ModuleRecord record, ClassLoader parent ) {
+				seenModule.set( record.name.getName() );
+				return original.createModuleClassLoader( record, parent );
+			}
+		} );
+
+		IBoxContext		context			= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		String			physicalPath	= Paths.get( "./modules/test" ).toAbsolutePath().toString();
+		ModuleRecord	moduleRecord	= new ModuleRecord( physicalPath )
+		    .loadDescriptor( context )
+		    .register( context );
+
+		assertThat( seenModule.get() ).isEqualTo( moduleRecord.name.getName() );
+		assertThat( moduleRecord.classLoader ).isInstanceOf( IModuleClassLoader.class );
+		assertThat( moduleRecord.classLoader.toClassLoader() ).isNotNull();
+
+		moduleRecord.unregister( context );
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/loader/resolvers/JavaResolverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/resolvers/JavaResolverTest.java
@@ -235,16 +235,15 @@ public class JavaResolverTest extends AbstractResolverTest {
 	@DisplayName( "It can load libs from the 'home/libs' convention" )
 	@Test
 	void testItCanLoadLibsFromHomeLibs() throws IOException {
-		IBoxContext			ctx				= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
-		Path				homeLibs		= Path.of( "src/test/resources/libs" ).toAbsolutePath();
+		IBoxContext	ctx			= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		Path		homeLibs	= Path.of( "src/test/resources/libs" ).toAbsolutePath();
 
-		// On the JVM the runtime loader is a DynamicClassLoader; cast to seed it with jars.
-		DynamicClassLoader	runtimeLoader	= ( DynamicClassLoader ) runtime.getRuntimeLoader();
+		// On the JVM the runtime loader is a DynamicClassLoader; assert before casting to seed it with jars.
+		assertThat( runtime.getRuntimeLoader() ).isInstanceOf( DynamicClassLoader.class );
+		DynamicClassLoader runtimeLoader = ( DynamicClassLoader ) runtime.getRuntimeLoader();
 		runtimeLoader.addURLs(
 		    DynamicClassLoader.getJarURLs( homeLibs )
 		);
-
-		System.out.println( Arrays.toString( runtimeLoader.getURLs() ) );
 
 		String					targetClass	= "com.github.benmanes.caffeine.cache.Caffeine";
 		Optional<ClassLocation>	location	= javaResolver.resolve( ctx, targetClass );

--- a/src/test/java/ortus/boxlang/runtime/loader/resolvers/JavaResolverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/resolvers/JavaResolverTest.java
@@ -235,14 +235,16 @@ public class JavaResolverTest extends AbstractResolverTest {
 	@DisplayName( "It can load libs from the 'home/libs' convention" )
 	@Test
 	void testItCanLoadLibsFromHomeLibs() throws IOException {
-		IBoxContext	ctx			= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
-		Path		homeLibs	= Path.of( "src/test/resources/libs" ).toAbsolutePath();
+		IBoxContext			ctx				= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		Path				homeLibs		= Path.of( "src/test/resources/libs" ).toAbsolutePath();
 
-		runtime.getRuntimeLoader().addURLs(
+		// On the JVM the runtime loader is a DynamicClassLoader; cast to seed it with jars.
+		DynamicClassLoader	runtimeLoader	= ( DynamicClassLoader ) runtime.getRuntimeLoader();
+		runtimeLoader.addURLs(
 		    DynamicClassLoader.getJarURLs( homeLibs )
 		);
 
-		System.out.println( Arrays.toString( runtime.getRuntimeLoader().getURLs() ) );
+		System.out.println( Arrays.toString( runtimeLoader.getURLs() ) );
 
 		String					targetClass	= "com.github.benmanes.caffeine.cache.Caffeine";
 		Optional<ClassLocation>	location	= javaResolver.resolve( ctx, targetClass );


### PR DESCRIPTION
## Why

Introduce a **single `IClassLoaderFactory`** that governs **all** class-loader construction — both the `BoxRuntime` root loader and each module's isolated loader — so a deployment target can swap the whole strategy in one place, **without forking `BoxRuntime`/`ModuleService`/`ModuleRecord`**. JVM behavior is unchanged: the default `DynamicClassLoaderFactory` reproduces today's `DynamicClassLoader` paths exactly.

The motivating target is **BoxLang on Android**, where `java.net.URLClassLoader` doesn't exist and ART forbids runtime `defineClass()` of JVM bytecode. Today both loaders are hard-coded to `new DynamicClassLoader(...)`, which can't even be constructed on Android. With this seam the runtime loader becomes the app `PathClassLoader` and modules become `DexClassLoader`-backed — all via one swapped factory, while reusing every bit of runtime/module lifecycle logic.

## What changed

- **`IClassLoaderFactory`** (`runtime.loader`) — one interface, two methods:
  - `createRuntimeClassLoader(BoxRuntime, appParent) → ClassLoader`
  - `createModuleClassLoader(ModuleRecord, parent) → IModuleClassLoader`
- **`DynamicClassLoaderFactory`** — the default JVM impl (runtime loader seeded with `javaLibraryPaths`; module loader over the module dir + `libs/*.jar`; logic lifted out of the `BoxRuntime` ctor and `ModuleRecord.register()`).
- **`IModuleClassLoader`** (`runtime.loader`) — the contract a module loader must satisfy: `findClass(name, safe, checkParent)`, `getNameAsKey()`, `close()`, `toClassLoader()` (implementations are `ClassLoader`s so they work with `ServiceLoader`). `DynamicClassLoader` now implements it.
- **`BoxRuntime`** — static `get/setClassLoaderFactory()`. The runtime loader is built during construction, so the factory **must be installed before boot** (`getInstance(...)`). `runtimeLoader` field + `getRuntimeLoader()` now return `ClassLoader`.
- **`ModuleRecord`** — `classLoader` is now `IModuleClassLoader`, obtained from `runtime.getClassLoaderFactory().createModuleClassLoader(...)` in `register()`; `ServiceLoader.load(...)` goes through `toClassLoader()`. `ModuleService` is unchanged.

**Ripple is type-only:** every `getRuntimeLoader()` / `getRequestClassLoader()` / `getSystemClassLoader()` consumer uses the result purely as a `ClassLoader` (verified — no `DynamicClassLoader`-specific calls), so those getters/fields were widened to `ClassLoader` in `BaseApplicationListener`, `RequestBoxContext`, `BaseResolver`, `JavaResolver`. `JavaResolverTest` casts to `DynamicClassLoader` only where it seeds `home/libs` jars.

No public behavior change for existing users.

## Tests

- **`ClassLoaderFactoryTest`** — default factory is the JVM one; the booted runtime loader was built by it (a `DynamicClassLoader`); the default factory creates a `DynamicClassLoader`; a swapped factory yields a non-`DynamicClassLoader` runtime loader; and `ModuleRecord.register()` builds the module loader through the factory.
- No regressions: `ModuleRecordTest`, `ModuleServiceTest`, `DynamicClassLoaderTest`, `JavaResolverTest`, `ClassLocatorTest`, `CreateObjectTest`, `CreateDynamicProxyTest`, and the rest of the `loader` package stay green.

## Notes

Core-side companion to the standalone BoxLang Android runtime; intentionally only the platform-neutral seam. A sibling `ClassInfo` loader hook (for AOT class resolution on ART) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)