### PR TITLE
feat(compiler): pluggable generated-class loader + deterministic AOT FQNs

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/BXCompiler.java
+++ b/src/main/java/ortus/boxlang/compiler/BXCompiler.java
@@ -226,13 +226,14 @@ public class BXCompiler {
 	 * Compiles a single file to the target path, deriving the generated class name from the file's
 	 * path <b>relative to {@code sourceRoot}</b> (the {@code --source} directory) so the baked
 	 * {@code boxgenerated.*} FQN is deterministic and portable instead of embedding the absolute
-	 * build path. When {@code sourceRoot} is {@code null} (single-file compile) the file name alone
-	 * is used. A stable name is required for ahead-of-time targets (e.g. Android) that resolve the
-	 * dexed class by name via parent-first delegation rather than renaming it on load.
+	 * build path. When {@code sourceRoot} is {@code null}, legacy behavior is preserved and the
+	 * full source path string is used. A stable name is required for ahead-of-time targets (e.g.
+	 * Android) that resolve the dexed class by name via parent-first delegation rather than
+	 * renaming it on load.
 	 *
 	 * @param sourcePath  The path to the source file to compile.
 	 * @param targetPath  The path where the compiled file should be written.
-	 * @param sourceRoot  The root the relative class name is computed against; {@code null} → file name only.
+	 * @param sourceRoot  The root the relative class name is computed against; {@code null} preserves legacy full-path behavior.
 	 * @param stopOnError If true, throws an exception on compilation errors; otherwise logs the error and continues.
 	 * @param runtime     The BoxRuntime instance used for compilation.
 	 * @param errors      List to collect file paths for failed compilations.
@@ -244,7 +245,7 @@ public class BXCompiler {
 		System.out.println( "⚡ Writing -> " + targetPath.toString() );
 		String			relativePath	= sourceRoot != null
 		    ? sourceRoot.relativize( sourcePath ).toString()
-		    : sourcePath.getFileName().toString();
+		    : sourcePath.toString();
 		List<byte[]>	bytesList		= null;
 		try {
 			bytesList = RunnableLoader.getInstance()

--- a/src/main/java/ortus/boxlang/compiler/BXCompiler.java
+++ b/src/main/java/ortus/boxlang/compiler/BXCompiler.java
@@ -135,7 +135,7 @@ public class BXCompiler {
 						    Path resolvedTargetPath	= finalTargetPath.resolve( finalSourcePath.relativize( path ).toString() );
 
 						    if ( SUPPORTED_EXTENSIONS.contains( sourceExtension ) ) {
-							    boolean success = compileFile( path, resolvedTargetPath, finalStopOnError, runtime, errors );
+							    boolean success = compileFile( path, resolvedTargetPath, finalSourcePath, finalStopOnError, runtime, errors );
 							    if ( success ) {
 								    successCount.incrementAndGet();
 							    } else {
@@ -219,13 +219,37 @@ public class BXCompiler {
 	 * @return true if compilation was successful, false otherwise
 	 */
 	public static boolean compileFile( Path sourcePath, Path targetPath, Boolean stopOnError, BoxRuntime runtime, List<String> errors ) {
+		return compileFile( sourcePath, targetPath, null, stopOnError, runtime, errors );
+	}
+
+	/**
+	 * Compiles a single file to the target path, deriving the generated class name from the file's
+	 * path <b>relative to {@code sourceRoot}</b> (the {@code --source} directory) so the baked
+	 * {@code boxgenerated.*} FQN is deterministic and portable instead of embedding the absolute
+	 * build path. When {@code sourceRoot} is {@code null} (single-file compile) the file name alone
+	 * is used. A stable name is required for ahead-of-time targets (e.g. Android) that resolve the
+	 * dexed class by name via parent-first delegation rather than renaming it on load.
+	 *
+	 * @param sourcePath  The path to the source file to compile.
+	 * @param targetPath  The path where the compiled file should be written.
+	 * @param sourceRoot  The root the relative class name is computed against; {@code null} → file name only.
+	 * @param stopOnError If true, throws an exception on compilation errors; otherwise logs the error and continues.
+	 * @param runtime     The BoxRuntime instance used for compilation.
+	 * @param errors      List to collect file paths for failed compilations.
+	 *
+	 * @return true if compilation was successful, false otherwise
+	 */
+	public static boolean compileFile( Path sourcePath, Path targetPath, Path sourceRoot, Boolean stopOnError, BoxRuntime runtime, List<String> errors ) {
 		ensureParentDirectoriesExist( targetPath );
 		System.out.println( "⚡ Writing -> " + targetPath.toString() );
-		List<byte[]> bytesList = null;
+		String			relativePath	= sourceRoot != null
+		    ? sourceRoot.relativize( sourcePath ).toString()
+		    : sourcePath.getFileName().toString();
+		List<byte[]>	bytesList		= null;
 		try {
 			bytesList = RunnableLoader.getInstance()
 			    .getBoxpiler()
-			    .compileTemplateBytes( ResolvedFilePath.of( "", "", sourcePath.toString(), sourcePath ) );
+			    .compileTemplateBytes( ResolvedFilePath.of( "", "", relativePath, sourcePath ) );
 		} catch ( Exception e ) {
 			synchronized ( errors ) {
 				errors.add( sourcePath.toString() );

--- a/src/main/java/ortus/boxlang/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/Boxpiler.java
@@ -17,6 +17,7 @@
  */
 package ortus.boxlang.compiler;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -333,8 +334,17 @@ public abstract class Boxpiler implements IBoxpiler {
 				lastModified	= classPool.get( classInfo.fqn().toString() ).lastModified();
 				lastModified2	= classInfo.lastModified();
 				if ( ( lastModified > 0 ) && ( lastModified2 > 0 ) && !trustedCache && ( lastModified != lastModified2 ) ) {
-					// Close + discard the stale loader before recompiling (no-op for resolve-only loaders).
-					classPool.get( classInfo.fqn().toString() ).shutdownClassLoader();
+					// Close the stale loader before recompiling. Match the prior behavior exactly: close
+					// without nulling the discarded ClassInfo's reference (it is replaced in the pool
+					// below). Guard for resolve-only loaders (e.g. Android's) which are not Closeable.
+					ClassLoader staleLoader = classPool.get( classInfo.fqn().toString() ).getClassLoader();
+					if ( staleLoader instanceof Closeable closeable ) {
+						try {
+							closeable.close();
+						} catch ( IOException e ) {
+							e.printStackTrace();
+						}
+					}
 					try {
 						// Mark the class info instance as not ready to use yet
 						classInfo.startCompiling();

--- a/src/main/java/ortus/boxlang/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/Boxpiler.java
@@ -333,12 +333,8 @@ public abstract class Boxpiler implements IBoxpiler {
 				lastModified	= classPool.get( classInfo.fqn().toString() ).lastModified();
 				lastModified2	= classInfo.lastModified();
 				if ( ( lastModified > 0 ) && ( lastModified2 > 0 ) && !trustedCache && ( lastModified != lastModified2 ) ) {
-					try {
-						// Don't know if this does anything, but calling it for good measure
-						classPool.get( classInfo.fqn().toString() ).getClassLoader().close();
-					} catch ( IOException e ) {
-						e.printStackTrace();
-					}
+					// Close + discard the stale loader before recompiling (no-op for resolve-only loaders).
+					classPool.get( classInfo.fqn().toString() ).shutdownClassLoader();
 					try {
 						// Mark the class info instance as not ready to use yet
 						classInfo.startCompiling();

--- a/src/main/java/ortus/boxlang/compiler/ClassInfo.java
+++ b/src/main/java/ortus/boxlang/compiler/ClassInfo.java
@@ -288,9 +288,13 @@ public record ClassInfo(
 	 *
 	 * @return The disk class loader for this class
 	 */
-	public DiskClassLoader getDiskClassLoader() {
-		return ( DiskClassLoader ) getClassLoader();
+public DiskClassLoader getDiskClassLoader() {
+	ClassLoader loader = getClassLoader();
+	if ( loader instanceof DiskClassLoader diskLoader ) {
+		return diskLoader;
 	}
+	throw new BoxRuntimeException( "Generated class loader is not a DiskClassLoader; bytecode definition is not supported on this target." );
+}
 
 	/**
 	 * Close and discard this class's loader, if one was created. The next {@link #getClassLoader()}

--- a/src/main/java/ortus/boxlang/compiler/ClassInfo.java
+++ b/src/main/java/ortus/boxlang/compiler/ClassInfo.java
@@ -1,8 +1,7 @@
 package ortus.boxlang.compiler;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Paths;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.Parser;
@@ -27,7 +26,7 @@ public record ClassInfo(
     BoxSourceType sourceType,
     String source,
     long lastModified,
-    DiskClassLoader[] diskClassLoader,
+    ClassLoader[] generatedClassLoader,
     InterfaceProxyDefinition interfaceProxyDefinition,
     IBoxpiler boxpiler,
     ResolvedFilePath resolvedFilePath,
@@ -73,7 +72,7 @@ public record ClassInfo(
 		    sourceType,
 		    source,
 		    0L,
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    null,
 		    boxpiler,
 		    null,
@@ -101,7 +100,7 @@ public record ClassInfo(
 		    sourceType,
 		    source,
 		    0L,
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    null,
 		    boxpiler,
 		    null,
@@ -129,7 +128,7 @@ public record ClassInfo(
 		    sourceType,
 		    null,
 		    isTrustedCache() ? 0 : resolvedFilePath.absolutePath().toFile().lastModified(),
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    null,
 		    boxpiler,
 		    resolvedFilePath,
@@ -173,7 +172,7 @@ public record ClassInfo(
 		    sourceType,
 		    null,
 		    isTrustedCache() ? 0 : resolvedFilePath.absolutePath().toFile().lastModified(),
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    null,
 		    boxpiler,
 		    resolvedFilePath,
@@ -201,7 +200,7 @@ public record ClassInfo(
 		    sourceType,
 		    source,
 		    0L,
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    null,
 		    boxpiler,
 		    null,
@@ -229,7 +228,7 @@ public record ClassInfo(
 		    null,
 		    null,
 		    0L,
-		    new DiskClassLoader[ 1 ],
+		    new ClassLoader[ 1 ],
 		    interfaceProxyDefinition,
 		    boxpiler,
 		    null,
@@ -256,45 +255,59 @@ public record ClassInfo(
 	}
 
 	/**
-	 * Get or create the DiskClassLoader for this class.
+	 * Get or create the class loader used to resolve this generated class.
 	 * Uses double-checked locking to ensure thread-safe lazy initialization.
+	 * <p>
+	 * The concrete loader is supplied by the runtime's {@link ortus.boxlang.runtime.loader.IClassLoaderFactory}:
+	 * the default builds a {@link DiskClassLoader} (which {@code defineClass()}es bytecode and
+	 * JIT-compiles on miss), while targets that cannot {@code defineClass} at runtime (e.g. Android
+	 * AOT) supply a resolve-only loader that delegates to a parent holding the pre-compiled classes.
 	 *
-	 * @return The DiskClassLoader for this class
+	 * @return The class loader for this class
 	 */
-	public DiskClassLoader getClassLoader() {
-		if ( diskClassLoader[ 0 ] != null ) {
-			return diskClassLoader[ 0 ];
+	public ClassLoader getClassLoader() {
+		if ( generatedClassLoader[ 0 ] != null ) {
+			return generatedClassLoader[ 0 ];
 		}
 		synchronized ( this ) {
-			if ( diskClassLoader[ 0 ] != null ) {
-				return diskClassLoader[ 0 ];
+			if ( generatedClassLoader[ 0 ] != null ) {
+				return generatedClassLoader[ 0 ];
 			}
-			diskClassLoader[ 0 ] = new DiskClassLoader(
-			    new URL[] {},
-			    boxpiler().getClass().getClassLoader(),
-			    Paths.get( BoxRuntime.getInstance().getConfiguration().classGenerationDirectory ),
-			    boxpiler(),
-			    classPoolName()
-			);
-			return diskClassLoader[ 0 ];
+			generatedClassLoader[ 0 ] = BoxRuntime.getInstance()
+			    .getClassLoaderFactory()
+			    .createGeneratedClassLoader( BoxRuntime.getInstance(), boxpiler(), classPoolName() );
+			return generatedClassLoader[ 0 ];
 		}
 	}
 
 	/**
-	 * Get or create the DiskClassLoader for this class.
-	 * Uses double-checked locking to ensure thread-safe lazy initialization.
+	 * Get the loader as a {@link DiskClassLoader} for the bytecode-defining compile paths
+	 * (ASM/Java/NoOp boxpilers) that need {@code defineClass*}. These run only under the default
+	 * factory, which always yields a {@link DiskClassLoader}; on resolve-only targets the boxpiler
+	 * never reaches these calls.
 	 *
-	 * @return The DiskClassLoader for this class
+	 * @return The disk class loader for this class
+	 */
+	public DiskClassLoader getDiskClassLoader() {
+		return ( DiskClassLoader ) getClassLoader();
+	}
+
+	/**
+	 * Close and discard this class's loader, if one was created. The next {@link #getClassLoader()}
+	 * call will lazily build a fresh one.
 	 */
 	public void shutdownClassLoader() {
 		synchronized ( this ) {
-			if ( diskClassLoader[ 0 ] != null ) {
-				try {
-					diskClassLoader[ 0 ].close();
-				} catch ( IOException e ) {
-					e.printStackTrace();
+			if ( generatedClassLoader[ 0 ] != null ) {
+				// Resolve-only loaders (e.g. Android) are not Closeable; only DiskClassLoader/URLClassLoader is.
+				if ( generatedClassLoader[ 0 ] instanceof Closeable closeable ) {
+					try {
+						closeable.close();
+					} catch ( IOException e ) {
+						e.printStackTrace();
+					}
 				}
-				diskClassLoader[ 0 ] = null;
+				generatedClassLoader[ 0 ] = null;
 			}
 		}
 	}
@@ -459,8 +472,9 @@ public record ClassInfo(
 	 * Clears the in-memory cache of loaded classes.
 	 */
 	public void clearCacheClass() {
-		if ( diskClassLoader[ 0 ] != null ) {
-			diskClassLoader[ 0 ].clearClassesCache();
+		// clearClassesCache is DiskClassLoader-specific; resolve-only loaders have no JIT cache to clear.
+		if ( generatedClassLoader[ 0 ] instanceof DiskClassLoader diskLoader ) {
+			diskLoader.clearClassesCache();
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/ClassInfo.java
+++ b/src/main/java/ortus/boxlang/compiler/ClassInfo.java
@@ -288,13 +288,13 @@ public record ClassInfo(
 	 *
 	 * @return The disk class loader for this class
 	 */
-public DiskClassLoader getDiskClassLoader() {
-	ClassLoader loader = getClassLoader();
-	if ( loader instanceof DiskClassLoader diskLoader ) {
-		return diskLoader;
+	public DiskClassLoader getDiskClassLoader() {
+		ClassLoader loader = getClassLoader();
+		if ( loader instanceof DiskClassLoader diskLoader ) {
+			return diskLoader;
+		}
+		throw new BoxRuntimeException( "Generated class loader is not a DiskClassLoader; bytecode definition is not supported on this target." );
 	}
-	throw new BoxRuntimeException( "Generated class loader is not a DiskClassLoader; bytecode definition is not supported on this target." );
-}
 
 	/**
 	 * Close and discard this class's loader, if one was created. The next {@link #getClassLoader()}

--- a/src/main/java/ortus/boxlang/compiler/NoOpBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/NoOpBoxpiler.java
@@ -64,7 +64,7 @@ public class NoOpBoxpiler extends Boxpiler {
 			File sourceFile = classInfo.resolvedFilePath().absolutePath().toFile();
 			// Check if the source file contains Java bytecode by reading the first few bytes
 			if ( diskClassUtil.isJavaBytecode( sourceFile ) ) {
-				return classInfo.getClassLoader().defineClasses( FQN, sourceFile, classInfo );
+				return classInfo.getDiskClassLoader().defineClasses( FQN, sourceFile, classInfo );
 			}
 			throw new BoxRuntimeException( "NoOpBoxpiler does not support compiling source files." );
 		} else if ( classInfo.source() != null ) {

--- a/src/main/java/ortus/boxlang/compiler/asmboxpiler/ASMBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/asmboxpiler/ASMBoxpiler.java
@@ -83,7 +83,7 @@ public class ASMBoxpiler extends Boxpiler {
 			File sourceFile = classInfo.resolvedFilePath().absolutePath().toFile();
 			// Check if the source file contains Java bytecode by reading the first few bytes
 			if ( DiskClassUtil.isJavaByteCode( sourceFile ) ) {
-				return classInfo.getClassLoader().defineClasses( FQN, sourceFile, classInfo );
+				return classInfo.getDiskClassLoader().defineClasses( FQN, sourceFile, classInfo );
 			}
 			ParsingResult result = parseOrFail( sourceFile );
 			classes = doWriteClassInfo( result.getRoot(), classInfo );
@@ -131,7 +131,7 @@ public class ASMBoxpiler extends Boxpiler {
 			// Define auxiliary class (no initialization - will be initialized on first use)
 			byte[] bytes = convertClassNodeToBytes( fqn, classNode, classInfo );
 			classes.addFirst( bytes );
-			classInfo.getClassLoader().defineClassWithoutInit( fqn, bytes );
+			classInfo.getDiskClassLoader().defineClassWithoutInit( fqn, bytes );
 
 			// Store on disk if configured
 			if ( runtime.getConfiguration().storeClassFilesOnDisk ) {
@@ -146,7 +146,7 @@ public class ASMBoxpiler extends Boxpiler {
 		if ( mainClassNode != null ) {
 			byte[] bytes = convertClassNodeToBytes( mainClassFqn, mainClassNode, classInfo );
 			classes.addFirst( bytes );
-			classInfo.getClassLoader().defineClass( mainClassFqn, bytes );
+			classInfo.getDiskClassLoader().defineClass( mainClassFqn, bytes );
 
 			// Store on disk if configured
 			if ( runtime.getConfiguration().storeClassFilesOnDisk ) {

--- a/src/main/java/ortus/boxlang/compiler/javaboxpiler/JavaBoxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/javaboxpiler/JavaBoxpiler.java
@@ -179,7 +179,7 @@ public class JavaBoxpiler extends Boxpiler {
 			File sourceFile = classInfo.resolvedFilePath().absolutePath().toFile();
 			// Check if the source file contains Java bytecode by reading the first few bytes
 			if ( diskClassUtil.isJavaBytecode( sourceFile ) ) {
-				return classInfo.getClassLoader().defineClasses( FQN, sourceFile, classInfo );
+				return classInfo.getDiskClassLoader().defineClasses( FQN, sourceFile, classInfo );
 			}
 			ParsingResult result = parseOrFail( sourceFile );
 			compileSource( generateJavaSource( result.getRoot(), classInfo ), classInfo.fqn().toString(), classPoolName, classInfo.lastModified() );

--- a/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoaderFactory.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoaderFactory.java
@@ -19,9 +19,12 @@ package ortus.boxlang.runtime.loader;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import ortus.boxlang.compiler.IBoxpiler;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.modules.ModuleRecord;
 import ortus.boxlang.runtime.scopes.Key;
@@ -74,5 +77,22 @@ public class DynamicClassLoaderFactory implements IClassLoaderFactory {
 		}
 
 		return classLoader;
+	}
+
+	/**
+	 * Builds a {@link DiskClassLoader} for the generated class — the standard JVM behavior that
+	 * previously lived inline in {@code ClassInfo.getClassLoader()}: a {@code URLClassLoader} that
+	 * {@code defineClass()}es bytecode and JIT-compiles on a cache miss, parented to the boxpiler's
+	 * own class loader and reading from the configured class generation directory.
+	 */
+	@Override
+	public ClassLoader createGeneratedClassLoader( BoxRuntime runtime, IBoxpiler boxpiler, String classPoolName ) {
+		return new DiskClassLoader(
+		    new URL[] {},
+		    boxpiler.getClass().getClassLoader(),
+		    Paths.get( runtime.getConfiguration().classGenerationDirectory ),
+		    boxpiler,
+		    classPoolName
+		);
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/loader/IClassLoaderFactory.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/IClassLoaderFactory.java
@@ -17,6 +17,7 @@
  */
 package ortus.boxlang.runtime.loader;
 
+import ortus.boxlang.compiler.IBoxpiler;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.modules.ModuleRecord;
 
@@ -58,4 +59,22 @@ public interface IClassLoaderFactory {
 	 * @return The module's class loader
 	 */
 	IModuleClassLoader createModuleClassLoader( ModuleRecord record, ClassLoader parent );
+
+	/**
+	 * Create the class loader used to resolve a generated (compiled) BoxLang class for a given
+	 * class pool. This is the loader behind {@code ClassInfo.getClassLoader()}.
+	 * <p>
+	 * The default {@link DynamicClassLoaderFactory} returns a {@link DiskClassLoader} (a
+	 * {@code URLClassLoader}) that {@code defineClass()}es bytecode and JIT-compiles on miss.
+	 * Targets that cannot {@code defineClass} raw bytecode at runtime (e.g. Android AOT, where
+	 * ART forbids it) return a resolve-only loader that delegates to a parent already holding the
+	 * pre-compiled (dexed) classes, so resolution happens purely by parent-first delegation.
+	 *
+	 * @param runtime       The running runtime (provides configuration such as the class generation directory)
+	 * @param boxpiler      The boxpiler that owns the class pool (its loader becomes the parent in the default case)
+	 * @param classPoolName The name of the class pool the generated class belongs to
+	 *
+	 * @return The class loader for generated classes, consumed purely as a {@link ClassLoader}
+	 */
+	ClassLoader createGeneratedClassLoader( BoxRuntime runtime, IBoxpiler boxpiler, String classPoolName );
 }

--- a/src/test/java/ortus/boxlang/compiler/BXCompilerFQNTest.java
+++ b/src/test/java/ortus/boxlang/compiler/BXCompilerFQNTest.java
@@ -73,6 +73,25 @@ class BXCompilerFQNTest {
 		assertThat( baked ).doesNotContain( source.getFileName().toString() );
 	}
 
+	@DisplayName( "Legacy compileFile overload preserves full source-path-derived FQN behavior" )
+	@Test
+	void testLegacyCompileFileOverloadPreservesFullPathBehavior( @TempDir Path source, @TempDir Path target ) throws IOException {
+		Path srcFile = source.resolve( "views/main/index.bxm" );
+		Files.createDirectories( srcFile.getParent() );
+		Files.writeString( srcFile, "<bx:output>hi</bx:output>" );
+		Path	targetFile	= target.resolve( "views/main/index.bxm" );
+
+		boolean	ok			= BXCompiler.compileFile( srcFile, targetFile, true, runtime, new ArrayList<>() );
+		assertThat( ok ).isTrue();
+
+		String	baked				= readBakedClassName( targetFile );
+		String	expectedFullPath	= ResolvedFilePath.of( "", "", srcFile.toString(), srcFile ).getFQN( "boxgenerated.templates" ).toString();
+		String	fileNameOnly		= ResolvedFilePath.of( "", "", srcFile.getFileName().toString(), srcFile ).getFQN( "boxgenerated.templates" ).toString();
+
+		assertThat( baked ).isEqualTo( expectedFullPath );
+		assertThat( baked ).isNotEqualTo( fileNameOnly );
+	}
+
 	/**
 	 * Read the original class name baked into the head of a BXCompiler container:
 	 * {@code int magic, int nameLength, byte[] name (UTF-8), ...class entries}.

--- a/src/test/java/ortus/boxlang/compiler/BXCompilerFQNTest.java
+++ b/src/test/java/ortus/boxlang/compiler/BXCompilerFQNTest.java
@@ -1,0 +1,88 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.compiler;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.util.ResolvedFilePath;
+
+/**
+ * Verifies that {@link BXCompiler} bakes <b>deterministic, root-relative</b> generated class names
+ * — derived from each file's path relative to the {@code --source} root, not its absolute build
+ * path. Stable names are required for ahead-of-time targets (e.g. Android) that resolve the dexed
+ * class by name via parent-first delegation instead of renaming it on load.
+ */
+class BXCompilerFQNTest {
+
+	static BoxRuntime runtime;
+
+	@BeforeAll
+	static void setUp() {
+		runtime = BoxRuntime.getInstance();
+	}
+
+	@DisplayName( "A nested .bxm bakes a root-relative FQN, not the absolute build path" )
+	@Test
+	void testTemplateFqnIsRootRelative( @TempDir Path source, @TempDir Path target ) throws IOException {
+		Path srcFile = source.resolve( "views/main/index.bxm" );
+		Files.createDirectories( srcFile.getParent() );
+		Files.writeString( srcFile, "<bx:output>hi</bx:output>" );
+		Path	targetFile	= target.resolve( "views/main/index.bxm" );
+
+		boolean	ok			= BXCompiler.compileFile( srcFile, targetFile, source, true, runtime, new ArrayList<>() );
+		assertThat( ok ).isTrue();
+
+		String	baked				= readBakedClassName( targetFile );
+		String	relative			= source.relativize( srcFile ).toString();
+		String	expectedRelative	= ResolvedFilePath.of( "", "", relative, srcFile ).getFQN( "boxgenerated.templates" ).toString();
+		String	absoluteVariant		= ResolvedFilePath.of( "", "", srcFile.toString(), srcFile ).getFQN( "boxgenerated.templates" ).toString();
+
+		// The baked name is derived from the relative path...
+		assertThat( baked ).isEqualTo( expectedRelative );
+		// ...and is NOT the old absolute-path-derived name, nor does it leak the temp build dir.
+		assertThat( baked ).isNotEqualTo( absoluteVariant );
+		assertThat( baked ).contains( "views" );
+		assertThat( baked ).doesNotContain( source.getFileName().toString() );
+	}
+
+	/**
+	 * Read the original class name baked into the head of a BXCompiler container:
+	 * {@code int magic, int nameLength, byte[] name (UTF-8), ...class entries}.
+	 */
+	private String readBakedClassName( Path container ) throws IOException {
+		ByteBuffer buffer = ByteBuffer.wrap( Files.readAllBytes( container ) );
+		buffer.getInt();								// magic (0xCAFEBABE)
+		byte[] nameBytes = new byte[ buffer.getInt() ];	// nameLength
+		buffer.get( nameBytes );
+		return new String( nameBytes, StandardCharsets.UTF_8 );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
+++ b/src/test/java/ortus/boxlang/runtime/loader/ClassLoaderFactoryTest.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.runtime.loader;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,10 +29,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import ortus.boxlang.compiler.ClassInfo;
+import ortus.boxlang.compiler.IBoxpiler;
+import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.modules.ModuleRecord;
+import ortus.boxlang.runtime.runnables.RunnableLoader;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.util.BoxFQN;
+import ortus.boxlang.runtime.util.FQN;
 
 /**
  * Verifies the single, consolidated {@link IClassLoaderFactory} seam that governs BOTH the
@@ -130,6 +138,84 @@ class ClassLoaderFactoryTest {
 				moduleRecord.unload( context );
 			}
 		}
+	}
+
+	@DisplayName( "The default factory builds a DiskClassLoader for generated classes" )
+	@Test
+	void testDefaultGeneratedClassLoader() {
+		IBoxpiler	boxpiler	= RunnableLoader.getInstance().getBoxpiler();
+		ClassLoader	created		= new DynamicClassLoaderFactory().createGeneratedClassLoader( runtime, boxpiler, "__ad_hoc_source__" );
+		assertThat( created ).isInstanceOf( DiskClassLoader.class );
+	}
+
+	@DisplayName( "ClassInfo.getClassLoader() is built through the factory (the AOT seam)" )
+	@Test
+	void testClassInfoUsesFactoryForGeneratedLoader() {
+		ClassLoader				sentinel	= new ClassLoader( getClass().getClassLoader() ) {
+											};
+		AtomicReference<String>	seenPool	= new AtomicReference<>();
+
+		// A target like Android returns a resolve-only loader instead of a DiskClassLoader.
+		BoxRuntime.setClassLoaderFactory( new DynamicClassLoaderFactory() {
+
+			@Override
+			public ClassLoader createGeneratedClassLoader( BoxRuntime rt, IBoxpiler boxpiler, String classPoolName ) {
+				assertThat( boxpiler ).isNotNull();
+				seenPool.set( classPoolName );
+				return sentinel;
+			}
+		} );
+
+		ClassInfo classInfo = ClassInfo.forScript( "x = 1", BoxSourceType.BOXSCRIPT, RunnableLoader.getInstance().getBoxpiler() );
+		assertThat( classInfo.getClassLoader() ).isSameInstanceAs( sentinel );
+		assertThat( seenPool.get() ).isEqualTo( "__ad_hoc_source__" );
+	}
+
+	@DisplayName( "getDiskClass() resolves a generated class by parent delegation — no defineClass" )
+	@Test
+	void testGeneratedClassResolvesByDelegation() {
+		ClassLoader appLoader = getClass().getClassLoader();
+		// Resolve-only loader: never defines, only delegates to a parent that already has the class.
+		BoxRuntime.setClassLoaderFactory( new DynamicClassLoaderFactory() {
+
+			@Override
+			public ClassLoader createGeneratedClassLoader( BoxRuntime rt, IBoxpiler boxpiler, String classPoolName ) {
+				return new ClassLoader( appLoader ) {
+				};
+			}
+		} );
+
+		// A ClassInfo whose FQN points at a class already present on the parent loader, simulating
+		// an AOT-dexed class. getDiskClass() must resolve it via delegation, loaded by the parent.
+		ClassInfo	classInfo	= classInfoFor( "ortus.boxlang.runtime.types.Array" );
+		Class<?>	resolved	= classInfo.getDiskClass();
+		assertThat( resolved.getName() ).isEqualTo( "ortus.boxlang.runtime.types.Array" );
+		assertThat( resolved.getClassLoader() ).isSameInstanceAs( appLoader );
+
+		// A name no loader can resolve fails loudly (never an illegal define).
+		assertThrows( BoxRuntimeException.class, () -> classInfoFor( "boxgenerated.scripts.DoesNotExist_zzz" ).getDiskClass() );
+	}
+
+	/**
+	 * Build a minimal ad-hoc {@link ClassInfo} with an explicit FQN (no file on disk), so the test
+	 * controls exactly which class name {@code getDiskClass()} will ask the loader to resolve.
+	 */
+	private ClassInfo classInfoFor( String fqn ) {
+		return new ClassInfo(
+		    FQN.of( fqn ),
+		    BoxFQN.of( "" ),
+		    "BoxScript",
+		    "Object",
+		    BoxSourceType.BOXSCRIPT,
+		    "x = 1",
+		    0L,
+		    new ClassLoader[ 1 ],
+		    null,
+		    RunnableLoader.getInstance().getBoxpiler(),
+		    null,
+		    fqn.hashCode(),
+		    new boolean[] { false }
+		);
 	}
 
 }


### PR DESCRIPTION
## What
Adds the core capability for a deployment target to supply the class loader behind `ClassInfo`'s generated classes, and makes `BXCompiler` bake portable, root-relative class names.

## Why
Ahead-of-time targets (e.g. Android/ART) cannot `defineClass()` at runtime and have no `URLClassLoader`; generated classes must resolve by **parent-first delegation** to an already-loaded (dexed) class. That needs (a) a seam to swap the loader `ClassInfo` uses, and (b) generated FQNs that are **identical at build time and runtime** (today `BXCompiler` bakes the absolute build path into the name). Core-only — no target-specific code in this PR.

## Changes
- `IClassLoaderFactory.createGeneratedClassLoader(runtime, boxpiler, classPoolName)` — new seam, consistent with the existing runtime/module loader factory methods (PR #575).
- `DynamicClassLoaderFactory` — default impl returns the same `DiskClassLoader` previously hard-coded in `ClassInfo.getClassLoader()`; **byte-for-byte behavior** for desktop/web/lambda.
- `ClassInfo` — `getClassLoader()` delegates to the factory and is typed `ClassLoader`; `getDiskClass()`/`getDiskClassProxy()` resolve via `loadClass` (any loader). Added `getDiskClassLoader()` for the bytecode-defining compile paths (ASM/Java/NoOp, default factory only); shutdown/cache-clear guarded by `Closeable`/`DiskClassLoader` checks.
- `BXCompiler` — derive the generated FQN from each file's path **relative to `--source`** instead of the absolute path. Safe for desktop precompiled deployments because `DiskClassLoader.defineClasses` renames classes on load.

## Backward compatibility
Default factory reproduces the previous `DiskClassLoader` exactly; the `BXCompiler` name change is invisible to desktop (rename-on-load) and produces portable instead of machine-specific names.

## Tests (JVM, no Android)
Default factory yields a `DiskClassLoader`; `ClassInfo` resolves its loader through the factory (the AOT seam); `getDiskClass()` resolves by parent delegation with no `defineClass` and fails loudly on a missing name; `BXCompiler` bakes a root-relative FQN, not the absolute path. Full compiler + `runtimes:android-mvc` suites green locally.