### PR TITLE
Add class-based execution to bx:schedule, with life-cycle method support

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
+++ b/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
@@ -773,7 +773,7 @@ public class ScheduledTask implements Runnable {
 	public ScheduledTask call( DynamicObject task, String method ) {
 		debugLog( "call" );
 		setTask( task );
-		setMethod( method == null ? "run" : method );
+		setMethod( method == null || method.isBlank() ? "run" : method );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
+++ b/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
@@ -475,8 +475,15 @@ public class ScheduledTask implements Runnable {
 			// Execution by type
 			switch ( task ) {
 				case DynamicObject castedTask -> {
-					this.stats.put( "lastResult", Optional
-					    .ofNullable( castedTask.invoke( this.taskContext, method ) ) );
+					Object	targetInstance	= castedTask.getTargetInstance();
+					Object	result;
+					// BoxLang classes/objects dispatch UDFs dynamically (this scope), not via JVM reflection
+					if ( targetInstance instanceof IReferenceable referenceable ) {
+						result = referenceable.dereferenceAndInvoke( this.taskContext, Key.of( method ), DynamicObject.EMPTY_ARGS, false );
+					} else {
+						result = castedTask.invoke( this.taskContext, method );
+					}
+					this.stats.put( "lastResult", Optional.ofNullable( result ) );
 				}
 				case Callable<?> castedTask -> {
 					this.stats.put( "lastResult", Optional.ofNullable( castedTask.call() ) );
@@ -764,7 +771,10 @@ public class ScheduledTask implements Runnable {
 	 * @return The ScheduledTask instance
 	 */
 	public ScheduledTask call( DynamicObject task, String method ) {
-		return call( task, method );
+		debugLog( "call" );
+		setTask( task );
+		setMethod( method == null ? "run" : method );
+		return this;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -719,9 +719,12 @@ public class Schedule extends Component {
 				// HTTP/Runnable-based tasks: wrap the callable itself
 				final Runnable original = callable;
 				task.call( () -> {
-					original.run();
-					if ( runCount.incrementAndGet() >= maxRuns ) {
-						finalTask.disable();
+					try {
+						original.run();
+					} finally {
+						if ( runCount.incrementAndGet() >= maxRuns ) {
+							finalTask.disable();
+						}
 					}
 				} );
 			} else {

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -608,9 +608,13 @@ public class Schedule extends Component {
 		    .unWrapBoxLangClass();
 
 		// DI, mirroring BoxScheduler.prepTarget()
-		instance.getVariablesScope().put( Key.scheduler, scheduler );
-		instance.getVariablesScope().put( Key.boxRuntime, rt );
-		instance.getVariablesScope().put( Key.logger, scheduler.getLogger() );
+		var variablesScope = instance.getVariablesScope();
+		variablesScope.put( Key.scheduler, scheduler );
+		variablesScope.put( Key.boxRuntime, rt );
+		variablesScope.put( Key.asyncService, rt.getAsyncService() );
+		variablesScope.put( Key.interceptorService, rt.getInterceptorService() );
+		variablesScope.put( Key.cacheService, rt.getCacheService() );
+		variablesScope.put( Key.logger, scheduler.getLogger() );
 
 		ScheduledTask task = scheduler.task( taskName, group ).call( DynamicObject.of( instance ), methodName );
 

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -71,7 +71,7 @@ import ortus.boxlang.runtime.validation.Validator;
  *
  * @attribute.class The dotted path/name of a BoxLang class to instantiate and invoke when the task fires, instead of making an HTTP request. Mutually exclusive with {@code url}; exactly one of the two is required for create/update/modify. The class
  *                  is instantiated once and reused for the life of the task. Only the {@code method} target is mandatory; the class may optionally define {@code before()}, {@code after(result)}, {@code onSuccess(result)}, and
- *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are (see the {@code boxlang-core-dev-async-tasks} skill) — each is only invoked if defined.
+	 *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are — each is only invoked if defined.
  *
  * @attribute.method The method to invoke on the {@code class} instance when the task fires. Defaults to "run". Ignored when {@code url} is used.
  *

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -604,7 +604,7 @@ public class Schedule extends Component {
 
 		IClassRunnable	instance		= ( IClassRunnable ) classLocator
 		    .load( runtimeContext, "bx:" + className, imports )
-		    .invokeConstructor( runtimeContext, Key.noInit )
+		    .invokeConstructor( runtimeContext )
 		    .unWrapBoxLangClass();
 
 		// DI, mirroring BoxScheduler.prepTarget()

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -22,10 +22,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
+import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
 import ortus.boxlang.runtime.async.tasks.ScheduledTask;
 import ortus.boxlang.runtime.async.tasks.TaskRecord;
@@ -35,7 +38,10 @@ import ortus.boxlang.runtime.components.Component;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.ExpressionInterpreter;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.loader.ClassLocator;
 import ortus.boxlang.runtime.net.BoxHttpClient;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.HttpService;
 import ortus.boxlang.runtime.services.SchedulerService;
@@ -61,7 +67,13 @@ import ortus.boxlang.runtime.validation.Validator;
  *
  * @attribute.group Task group name for organizational purposes.
  *
- * @attribute.url The URL to request when the task fires (required for create/update/modify).
+ * @attribute.url The URL to request when the task fires. Mutually exclusive with {@code class}; exactly one of the two is required for create/update/modify.
+ *
+ * @attribute.class The dotted path/name of a BoxLang class to instantiate and invoke when the task fires, instead of making an HTTP request. Mutually exclusive with {@code url}; exactly one of the two is required for create/update/modify. The class
+ *                  is instantiated once and reused for the life of the task. Only the {@code method} target is mandatory; the class may optionally define {@code before()}, {@code after(result)}, {@code onSuccess(result)}, and
+ *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are (see the {@code boxlang-core-dev-async-tasks} skill) — each is only invoked if defined.
+ *
+ * @attribute.method The method to invoke on the {@code class} instance when the task fires. Defaults to "run". Ignored when {@code url} is used.
  *
  * @attribute.interval Scheduling interval: "once", "daily", "weekly", "monthly", or seconds (>=60).
  *
@@ -144,6 +156,8 @@ public class Schedule extends Component {
 		    new Attribute( Key.scheduler, "string", DEFAULT_SCHEDULER_NAME ),
 		    new Attribute( Key.group, "string", "" ),
 		    new Attribute( Key.URL, "string" ),
+		    new Attribute( Key._CLASS, "string" ),
+		    new Attribute( Key.method, "string", "run" ),
 		    new Attribute( Key.interval, "string" ),
 		    new Attribute( Key.isDaily, "boolean", false ),
 		    new Attribute( Key.cronTime, "string" ),
@@ -280,13 +294,17 @@ public class Schedule extends Component {
 		String	schedulerName	= attributes.getAsString( Key.scheduler );
 		String	group			= attributes.getAsString( Key.group );
 		String	url				= attributes.getAsString( Key.URL );
+		String	className		= attributes.getAsString( Key._CLASS );
 		String	interval		= attributes.getAsString( Key.interval );
 		String	cronTime		= attributes.getAsString( Key.cronTime );
 		boolean	isDaily			= BooleanCaster.cast( attributes.getOrDefault( Key.isDaily, false ) );
+		boolean	hasUrl			= url != null && !url.isBlank();
+		boolean	hasClass		= className != null && !className.isBlank();
 
-		// Validate required attributes
-		if ( url == null || url.isBlank() ) {
-			throw new BoxRuntimeException( "The [url] attribute is required for schedule action [update]" );
+		// Validate required attributes: exactly one of [url] or [class] is required
+		if ( hasUrl == hasClass ) {
+			throw new BoxRuntimeException(
+			    "Exactly one of [url] or [class] is required for schedule action [update] - they are mutually exclusive" );
 		}
 
 		if ( cronTime == null && interval == null && !isDaily ) {
@@ -301,11 +319,15 @@ public class Schedule extends Component {
 			scheduler.removeTask( taskName );
 		}
 
-		// Build the HTTP callable
-		Runnable		callable	= buildTaskCallable( context, attributes );
-
-		// Register task and apply full configuration
-		ScheduledTask	task		= scheduler.task( taskName, group ).call( callable );
+		// Register task, either as a class-based task or an HTTP callable task
+		ScheduledTask	task;
+		Runnable		callable	= null;
+		if ( hasClass ) {
+			task = registerClassTask( scheduler, taskName, group, context, attributes );
+		} else {
+			callable	= buildTaskCallable( context, attributes );
+			task		= scheduler.task( taskName, group ).call( callable );
+		}
 		applyTaskConfiguration( task, callable, attributes, runtime.getRuntimeContext() );
 
 		// Start the task if the scheduler is already running
@@ -555,9 +577,75 @@ public class Schedule extends Component {
 	}
 
 	/**
-	 * Build a {@link Runnable} that performs an HTTP GET request to the configured URL.
-	 * Captures the runtime context (not the request context) for long-lived use.
+	 * Build and register a class-based scheduled task. The target class is instantiated once and
+	 * reused for the life of the task — the same "resolve once, dispatch life-cycle methods to it"
+	 * convention used by {@code BoxScheduler} (for BoxLang scheduler classes) and {@code ClassListener}
+	 * (for file watcher classes).
+	 *
+	 * @param scheduler The scheduler to register the task on.
+	 * @param taskName  The name of the task.
+	 * @param group     The task group.
+	 * @param context   The context used to resolve imports for class-name resolution.
+	 * @param taskDef   Struct of task fields — accepts both live attribute structs and persisted JSON structs.
+	 *
+	 * @return The configured, registered {@link ScheduledTask}.
 	 */
+	public static ScheduledTask registerClassTask( BaseScheduler scheduler, String taskName, String group, IBoxContext context, IStruct taskDef ) {
+		String	className	= taskDef.getAsString( Key._CLASS );
+		String	methodName	= taskDef.getAsString( Key.method );
+		if ( methodName == null || methodName.isBlank() ) {
+			methodName = "run";
+		}
+
+		BoxRuntime		rt				= BoxRuntime.getInstance();
+		IBoxContext		runtimeContext	= rt.getRuntimeContext();
+		ClassLocator	classLocator	= rt.getClassLocator();
+		var				imports			= context.getCurrentImports();
+
+		IClassRunnable	instance		= ( IClassRunnable ) classLocator
+		    .load( runtimeContext, "bx:" + className, imports )
+		    .invokeConstructor( runtimeContext, Key.noInit )
+		    .unWrapBoxLangClass();
+
+		// DI, mirroring BoxScheduler.prepTarget()
+		instance.getVariablesScope().put( Key.scheduler, scheduler );
+		instance.getVariablesScope().put( Key.boxRuntime, rt );
+		instance.getVariablesScope().put( Key.logger, scheduler.getLogger() );
+
+		ScheduledTask task = scheduler.task( taskName, group ).call( DynamicObject.of( instance ), methodName );
+
+		wireClassLifecycle( task, instance, runtimeContext );
+
+		return task;
+	}
+
+	/**
+	 * Wire optional life-cycle methods defined on a task class: {@code before()}, {@code after(result)},
+	 * {@code onSuccess(result)}, and {@code onError(exception)}. Each is only invoked if the class defines
+	 * it, following the same {@code containsKey}-guarded-dispatch convention as {@code BoxScheduler} and
+	 * {@code ClassListener}.
+	 *
+	 * @param task           The task to wire life-cycle hooks onto.
+	 * @param instance       The already-instantiated task class.
+	 * @param runtimeContext The runtime context used for invocation.
+	 */
+	private static void wireClassLifecycle( ScheduledTask task, IClassRunnable instance, IBoxContext runtimeContext ) {
+		var thisScope = instance.getThisScope();
+
+		if ( thisScope.containsKey( Key.before ) ) {
+			task.before( t -> instance.dereferenceAndInvoke( runtimeContext, Key.before, DynamicObject.EMPTY_ARGS, false ) );
+		}
+		if ( thisScope.containsKey( Key.after ) ) {
+			task.after( ( t, result ) -> instance.dereferenceAndInvoke( runtimeContext, Key.after, new Object[] { result.orElse( null ) }, false ) );
+		}
+		if ( thisScope.containsKey( Key.onSuccess ) ) {
+			task.onSuccess( ( t, result ) -> instance.dereferenceAndInvoke( runtimeContext, Key.onSuccess, new Object[] { result.orElse( null ) }, false ) );
+		}
+		if ( thisScope.containsKey( Key.onError ) ) {
+			task.onFailure( ( t, ex ) -> instance.dereferenceAndInvoke( runtimeContext, Key.onError, new Object[] { ex }, false ) );
+		}
+	}
+
 	/**
 	 * Apply the full task configuration (scheduling, callbacks, metadata) to an already-registered
 	 * {@link ScheduledTask}. Used by both {@code doUpdate} and {@code registerPersistedScheduleTasks}
@@ -584,6 +672,8 @@ public class Schedule extends Component {
 		Integer	retryCount		= taskDef.getAsInteger( Key.retryCount );
 		boolean	cluster			= BooleanCaster.cast( taskDef.getOrDefault( Key.cluster, false ) );
 		String	url				= taskDef.getAsString( Key.URL );
+		String	className		= taskDef.getAsString( Key._CLASS );
+		String	method			= taskDef.getAsString( Key.method );
 
 		// Apply scheduling
 		if ( cronTime != null && !cronTime.isBlank() ) {
@@ -621,13 +711,24 @@ public class Schedule extends Component {
 			final int			maxRuns		= repeat;
 			AtomicInteger		runCount	= new AtomicInteger( 0 );
 			final ScheduledTask	finalTask	= task;
-			final Runnable		original	= callable;
-			task.call( () -> {
-				original.run();
-				if ( runCount.incrementAndGet() >= maxRuns ) {
-					finalTask.disable();
-				}
-			} );
+			if ( callable != null ) {
+				// HTTP/Runnable-based tasks: wrap the callable itself
+				final Runnable original = callable;
+				task.call( () -> {
+					original.run();
+					if ( runCount.incrementAndGet() >= maxRuns ) {
+						finalTask.disable();
+					}
+				} );
+			} else {
+				// Class-based tasks have no Runnable to wrap: compose onto the after() hook instead,
+				// layering on top of any class-defined after() life-cycle method
+				task.after( composeAfter( task.getAfterTask(), ( t, result ) -> {
+					if ( runCount.incrementAndGet() >= maxRuns ) {
+						t.disable();
+					}
+				} ) );
+			}
 		}
 
 		// Apply exclude dates predicate
@@ -636,18 +737,18 @@ public class Schedule extends Component {
 			task.when( t -> !isExcludedDate( t.getNow(), excludeList ) );
 		}
 
-		// Wire onFailure callback based on onException
+		// Wire onFailure callback based on onException, composing with any class-defined onError() method
 		if ( "pause".equalsIgnoreCase( onException ) ) {
-			task.onFailure( ( t, e ) -> t.disable() );
+			task.onFailure( composeFailure( task.getOnTaskFailure(), ( t, e ) -> t.disable() ) );
 		} else if ( "invokeHandler".equalsIgnoreCase( onException ) && eventHandler != null && !eventHandler.isBlank() ) {
 			final String handler = eventHandler;
-			task.onFailure( ( t, ex ) -> httpGet( handler, null, runtimeContext ) );
+			task.onFailure( composeFailure( task.getOnTaskFailure(), ( t, ex ) -> httpGet( handler, null, runtimeContext ) ) );
 		}
 
-		// Wire after callback for oncomplete
+		// Wire after callback for oncomplete, composing with any class-defined after() method
 		if ( onComplete != null && !onComplete.isBlank() ) {
 			final String completeUrl = onComplete;
-			task.after( ( t, result ) -> httpGet( completeUrl, null, runtimeContext ) );
+			task.after( composeAfter( task.getAfterTask(), ( t, result ) -> httpGet( completeUrl, null, runtimeContext ) ) );
 		}
 
 		// Store metadata
@@ -657,6 +758,41 @@ public class Schedule extends Component {
 		task.setMetaKey( "eventhandler", eventHandler );
 		task.setMetaKey( "oncomplete", onComplete );
 		task.setMetaKey( "url", url );
+		task.setMetaKey( "class", className );
+		task.setMetaKey( "method", method );
+	}
+
+	/**
+	 * Compose two failure handlers so both run, in order, instead of the second silently
+	 * replacing the first. Used so a class's own {@code onError()} life-cycle method and the
+	 * {@code onException} attribute's HTTP-based handler can coexist.
+	 */
+	private static BiConsumer<ScheduledTask, Exception> composeFailure( BiConsumer<ScheduledTask, Exception> first,
+	    BiConsumer<ScheduledTask, Exception> second ) {
+		if ( first == null ) {
+			return second;
+		}
+		return ( t, e ) -> {
+			first.accept( t, e );
+			second.accept( t, e );
+		};
+	}
+
+	/**
+	 * Compose two "after" handlers so both run, in order, instead of the second silently
+	 * replacing the first. Used so a class's own {@code after()} life-cycle method, the
+	 * repeat-limit counter, and the {@code oncomplete} attribute's HTTP-based handler can
+	 * all coexist.
+	 */
+	private static BiConsumer<ScheduledTask, Optional<?>> composeAfter( BiConsumer<ScheduledTask, Optional<?>> first,
+	    BiConsumer<ScheduledTask, Optional<?>> second ) {
+		if ( first == null ) {
+			return second;
+		}
+		return ( t, r ) -> {
+			first.accept( t, r );
+			second.accept( t, r );
+		};
 	}
 
 	/**
@@ -834,6 +970,8 @@ public class Schedule extends Component {
 		    "group", record.group,
 		    "disabled", record.disabled,
 		    "url", meta.getOrDefault( Key.url, "" ),
+		    "class", meta.getOrDefault( Key._CLASS, "" ),
+		    "method", meta.getOrDefault( Key.method, "" ),
 		    "cronTime", meta.getOrDefault( Key.cronExpression, "" ),
 		    "retryCount", meta.getOrDefault( Key.retryCount, 3 ),
 		    "scheduledAt", record.scheduledAt,

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -93,6 +93,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		additive							= Key.of( "additive" );
 	public static final Key		addnewline							= Key.of( "addnewline" );
 	public static final Key		addToken							= Key.of( "addToken" );
+	public static final Key		after								= Key.of( "after" );
 	public static final Key		afterAnyTask						= Key.of( "afterAnyTask" );
 	public static final Key		algorithm							= Key.of( "algorithm" );
 	public static final Key		all									= Key.of( "all" );
@@ -137,6 +138,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		autoCreate							= Key.of( "autoCreate" );
 	public static final Key		base64_or_object					= Key.of( "base64_or_object" );
 	public static final Key		baseTag								= Key.of( "baseTag" );
+	public static final Key		before								= Key.of( "before" );
 	public static final Key		beforeAnyTask						= Key.of( "beforeAnyTask" );
 	public static final Key		bif									= Key.of( "bif" );
 	public static final Key		bigdecimal							= Key.of( "bigdecimal" );
@@ -701,6 +703,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		onSessionStart						= Key.of( "onSessionStart" );
 	public static final Key		onShutdown							= Key.of( "onShutdown" );
 	public static final Key		onStartup							= Key.of( "onStartup" );
+	public static final Key		onSuccess							= Key.of( "onSuccess" );
 	public static final Key		onUnload							= Key.of( "onUnload" );
 	public static final Key		operation							= Key.of( "operation" );
 	public static final Key		options								= Key.of( "options" );

--- a/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
@@ -268,12 +268,20 @@ public class SchedulerService extends BaseService {
 			// Decrypt credentials before passing to the callable builder
 			decryptTaskCredentials( taskDef );
 
-			// Build callable and register the task
-			Runnable										callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext,
-			    taskDef );
+			String											group		= taskDef.getAsString( Key.group );
+			String											className	= taskDef.getAsString( Key._CLASS );
+			ortus.boxlang.runtime.async.tasks.ScheduledTask	scheduledTask;
+			Runnable										callable	= null;
 
-			String											group			= taskDef.getAsString( Key.group );
-			ortus.boxlang.runtime.async.tasks.ScheduledTask	scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+			if ( className != null && !className.isBlank() ) {
+				// Class-based task: instantiate once and wire life-cycle methods (identical to doUpdate)
+				scheduledTask = ortus.boxlang.runtime.components.async.Schedule.registerClassTask(
+				    scheduler, taskName, group != null ? group : "", runtimeContext, taskDef );
+			} else {
+				// Build callable and register the task
+				callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
+				scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+			}
 
 			// Apply full configuration (identical to doUpdate — repeat, exclude, callbacks, metadata, scheduling)
 			ortus.boxlang.runtime.components.async.Schedule.applyTaskConfiguration( scheduledTask, callable, taskDef, runtimeContext );
@@ -729,9 +737,18 @@ public class SchedulerService extends BaseService {
 
 				decryptTaskCredentials( taskDef );
 
-				Runnable		callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
-				String			group			= taskDef.getAsString( Key.group );
-				ScheduledTask	scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+				String			group		= taskDef.getAsString( Key.group );
+				String			className	= taskDef.getAsString( Key._CLASS );
+				ScheduledTask	scheduledTask;
+				Runnable		callable	= null;
+
+				if ( className != null && !className.isBlank() ) {
+					scheduledTask = ortus.boxlang.runtime.components.async.Schedule.registerClassTask(
+					    scheduler, taskName, group != null ? group : "", runtimeContext, taskDef );
+				} else {
+					callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
+					scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+				}
 
 				ortus.boxlang.runtime.components.async.Schedule.applyTaskConfiguration( scheduledTask, callable, taskDef, runtimeContext );
 
@@ -872,6 +889,8 @@ public class SchedulerService extends BaseService {
 			    "scheduler", scheduler,
 			    "group", attributes.getAsString( Key.group ),
 			    "url", attributes.getAsString( Key.URL ),
+			    "class", attributes.getAsString( Key._CLASS ),
+			    "method", attributes.getAsString( Key.method ),
 			    "interval", attributes.getAsString( Key.interval ),
 			    "cronTime", attributes.getAsString( Key.cronTime ),
 			    "startDate", attributes.getAsString( Key.startDate ),

--- a/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
+++ b/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
@@ -476,4 +476,30 @@ class ScheduledTaskTest {
 		assertThat( variables.get( result ) ).isEqualTo( "what" );
 
 	}
+
+	@DisplayName( "call( DynamicObject, String ) registers without infinite recursion and executes the named method" )
+	@Test
+	public void testCallDynamicObjectWithMethodName() {
+		DynamicObject	dyno		= DynamicObject.of( new CallableTestTarget() );
+
+		ScheduledTask	registered	= task.call( dyno, "run" );
+		assertThat( registered ).isSameInstanceAs( task );
+
+		task.run( true );
+
+		@SuppressWarnings( "unchecked" )
+		java.util.Optional<Object> lastResult = ( java.util.Optional<Object> ) task.getStats().get( "lastResult" );
+		assertThat( lastResult.get() ).isEqualTo( "ran" );
+	}
+
+	/**
+	 * A named, public class so JVM reflection can resolve its public methods —
+	 * anonymous test-local classes are not public and fail reflective lookup.
+	 */
+	public static class CallableTestTarget {
+
+		public String run() {
+			return "ran";
+		}
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleClassFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleClassFixture.bx
@@ -1,0 +1,34 @@
+class {
+
+	this.callOrder			= [];
+	this.shouldThrow		= false;
+	this.lastResult			= "";
+	this.lastErrorMessage	= "";
+
+	function before() {
+		this.callOrder.append( "before" );
+	}
+
+	function run() {
+		this.callOrder.append( "run" );
+		if ( this.shouldThrow ) {
+			throw( message = "boom" );
+		}
+		return "ran-ok";
+	}
+
+	function onSuccess( result ) {
+		this.callOrder.append( "onSuccess" );
+		this.lastResult = result;
+	}
+
+	function onError( exception ) {
+		this.callOrder.append( "onError" );
+		this.lastErrorMessage = exception.message;
+	}
+
+	function after( result ) {
+		this.callOrder.append( "after" );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleCustomMethodFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleCustomMethodFixture.bx
@@ -1,0 +1,9 @@
+class {
+
+	this.executed = false;
+
+	function purge() {
+		this.executed = true;
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleMinimalClassFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleMinimalClassFixture.bx
@@ -1,0 +1,9 @@
+class {
+
+	this.runCount = 0;
+
+	function run() {
+		this.runCount++;
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
@@ -33,15 +33,19 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
+import ortus.boxlang.runtime.async.tasks.ScheduledTask;
 import ortus.boxlang.runtime.async.tasks.TaskRecord;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.services.SchedulerService;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class ScheduleTest {
@@ -709,5 +713,174 @@ public class ScheduleTest {
 
 		// No scheduler is created when there is nothing to load
 		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+	}
+
+	// --------------------------------------------------------------------------
+	// Class-based task tests
+	// --------------------------------------------------------------------------
+
+	private static final String	CLASS_FIXTURE			= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleClassFixture";
+	private static final String	MINIMAL_CLASS_FIXTURE	= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleMinimalClassFixture";
+	private static final String	CUSTOM_METHOD_FIXTURE	= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleCustomMethodFixture";
+
+	private IClassRunnable getClassInstance( String taskName ) {
+		BaseScheduler	scheduler	= ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		TaskRecord		record		= scheduler.getTaskRecord( taskName );
+		DynamicObject	dyno		= ( DynamicObject ) record.task.getTask();
+		return ( IClassRunnable ) dyno.getTargetInstance();
+	}
+
+	/**
+	 * Register a class-based task directly via {@link Schedule#registerClassTask} without ever
+	 * calling {@code ScheduledTask.start()} — this keeps run-order assertions deterministic by
+	 * avoiding any race with the real scheduled executor's own immediate first fire (which
+	 * would otherwise run concurrently with a manual {@code run(true)} call in these tests).
+	 */
+	private ScheduledTask registerClassTaskDirect( String taskName, String className, String method ) {
+		BaseScheduler	scheduler	= Schedule.getOrCreateScheduler( context, Schedule.DEFAULT_SCHEDULER_NAME );
+		IStruct			taskDef		= Struct.of( Key._CLASS, className, Key.method, method );
+		return Schedule.registerClassTask( scheduler, taskName, "", context, taskDef );
+	}
+
+	@DisplayName( "It can create a task with a class instead of a url" )
+	@Test
+	public void testCreateWithClass() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="classTask" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		BaseScheduler scheduler = ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		assertThat( scheduler.hasTask( "classTask" ) ).isTrue();
+	}
+
+	@DisplayName( "update throws when both url and class are provided" )
+	@Test
+	public void testCreateThrowsWhenBothUrlAndClass() {
+		assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="myTask" url="http://localhost/test" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		) );
+	}
+
+	@DisplayName( "update throws when neither url nor class are provided" )
+	@Test
+	public void testCreateThrowsWhenNeitherUrlNorClass() {
+		assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="myTask" interval="120">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		) );
+	}
+
+	@DisplayName( "running a class task fires before/run/after/onSuccess in order" )
+	@Test
+	public void testClassTaskLifecycleOrderOnSuccess() {
+		ScheduledTask task = registerClassTaskDirect( "classTask", CLASS_FIXTURE, "run" );
+		task.run( true );
+
+		IClassRunnable	fixtureInstance	= getClassInstance( "classTask" );
+		Array			callOrder		= ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+
+		// ScheduledTask.run() fires afterTask before onTaskSuccess on the success path
+		assertThat( callOrder.toArray() ).asList().containsExactly( "before", "run", "after", "onSuccess" ).inOrder();
+		assertThat( fixtureInstance.getThisScope().getAsString( Key.of( "lastResult" ) ) ).isEqualTo( "ran-ok" );
+	}
+
+	@DisplayName( "running a class task that throws fires before/run/onError/after and records the failure" )
+	@Test
+	public void testClassTaskLifecycleOrderOnError() {
+		ScheduledTask	task			= registerClassTaskDirect( "classTask", CLASS_FIXTURE, "run" );
+		IClassRunnable	fixtureInstance	= getClassInstance( "classTask" );
+		fixtureInstance.getThisScope().put( Key.of( "shouldThrow" ), true );
+
+		task.run( true );
+
+		Array callOrder = ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().containsExactly( "before", "run", "onError", "after" ).inOrder();
+		assertThat( fixtureInstance.getThisScope().getAsString( Key.of( "lastErrorMessage" ) ) ).isEqualTo( "boom" );
+		assertThat( ( ( java.util.concurrent.atomic.AtomicInteger ) task.getStats().get( "totalFailures" ) ).get() ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "a class task with no lifecycle methods runs fine — they are optional" )
+	@Test
+	public void testClassTaskWithoutLifecycleMethods() {
+		ScheduledTask task = registerClassTaskDirect( "minimalTask", MINIMAL_CLASS_FIXTURE, "run" );
+		task.run( true );
+
+		IClassRunnable fixtureInstance = getClassInstance( "minimalTask" );
+		assertThat( fixtureInstance.getThisScope().getAsInteger( Key.of( "runCount" ) ) ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "a class task honors a custom method attribute instead of run()" )
+	@Test
+	public void testClassTaskCustomMethod() {
+		ScheduledTask task = registerClassTaskDirect( "customMethodTask", CUSTOM_METHOD_FIXTURE, "purge" );
+		task.run( true );
+
+		IClassRunnable fixtureInstance = getClassInstance( "customMethodTask" );
+		assertThat( fixtureInstance.getThisScope().getAsBoolean( Key.of( "executed" ) ) ).isTrue();
+	}
+
+	@DisplayName( "a class task's onError() composes with onException=\"pause\" instead of being overwritten" )
+	@Test
+	public void testClassTaskOnErrorComposesWithOnExceptionPause() {
+		BaseScheduler	scheduler	= Schedule.getOrCreateScheduler( context, Schedule.DEFAULT_SCHEDULER_NAME );
+		IStruct			taskDef		= Struct.of( Key._CLASS, CLASS_FIXTURE, Key.method, "run", Key.onException, "pause" );
+		ScheduledTask	task		= Schedule.registerClassTask( scheduler, "classTask", "", context, taskDef );
+		Schedule.applyTaskConfiguration( task, null, taskDef, instance.getRuntimeContext() );
+
+		IClassRunnable fixtureInstance = getClassInstance( "classTask" );
+		fixtureInstance.getThisScope().put( Key.of( "shouldThrow" ), true );
+
+		task.run( true );
+
+		// The class's own onError() still fired ...
+		Array callOrder = ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().contains( "onError" );
+		// ... and the onException="pause" behavior also fired, disabling the task
+		assertThat( task.isDisabled() ).isTrue();
+	}
+
+	@DisplayName( "a class-based task survives a persistence reload" )
+	@Test
+	public void testClassTaskSurvivesReload() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="classReloadTask" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		// Remove the in-memory scheduler to simulate a fresh state
+		svc.removeScheduler( SCHEDULER_KEY, true, 5 );
+		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="reload">
+		    <bx:schedule action="pause" task="classReloadTask">
+		    <bx:schedule action="run" task="classReloadTask">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		BaseScheduler scheduler = ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		assertThat( scheduler.hasTask( "classReloadTask" ) ).isTrue();
+
+		IClassRunnable	fixtureInstance	= getClassInstance( "classReloadTask" );
+		Array			callOrder		= ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().contains( "run" );
 	}
 }

--- a/workbench/samples/components/async/Schedule.md
+++ b/workbench/samples/components/async/Schedule.md
@@ -1,14 +1,87 @@
 ### Create a scheduled task
 
-Creates a new task that fires an HTTP URL on a recurring interval.
+Creates a new task that fires an HTTP GET request against a URL on a recurring interval.
 
 ```java
 <bx:schedule
     action="create"
     task="dailyReport"
-    url="/tasks/daily-report.bx"
+    url="https://example.com/tasks/daily-report.bx"
     interval="daily"
     startTime="08:00"
+>
+
+```
+
+### Create a task that runs a BoxLang class
+
+Instead of firing an HTTP request, point a task at a BoxLang class with `class` (mutually
+exclusive with `url`). The class is instantiated once and reused for the life of the task, and
+its `run()` method (or the method named by `method`) is invoked on every fire:
+
+```java
+<bx:schedule
+    action="create"
+    task="dailyReport"
+    class="tasks.DailyReport"
+    interval="daily"
+    startTime="08:00"
+>
+
+```
+
+```java
+// tasks/DailyReport.bx
+class {
+
+    function run() {
+        // do the work
+    }
+
+}
+```
+
+The class may optionally define any of `before()`, `after(result)`, `onSuccess(result)`, and
+`onError(exception)` — each is only invoked if defined, following the same convention as a
+BoxLang scheduler class's life-cycle methods:
+
+```java
+// tasks/DailyReport.bx
+class {
+
+    function before() {
+        logger.info( "About to generate the daily report" );
+    }
+
+    function run() {
+        // do the work and (optionally) return a result
+        return generateReport();
+    }
+
+    function onSuccess( result ) {
+        logger.info( "Daily report generated: #result#" );
+    }
+
+    function onError( exception ) {
+        logger.error( "Daily report failed: #exception.message#" );
+    }
+
+    function after( result ) {
+        logger.info( "Daily report task finished" );
+    }
+
+}
+```
+
+A custom method name can be used instead of `run()`:
+
+```java
+<bx:schedule
+    action="create"
+    task="cleanup"
+    class="tasks.Cleanup"
+    method="purgeOldFiles"
+    interval="daily"
 >
 
 ```


### PR DESCRIPTION
Lets a scheduled task instantiate a BoxLang class and invoke a method on it
(default run()) instead of firing an HTTP request, via a new class attribute
(mutually exclusive with url) and an optional method attribute. The class is
instantiated once and reused for the task's life, matching the BoxScheduler/
ClassListener convention, and may optionally define before()/after(result)/
onSuccess(result)/onError(exception) life-cycle methods that are dispatched
the same way a BoxLang scheduler class's life-cycle methods are.

Along the way, fixes two pre-existing bugs this path depends on:
- ScheduledTask.call(DynamicObject, String) recursed into itself infinitely
  instead of registering the task (dead code until now).
- ScheduledTask.run()'s DynamicObject case invoked methods via JVM reflection,
  which cannot resolve BoxLang classes' dynamically-defined UDFs; it now
  dispatches through dereferenceAndInvoke() for IReferenceable targets.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q2WWSFuM8VMMqKPiRWNLUr