### PR TITLE
dateCompare - handle "hours"

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompare.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompare.java
@@ -92,7 +92,7 @@ public class DateCompare extends BIF {
 			ChronoUnit unit = datePartMap.get( partKey );
 
 			switch ( unit ) {
-				case NANOS, MICROS, MILLIS, SECONDS, MINUTES, DAYS -> {
+				case NANOS, MICROS, MILLIS, SECONDS, MINUTES, HOURS, DAYS -> {
 					// For the smaller units, we can directly compare a truncated version
 					int comparison = date1.getWrapped().truncatedTo( unit ).compareTo( date2.getWrapped().truncatedTo( unit ) );
 					return comparison == 0 ? 0 : ( comparison < 0 ? -1 : 1 );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompareTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/temporal/DateCompareTest.java
@@ -287,14 +287,18 @@ public class DateCompareTest {
 	public void testCompareSimilar() {
 		instance.executeSource(
 		    """
-		    assert dateCompare('2025-01-01', '2025-02-01', 'd' ) == -1;
-		    assert dateCompare('2024-02-01', '2025-02-01', 'm' ) == -1;
-		    assert dateCompare( '2025-02-01', '2024-02-01', 'm' ) == 1;
-		    assert dateCompare('2025-01-01T00:00:01Z', '2025-01-01T00:10:00Z', 'd' ) == 0;
-		    assert dateCompare('2025-01-02T00:00:01Z', '2025-01-15T00:10:00Z', 'm' ) == 0;
-		    assert dateCompare('2025-01-01T00:00:00Z', '2025-01-15T00:00:00Z', 'y' ) == 0;
-		    assert dateCompare('2025-01-01T00:00:00Z', '2025-01-15T00:00:00Z', 'yyyy' ) == 0;
-		    """,
+		       assert dateCompare('2025-01-01', '2025-02-01', 'd' ) == -1;
+		       assert dateCompare('2024-02-01', '2025-02-01', 'm' ) == -1;
+		       assert dateCompare( '2025-02-01', '2024-02-01', 'm' ) == 1;
+		       assert dateCompare('2025-01-01T00:00:01Z', '2025-01-01T00:10:00Z', 'd' ) == 0;
+		       assert dateCompare('2025-01-02T00:00:01Z', '2025-01-15T00:10:00Z', 'm' ) == 0;
+		       assert dateCompare('2025-01-01T00:00:00Z', '2025-01-15T00:00:00Z', 'y' ) == 0;
+		       assert dateCompare('2025-01-01T00:00:00Z', '2025-01-15T00:00:00Z', 'yyyy' ) == 0;
+
+		    assert dateCompare('2025-01-01T03:00:00Z', '2025-01-01T04:00:00Z', 'h' ) == -1;
+		    assert dateCompare('2025-01-01T04:00:00Z', '2025-01-01T04:00:00Z', 'h' ) == 0;
+		    assert dateCompare('2025-01-01T05:00:00Z', '2025-01-01T04:00:00Z', 'h' ) == 1;
+		       """,
 		    context );
 	}
 


### PR DESCRIPTION
# Description

handle missing case "hours" in dateCompare

- [x] Bug Fix


- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
