### PR TITLE
version bump

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,15 +132,15 @@ jobs:
             **/build/reports/tests/**
             **/build/test-results/**
 
-      # - name: Inform Slack
-      #   if: ${{ !matrix.experimental && failure() && github.ref == 'refs/heads/development' }}
-      #   uses: rtCamp/action-slack-notify@v2
-      #   env:
-      #     SLACK_CHANNEL: boxlang
-      #     SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
-      #     SLACK_ICON_EMOJI: ":bell:"
-      #     SLACK_MESSAGE: "${{ github.repository }} Tests FAILED!  You broke the build! :("
-      #     SLACK_TITLE: "${{ github.repository }} Build Failure"
-      #     SLACK_USERNAME: CI
-      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     MSG_MINIMAL: true
+      - name: Inform Slack
+        if: ${{ !matrix.experimental && failure() && github.ref == 'refs/heads/development' }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: boxlang
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+          SLACK_ICON_EMOJI: ":bell:"
+          SLACK_MESSAGE: "${{ github.repository }} Tests FAILED!  You broke the build! :("
+          SLACK_TITLE: "${{ github.repository }} Build Failure"
+          SLACK_USERNAME: CI
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MSG_MINIMAL: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,15 +132,15 @@ jobs:
             **/build/reports/tests/**
             **/build/test-results/**
 
-      - name: Inform Slack
-        if: ${{ !matrix.experimental && failure() && github.ref == 'refs/heads/development' }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: boxlang
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
-          SLACK_ICON_EMOJI: ":bell:"
-          SLACK_MESSAGE: "${{ github.repository }} Tests FAILED!  You broke the build! :("
-          SLACK_TITLE: "${{ github.repository }} Build Failure"
-          SLACK_USERNAME: CI
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MSG_MINIMAL: true
+      # - name: Inform Slack
+      #   if: ${{ !matrix.experimental && failure() && github.ref == 'refs/heads/development' }}
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_CHANNEL: boxlang
+      #     SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+      #     SLACK_ICON_EMOJI: ":bell:"
+      #     SLACK_MESSAGE: "${{ github.repository }} Tests FAILED!  You broke the build! :("
+      #     SLACK_TITLE: "${{ github.repository }} Build Failure"
+      #     SLACK_USERNAME: CI
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #     MSG_MINIMAL: true

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ dependencies {
 	// Implementation Dependencies
 	// https://mvnrepository.com/artifact/commons-io/commons-io
 	implementation "commons-io:commons-io:2.22.0"
+	// https://mvnrepository.com/artifact/org.itadaki/bzip2
+	implementation "org.itadaki:bzip2:0.9.1"
 	// https://mvnrepository.com/artifact/com.github.javaparser/javaparser-symbol-solver-core
 	implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.27.1'
 	// https://mvnrepository.com/artifact/org.apache.commons/commons-lang3

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-08
+
 ## [1.14.0] - 2026-06-03
 
 ## [1.13.0] - 2026-05-01
@@ -73,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - <https://boxlang.ortusbooks.com/readme/release-history/1.0.0>
 
-[unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.14.0...HEAD
+[unreleased]: https://github.com/ortus-boxlang/BoxLang/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/ortus-boxlang/BoxLang/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/ortus-boxlang/BoxLang/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/ortus-boxlang/BoxLang/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/ortus-boxlang/BoxLang/compare/v1.11.0...v1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Wed Jun 03 09:13:08 UTC 2026
+#Wed Jul 08 20:51:03 UTC 2026
 antlrVersion=4.13.1
 jdkVersion=21
-version=1.15.0
+version=1.16.0

--- a/src/main/java/ortus/boxlang/compiler/Boxpiler.java
+++ b/src/main/java/ortus/boxlang/compiler/Boxpiler.java
@@ -154,17 +154,21 @@ public abstract class Boxpiler implements IBoxpiler {
 	 *
 	 * @param classPool The class pool to check
 	 * @param classInfo The class info to ensure
+	 * 
+	 * @return The ensured class info.
 	 */
-	protected void ensureClassInfo( Map<String, ClassInfo> classPool, ClassInfo classInfo ) {
-		String name = classInfo.fqn().toString();
-		if ( classPool.get( name ) != null ) {
-			return;
+	protected ClassInfo ensureClassInfo( Map<String, ClassInfo> classPool, ClassInfo classInfo ) {
+		String		name	= classInfo.fqn().toString();
+		ClassInfo	ensuredClassInfo;
+		if ( ( ensuredClassInfo = classPool.get( name ) ) != null ) {
+			return ensuredClassInfo;
 		}
 		synchronized ( classPool ) {
-			if ( classPool.get( name ) != null ) {
-				return;
+			if ( ( ensuredClassInfo = classPool.get( name ) ) != null ) {
+				return ensuredClassInfo;
 			}
 			classPool.put( name, classInfo );
+			return classInfo;
 		}
 	}
 
@@ -285,8 +289,7 @@ public abstract class Boxpiler implements IBoxpiler {
 	public Class<IBoxRunnable> compileStatement( String source, BoxSourceType type ) {
 		ClassInfo	classInfo	= ClassInfo.forStatement( source, type, this );
 		var			classPool	= getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
-		classInfo = classPool.get( classInfo.fqn().toString() );
+		classInfo = ensureClassInfo( classPool, classInfo );
 
 		return classInfo.getDiskClass();
 
@@ -304,8 +307,7 @@ public abstract class Boxpiler implements IBoxpiler {
 	public Class<IBoxRunnable> compileScript( String source, BoxSourceType type ) {
 		ClassInfo	classInfo	= ClassInfo.forScript( source, type, this );
 		var			classPool	= getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
-		classInfo = classPool.get( classInfo.fqn().toString() );
+		classInfo = ensureClassInfo( classPool, classInfo );
 		return classInfo.getDiskClass();
 	}
 
@@ -318,26 +320,26 @@ public abstract class Boxpiler implements IBoxpiler {
 	 */
 	@Override
 	public Class<IBoxRunnable> compileTemplate( ResolvedFilePath resolvedFilePath ) {
-		ClassInfo	classInfo	= ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( resolvedFilePath.absolutePath().toFile(), true ), this );
-		var			classPool	= getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
+		ClassInfo	classInfo			= ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( resolvedFilePath.absolutePath().toFile(), true ), this );
+		var			classPool			= getClassPool( classInfo.classPoolName() );
+		ClassInfo	ensuredClassInfo	= ensureClassInfo( classPool, classInfo );
 		// If the new class is newer than the one on disk, recompile it
-		long	lastModified	= classPool.get( classInfo.fqn().toString() ).lastModified();
-		long	lastModified2	= classInfo.lastModified();
+		long		lastModified		= ensuredClassInfo.lastModified();
+		long		lastModified2		= classInfo.lastModified();
 		// This needs to be tested at decision time since the setting may have changed in the runtime since the compiler was created
-		Boolean	trustedCache	= runtime.getConfiguration().trustedCache;
+		Boolean		trustedCache		= runtime.getConfiguration().trustedCache;
 		if ( ( lastModified > 0 ) && ( lastModified2 > 0 ) && !trustedCache && ( lastModified != lastModified2 ) ) {
 			// Double check lock using the class name as the lockn. This ensures only one thread recompiles a class at a time
 			String internedFQN = classInfo.fqn().toString().intern();
 			synchronized ( internedFQN ) {
 
-				lastModified	= classPool.get( classInfo.fqn().toString() ).lastModified();
+				lastModified	= ensuredClassInfo.lastModified();
 				lastModified2	= classInfo.lastModified();
 				if ( ( lastModified > 0 ) && ( lastModified2 > 0 ) && !trustedCache && ( lastModified != lastModified2 ) ) {
 					// Close the stale loader before recompiling. Match the prior behavior exactly: close
 					// without nulling the discarded ClassInfo's reference (it is replaced in the pool
 					// below). Guard for resolve-only loaders (e.g. Android's) which are not Closeable.
-					ClassLoader staleLoader = classPool.get( classInfo.fqn().toString() ).getClassLoader();
+					ClassLoader staleLoader = ensuredClassInfo.getClassLoader();
 					if ( staleLoader instanceof Closeable closeable ) {
 						try {
 							closeable.close();
@@ -355,11 +357,11 @@ public abstract class Boxpiler implements IBoxpiler {
 						classInfo.doneCompiling();
 					}
 				} else {
-					classInfo = classPool.get( classInfo.fqn().toString() );
+					classInfo = ensuredClassInfo;
 				}
 			}
 		} else {
-			classInfo = classPool.get( classInfo.fqn().toString() );
+			classInfo = ensuredClassInfo;
 		}
 		// This will block if the class info is still being compiled
 		return classInfo.getDiskClass();
@@ -376,8 +378,7 @@ public abstract class Boxpiler implements IBoxpiler {
 	public Class<IBoxRunnable> compileClass( String source, BoxSourceType type ) {
 		ClassInfo	classInfo	= ClassInfo.forClass( source, type, this );
 		var			classPool	= getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
-		classInfo = classPool.get( classInfo.fqn().toString() );
+		classInfo = ensureClassInfo( classPool, classInfo );
 
 		return classInfo.getDiskClass();
 	}
@@ -392,6 +393,7 @@ public abstract class Boxpiler implements IBoxpiler {
 	@Override
 	public Class<IBoxRunnable> compileClass( ResolvedFilePath resolvedFilePath ) {
 		ClassInfo				classInfo			= null;
+		ClassInfo				ensuredClassInfo	= null;
 		Map<String, ClassInfo>	classPool			= null;
 		FQN						fqn					= null;
 		long					lastModifiedCurrent	= 0;
@@ -411,6 +413,7 @@ public abstract class Boxpiler implements IBoxpiler {
 					}
 					if ( entry.resolvedFilePath().equals( resolvedFilePath ) ) {
 						classInfo			= entry;
+						ensuredClassInfo	= classInfo;
 						// The classInfo may be cached, but get a fresh modified date
 						lastModifiedCurrent	= classInfo.getFreshLastModified();
 						break;
@@ -418,8 +421,9 @@ public abstract class Boxpiler implements IBoxpiler {
 				}
 				// Ok, if that didn't work, look for the normalized FQN.
 				if ( classInfo == null ) {
-					fqn			= resolvedFilePath.getFQN( "boxgenerated.boxclass" );
-					classInfo	= classPool.get( fqn.toString() );
+					fqn					= resolvedFilePath.getFQN( "boxgenerated.boxclass" );
+					classInfo			= classPool.get( fqn.toString() );
+					ensuredClassInfo	= classInfo;
 					if ( classInfo != null ) {
 						// The classInfo may be cached, but get a fresh modified date
 						lastModifiedCurrent = classInfo.getFreshLastModified();
@@ -435,12 +439,12 @@ public abstract class Boxpiler implements IBoxpiler {
 			// This date will be fresh since we just created the ClassInfo.
 			lastModifiedCurrent	= classInfo.lastModified();
 			classPool			= getClassPool( classInfo.classPoolName() );
-			ensureClassInfo( classPool, classInfo );
+			ensuredClassInfo	= ensureClassInfo( classPool, classInfo );
 		}
 
 		// If the new class is newer than the one on disk, recompile it
 		@SuppressWarnings( "null" )
-		long	lastModifiedPrevious	= classPool.get( classInfo.fqn().toString() ).lastModified();
+		long	lastModifiedPrevious	= ensuredClassInfo.lastModified();
 		// This needs to be tested at decision time since the setting may have changed in the runtime since the compiler was created
 		Boolean	trustedCache			= runtime.getConfiguration().trustedCache;
 		if ( ( lastModifiedPrevious > 0 ) && ( lastModifiedCurrent > 0 ) && !trustedCache && ( lastModifiedPrevious != lastModifiedCurrent ) ) {
@@ -448,10 +452,10 @@ public abstract class Boxpiler implements IBoxpiler {
 			String internedFQN = classInfo.fqn().toString().intern();
 			synchronized ( internedFQN ) {
 
-				lastModifiedPrevious	= classPool.get( classInfo.fqn().toString() ).lastModified();
+				lastModifiedPrevious	= ensuredClassInfo.lastModified();
 				lastModifiedCurrent		= classInfo.getFreshLastModified();
 				if ( ( lastModifiedPrevious > 0 ) && ( lastModifiedCurrent > 0 ) && !trustedCache && ( lastModifiedPrevious != lastModifiedCurrent ) ) {
-					classPool.get( classInfo.fqn().toString() ).shutdownClassLoader();
+					ensuredClassInfo.shutdownClassLoader();
 					// Get a fresh class info since we may have had a used one from above with an outdated modified date and class loader
 					classInfo = ClassInfo.forClass( resolvedFilePath, Parser.detectFile( resolvedFilePath.absolutePath().toFile(), true ), this, fqn );
 					try {
@@ -464,11 +468,11 @@ public abstract class Boxpiler implements IBoxpiler {
 						classInfo.doneCompiling();
 					}
 				} else {
-					classInfo = classPool.get( classInfo.fqn().toString() );
+					classInfo = ensuredClassInfo;
 				}
 			}
 		} else {
-			classInfo = classPool.get( classInfo.fqn().toString() );
+			classInfo = ensuredClassInfo;
 		}
 		// This will block if the class info is still being compiled
 		return classInfo.getDiskClass();
@@ -478,8 +482,7 @@ public abstract class Boxpiler implements IBoxpiler {
 	public Class<IProxyRunnable> compileInterfaceProxy( IBoxContext context, InterfaceProxyDefinition definition ) {
 		ClassInfo	classInfo	= ClassInfo.forInterfaceProxy( definition.name(), definition, this );
 		var			classPool	= getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
-		classInfo = classPool.get( classInfo.fqn().toString() );
+		classInfo = ensureClassInfo( classPool, classInfo );
 
 		return classInfo.getDiskClassProxy();
 
@@ -513,7 +516,7 @@ public abstract class Boxpiler implements IBoxpiler {
 			classInfo = ClassInfo.forTemplate( resolvedFilePath, Parser.detectFile( path.toFile() ), this );
 		}
 		var classPool = getClassPool( classInfo.classPoolName() );
-		ensureClassInfo( classPool, classInfo );
+		classInfo = ensureClassInfo( classPool, classInfo );
 		return compileClassInfo( classInfo.classPoolName(), classInfo.fqn().toString() );
 	}
 

--- a/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLColumn.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/sql/select/expression/SQLColumn.java
@@ -173,17 +173,6 @@ public class SQLColumn extends SQLExpression {
 		}
 
 		return data.get( intersection[ tableIndex ] - 1 )[ colIndex ];
-		/*
-		 * var tableFinal = getTableFinal( QoQExec );
-		 * // System.out.println( "getting SQL column: " + name.getName() + " from table: " + tableFinal.getName() + " with index: " + tableFinal.getIndex() );
-		 * // System.out.println( "intersection: " + Arrays.toString( intersection ) );
-		 * int rowNum = intersection[ tableFinal.getIndex() ];
-		 * // This means an outer join matched nothing
-		 * if ( rowNum == 0 ) {
-		 * return null;
-		 * }
-		 * return QoQExec.getTableLookup().get( tableFinal ).getCell( name, rowNum - 1 );
-		 */
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -785,10 +785,63 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		return super.visit( node );
 	}
 
+	/**
+	 * Transforms BoxMethodInvocation nodes for CFML compatibility.
+	 *
+	 * Currently handles:
+	 * - listAppend() member function: defaults includeEmptyFields to true (CF-compat)
+	 *
+	 * @param node The BoxMethodInvocation node to transform
+	 *
+	 * @return The transformed BoxMethodInvocation node
+	 */
+	@Override
+	public BoxNode visit( BoxMethodInvocation node ) {
+		// Only handle simple dot-access method calls like foo.listAppend(...)
+		if ( node.getName() instanceof BoxIdentifier id ) {
+			String name = id.getName().toLowerCase();
+			if ( name.equals( "listappend" ) ) {
+				return transpileListAppend( node );
+			}
+		}
+		return super.visit( node );
+	}
+
 	private BoxNode transpileListAppend( BoxFunctionInvocation node ) {
 		var args = node.getArguments();
 		if ( args.isEmpty() ) {
 			return super.visit( node );
+		}
+		// For a function invocation, the "list" is the 1st positional arg, so we expect up to 4 positional args total.
+		// The delimiter (positional) goes into slot 3, and includeEmptyFields goes into slot 4.
+		fixupListAppendArgs( args, /* delimiterInsertAtSize */ 2, /* maxPositional */ 4 );
+		node.setArguments( args );
+		return super.visit( node );
+	}
+
+	private BoxNode transpileListAppend( BoxMethodInvocation node ) {
+		var args = node.getArguments();
+		// For a method invocation like myList.listAppend( value, delim, includeEmptyFields ),
+		// the receiver IS the list, so the args list only contains value/delim/includeEmptyFields (up to 3).
+		// The delimiter (positional) goes into slot 2, and includeEmptyFields goes into slot 3.
+		fixupListAppendArgs( args, /* delimiterInsertAtSize */ 1, /* maxPositional */ 3 );
+		node.setArguments( args );
+		return super.visit( node );
+	}
+
+	/**
+	 * Shared logic for transpiling listAppend() calls to default the includeEmptyFields
+	 * argument to true (CF-compat behavior).
+	 *
+	 * @param args                  The mutable list of arguments to fix up
+	 * @param delimiterInsertAtSize The current size at which a missing delimiter needs to be inserted
+	 *                              (2 for BIF form, 1 for member form)
+	 * @param maxPositional         The maximum number of positional args after fixup
+	 *                              (4 for BIF form, 3 for member form)
+	 */
+	private void fixupListAppendArgs( List<BoxArgument> args, int delimiterInsertAtSize, int maxPositional ) {
+		if ( args.isEmpty() ) {
+			return;
 		}
 		// Check if named args
 		if ( args.get( 0 ).getName() != null ) {
@@ -803,13 +856,12 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 				        null
 				    )
 				);
-				node.setArguments( args );
 			}
 		} else {
 			// positional args
-			if ( args.size() < 4 ) {
-				if ( args.size() == 2 ) {
-					// add delimiter as 3rd positional arg
+			if ( args.size() < maxPositional ) {
+				if ( args.size() == delimiterInsertAtSize ) {
+					// add delimiter positional arg
 					args.add(
 					    new BoxArgument(
 					        null,
@@ -819,7 +871,7 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 					    )
 					);
 				}
-				// add includeEmptyFields as 4th positional arg
+				// add includeEmptyFields as final positional arg
 				args.add(
 				    new BoxArgument(
 				        null,
@@ -828,11 +880,8 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 				        null
 				    )
 				);
-				// Always re-set args and don't just modify the list so the AST model can be updated
-				node.setArguments( args );
 			}
 		}
-		return super.visit( node );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -309,6 +309,7 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		componentAttrMap.put( "procparam", Map.of( "cfsqltype", "sqltype" ) );
 		componentAttrMap.put( "queryparam", Map.of( "cfsqltype", "sqltype" ) );
 		componentAttrMap.put( "object", Map.of( "component", "className" ) );
+		componentAttrMap.put( "loop", Map.of( "struct", "collection" ) );
 
 		/*
 		 * Outer string is name of BIF (lowercase)

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -318,6 +318,7 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		 */
 		BIFArgMap.put( "directorylist", Map.of( "absolute_path", "path" ) );
 		BIFArgMap.put( "hash", Map.of( "string", "input" ) );
+		BIFArgMap.put( "extract", Map.of( "target", "destination" ) );
 		BIFArgMap.put( "getsafehtml", Map.of( "inputstring", "string", "policyfile", "policy" ) );
 
 		/*

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxLexerCustom.java
@@ -392,7 +392,11 @@ public class BoxLexerCustom extends BoxLexer {
 					    && !nextNonWhiteSpaceCharIs( '=' )
 					    && !lastTokenWas( DOT )
 					    && ( !nextNonWhiteSpaceCharIs( ':' ) || lastTokenOneOf( new int[] { CASE, QM } ) ) ) {
-						// any null but foo.null, null.foo, and null() and null = foo and null : (unless it's in a case statement or ternary operator)
+						// null()
+						// null.foo
+						// null = foo
+						// foo.null
+						// null : (unless it's in a case statement or ternary operator such as `case null:` or `condition ? null : ...`)
 						isIdentifier = false;
 					} else if ( ( nextTokenType == FALSE || nextTokenType == TRUE ) && !nextNonWhiteSpaceCharIs( '(' )
 					    && !lastTokenWas( DOT )
@@ -477,10 +481,12 @@ public class BoxLexerCustom extends BoxLexer {
 						if ( debug )
 							System.out.println( "Switching [" + nextToken.getText() + "] token to identifer because it is not a function declaration" );
 						isIdentifier = true;
-					} else if ( nextNonWhiteSpaceCharIs( ':' ) && ! ( nextTokenType == DEFAULT && inSwitchBody ) && ! ( lastTokenWas( EQUALSIGN ) ) ) {
+					} else if ( nextNonWhiteSpaceCharIs( ':' ) && ! ( nextTokenType == DEFAULT && inSwitchBody ) && ! ( lastTokenWas( EQUALSIGN ) )
+					    && !operatorEndingTokens.contains( lastToken.getType() ) ) {
 						// left side of a : which is usually { foo : bar }
 						// however, ignore default: in a switch body.
 						// also ignore condition ? foo = true : bar = false
+						// ignore assert null == null : "Expected true"
 						if ( debug )
 							System.out.println( "Switching [" + nextToken.getText() + "] token to identifer because next char is a colon" );
 						isIdentifier = true;
@@ -573,11 +579,13 @@ public class BoxLexerCustom extends BoxLexer {
 					    && nextNonWhiteSpaceCharsAre( operatorStartingChars )
 					    && !isFunctionDeclaration( nextToken )
 					    && ! ( operatorEndingTokens.contains( nextTokenType ) && nextNonWhiteSpaceCharIsOneOf( new int[] { '-', '+' } ) )
-					    && ! ( nextTokenType == NOT && nextCharsAreWord( "EQUAL" ) ) ) {
+					    && ! ( nextTokenType == NOT && nextCharsAreWord( "EQUAL" ) )
+					    && ! ( nextTokenType == NULL ) ) {
 						// The next chars are the start of an operator
 						// ignore THAN if it's GREATER THAN or LESS THAN
 						// ignore OR if it's GREATER|LESS THAN OR ...
 						// Ignore operators that are followed by a - or + (e.g. 5 EQ -3)
+						// ignore null ==, null !=, null NEQ, null EQ, null IS, null ===, null !==
 						if ( debug )
 							System.out.println( "Switching [" + nextToken.getText() + "] token to identifer because next chars are the start of an operator" );
 						isIdentifier = true;
@@ -960,7 +968,7 @@ public class BoxLexerCustom extends BoxLexer {
 
 	/**
 	 * Recursively match characters from the input stream against an operator trie.
-	 * Walks the trie character-by-character until a complete operator is matched or matching fails.
+	 * Walks the tree character-by-character until a complete operator is matched or matching fails.
 	 *
 	 * @param input          the character stream to read from
 	 * @param pos            the current position in the input stream
@@ -1096,6 +1104,22 @@ public class BoxLexerCustom extends BoxLexer {
 		// now that we've matched the word, the next char must be a non-character or the EOF
 		int nextChar = getInputStream().LA( pos );
 		return !Character.isAlphabetic( nextChar ) && !Character.isDigit( nextChar );
+	}
+
+	/**
+	 * Check if the next sequence of characters matches any of the specified words
+	 *
+	 * @param words an array of words to match. Pass as upper case
+	 *
+	 * @return true if the next sequence of characters matches any of the specified words
+	 */
+	private boolean nextCharsAreWordOneOf( String[] words ) {
+		for ( String word : words ) {
+			if ( nextCharsAreWord( word ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/compiler/parser/BoxLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/BoxLexerCustom.java
@@ -529,7 +529,7 @@ public class BoxLexerCustom extends BoxLexer {
 					        && ( ( ( nextTokenType == IF || nextTokenType == SWITCH ) && nextNonWhiteSpaceCharIs( '(' ) )
 					            || ( nextTokenType == TRY && nextNonWhiteSpaceCharIs( '{' ) )
 					            || ( nextTokenType == INCLUDE || nextTokenType == THROW || nextTokenType == VAR || nextTokenType == DEFAULT
-					                || nextTokenType == CONTINUE ) ) ) ) {
+					                || nextTokenType == CONTINUE || nextTokenType == RETHROW || nextTokenType == ASSERT ) ) ) ) {
 						// preceeded by a :
 						// but myLabel : for() is fine
 						// and myLabel : while()
@@ -538,6 +538,8 @@ public class BoxLexerCustom extends BoxLexer {
 						// but not case: try {} catch(){}
 						// and not case: include "foo"
 						// and not case: continue
+						// and not case: rethrow
+						// and not case: assert
 						if ( debug )
 							System.out.println( "Switching [" + nextToken.getText() + "] token to identifer because last token was a colon" );
 						isIdentifier = true;

--- a/src/main/java/ortus/boxlang/compiler/parser/CFLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFLexerCustom.java
@@ -1026,7 +1026,7 @@ public class CFLexerCustom extends CFLexer {
 
 	/**
 	 * Recursively match characters from the input stream against an operator trie.
-	 * Walks the trie character-by-character until a complete operator is matched or matching fails.
+	 * Walks the tree character-by-character until a complete operator is matched or matching fails.
 	 *
 	 * @param input          the character stream to read from
 	 * @param pos            the current position in the input stream

--- a/src/main/java/ortus/boxlang/compiler/parser/CFLexerCustom.java
+++ b/src/main/java/ortus/boxlang/compiler/parser/CFLexerCustom.java
@@ -538,7 +538,7 @@ public class CFLexerCustom extends CFLexer {
 					        && ( ( ( nextTokenType == IF || nextTokenType == PREFIXEDIDENTIFIER || nextTokenType == SWITCH ) && nextNonWhiteSpaceCharIs( '(' ) )
 					            || ( nextTokenType == TRY && nextNonWhiteSpaceCharIs( '{' ) )
 					            || ( nextTokenType == INCLUDE || nextTokenType == THROW || nextTokenType == VAR || nextTokenType == DEFAULT
-					                || nextTokenType == CONTINUE ) ) ) ) {
+					                || nextTokenType == CONTINUE || nextTokenType == RETHROW ) ) ) ) {
 						// preceeded by a :
 						// but myLabel : for() is fine
 						// and myLabel : while()
@@ -547,6 +547,7 @@ public class CFLexerCustom extends CFLexer {
 						// but not case: try {} catch(){}
 						// and not case: include "foo"
 						// and not case: continue
+						// and not case: rethrow
 						if ( debug )
 							System.out.println( "Switching [" + nextToken.getText() + "] token to identifer because last token was a colon" );
 						isIdentifier = true;

--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -17,6 +17,7 @@
  */
 package ortus.boxlang.runtime.application;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
@@ -70,7 +71,7 @@ import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.AbortException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.DateTimeHelper;
-import ortus.boxlang.runtime.util.EncryptionUtil;
+import ortus.boxlang.runtime.util.ClassLoaderUtil;
 
 /**
  * I represent an Application in BoxLang
@@ -278,7 +279,7 @@ public class Application {
 	 *
 	 * @param requestContext The request context
 	 */
-	public void startupClassLoaderPaths( RequestBoxContext requestContext ) {
+	public ClassLoader startupClassLoaderPaths( RequestBoxContext requestContext ) {
 		URL[] loadPathsUrls = this.startingListener.getJavaSettingsLoadPaths( requestContext );
 
 		// if we don't have any return out
@@ -286,23 +287,53 @@ public class Application {
 			logger.trace( "===> Setting the context classLoader to the [runtime] loader during startupClassLoaderPaths via [{}]",
 			    Thread.currentThread().getName() );
 			// If there are no javasettings, ensure we just use the runtime CL
-			Thread.currentThread().setContextClassLoader( BoxRuntime.getInstance().getRuntimeLoader() );
-			return;
+			ClassLoader runtimeClassLoader = BoxRuntime.getInstance().getRuntimeLoader();
+			Thread.currentThread().setContextClassLoader( runtimeClassLoader );
+			return runtimeClassLoader;
 		}
 
 		// Get or compute a class loader according to the incoming URIs for classes to load
 		// Remember that Application.bx is instantiated per request, so each request could be different
-		String loaderCacheKey = EncryptionUtil.hash( Arrays.toString( loadPathsUrls ) );
-		this.classLoaders.computeIfAbsent( loaderCacheKey,
-		    key -> {
-			    logger.debug( "Application ClassLoader [{}] registered with these paths: [{}]", this.name, Arrays.toString( loadPathsUrls ) );
-			    return new DynamicClassLoader( this.name, loadPathsUrls, BoxRuntime.getInstance().getRuntimeLoader(), false );
-		    } );
+
+		// if javaSettings.reloadOnChange is true, incorporate time stamps for each jar
+
+		Object[]	pathsForHashing	= Arrays.copyOf( loadPathsUrls, loadPathsUrls.length, Object[].class );
+		IStruct		javaSettings	= this.startingListener.getSettings().getAsStruct( Key.javaSettings );
+		boolean		reloadOnChange	= BooleanCaster.cast( javaSettings.get( Key.reloadOnChange ) );
+		// If we want to reload when the jars change on disk, add the timestamps into the array to hash.
+		if ( reloadOnChange ) {
+			for ( int i = 0; i < loadPathsUrls.length; i++ ) {
+				File file = new File( loadPathsUrls[ i ].getPath() );
+				if ( file.exists() ) {
+					pathsForHashing[ i ] = loadPathsUrls[ i ].toString() + file.lastModified();
+				}
+			}
+			// Now the URL of paths has been modified to include the last modified timestamps if reloadOnChange is true
+			// This will force a new CL if one of the jars has changed on disk
+		}
+		String				loaderCacheKey	= ClassLoaderUtil.hashSorted( pathsForHashing );
+		DynamicClassLoader	theCL			= this.classLoaders.computeIfAbsent( loaderCacheKey, key -> {
+												logger.debug( "Application ClassLoader [{}] registered with these paths: [{}]", this.name,
+												    Arrays.toString( loadPathsUrls ) );
+												return new DynamicClassLoader( this.name, loadPathsUrls,
+												    BoxRuntime.getInstance().getRuntimeLoader(), false );
+											} );
+
+		// clear old class loaders for the same file set
+		if ( reloadOnChange ) {
+			// remove any CLs from the map whose URLHash is the same as theCL.getURLHash() but don't remove ourselves!
+			// This is to prevent memory leaks when using reloadOnChange and changing the jars many times in a row
+			// Note, we are NOT closing these CLs. It's not safe to since they may be in by another request and I don't want this action
+			// to activley trash any other threads still using the old CL.
+			this.classLoaders.entrySet().removeIf( entry -> entry.getValue() != theCL && entry.getValue().getURLHash().equals( theCL.getURLHash() ) );
+		}
+
 		// Make sure our thread is using the right class loader
 		logger.trace( "===> Setting the context classLoader to the [javasettings] loader during startupClassLoaderPaths via [{}]",
 		    Thread.currentThread().getName() );
 
-		Thread.currentThread().setContextClassLoader( this.classLoaders.get( loaderCacheKey ) );
+		Thread.currentThread().setContextClassLoader( theCL );
+		return theCL;
 	}
 
 	/**
@@ -356,8 +387,8 @@ public class Application {
 			// TODO: the context when the application started isn't even nececarily the same as the context whe the session started, so even that isn't quite right.
 			// Both app end and session end generally run outside of an HTTP request, so it's ambiguous what should really be available to them.
 			this.startingListener.getRequestContext().registerDependentThread();
-			// Startup the class loader
-			startupClassLoaderPaths( context.getRequestContext() );
+			// Startup the class loader and retain it on the request-scoped listener
+			this.startingListener.setRequestClassLoader( startupClassLoaderPaths( context.getRequestContext() ) );
 			// Startup the caches
 			startupAppCaches( context.getRequestContext() );
 			// Startup session storages

--- a/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
@@ -18,7 +18,6 @@
 package ortus.boxlang.runtime.application;
 
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -57,7 +56,6 @@ import ortus.boxlang.runtime.types.exceptions.AbortException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.BLCollector;
 import ortus.boxlang.runtime.types.util.JSONUtil;
-import ortus.boxlang.runtime.util.EncryptionUtil;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
@@ -120,6 +118,11 @@ public abstract class BaseApplicationListener {
 	 * The application linked to this listener
 	 */
 	protected Application					application;
+
+	/**
+	 * The class loader selected while creating or updating the application.
+	 */
+	private ClassLoader						requestClassLoader;
 
 	/**
 	 * The request context bound to this listener
@@ -358,15 +361,17 @@ public abstract class BaseApplicationListener {
 			return BoxRuntime.getInstance().getRuntimeLoader();
 		}
 
-		// We are in app mode
-		URL[]		loadPathsUrls	= getJavaSettingsLoadPaths( context );
-		String		loaderCacheKey	= EncryptionUtil.hash( Arrays.toString( loadPathsUrls ) );
-		ClassLoader	target			= this.application.getClassLoader( loaderCacheKey );
-		if ( target == null ) {
-			target = BoxRuntime.getInstance().getRuntimeLoader();
-		}
+		// We are in app mode. The loader was selected during application path startup.
+		return this.requestClassLoader == null ? BoxRuntime.getInstance().getRuntimeLoader() : this.requestClassLoader;
+	}
 
-		return target;
+	/**
+	 * Set the class loader selected for this request.
+	 *
+	 * @param requestClassLoader The request class loader
+	 */
+	void setRequestClassLoader( ClassLoader requestClassLoader ) {
+		this.requestClassLoader = requestClassLoader;
 	}
 
 	/**
@@ -402,7 +407,7 @@ public abstract class BaseApplicationListener {
 	 * Update or create the application class loader paths
 	 */
 	private void createOrUpdateClassLoaderPaths() {
-		this.application.startupClassLoaderPaths( this.context );
+		setRequestClassLoader( this.application.startupClassLoaderPaths( this.context ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
+++ b/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
@@ -773,7 +773,7 @@ public class ScheduledTask implements Runnable {
 	public ScheduledTask call( DynamicObject task, String method ) {
 		debugLog( "call" );
 		setTask( task );
-		setMethod( method == null ? "run" : method );
+		setMethod( method == null || method.isBlank() ? "run" : method );
 		return this;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
+++ b/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
@@ -475,8 +475,15 @@ public class ScheduledTask implements Runnable {
 			// Execution by type
 			switch ( task ) {
 				case DynamicObject castedTask -> {
-					this.stats.put( "lastResult", Optional
-					    .ofNullable( castedTask.invoke( this.taskContext, method ) ) );
+					Object	targetInstance	= castedTask.getTargetInstance();
+					Object	result;
+					// BoxLang classes/objects dispatch UDFs dynamically (this scope), not via JVM reflection
+					if ( targetInstance instanceof IReferenceable referenceable ) {
+						result = referenceable.dereferenceAndInvoke( this.taskContext, Key.of( method ), DynamicObject.EMPTY_ARGS, false );
+					} else {
+						result = castedTask.invoke( this.taskContext, method );
+					}
+					this.stats.put( "lastResult", Optional.ofNullable( result ) );
 				}
 				case Callable<?> castedTask -> {
 					this.stats.put( "lastResult", Optional.ofNullable( castedTask.call() ) );
@@ -764,7 +771,10 @@ public class ScheduledTask implements Runnable {
 	 * @return The ScheduledTask instance
 	 */
 	public ScheduledTask call( DynamicObject task, String method ) {
-		return call( task, method );
+		debugLog( "call" );
+		setTask( task );
+		setMethod( method == null ? "run" : method );
+		return this;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BinaryDecode.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BinaryDecode.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.util.EncryptionUtil;
 
 @BoxBIF( description = "Decode binary data from a string" )
 public class BinaryDecode extends BIF {
@@ -64,7 +65,7 @@ public class BinaryDecode extends BIF {
 		}
 		// UU encoding
 		else if ( encodingKey.equals( Key.encodingUU ) ) {
-			return Base64.getMimeDecoder().decode( ref );
+			return EncryptionUtil.uuDecode( ref );
 		}
 		// Base64 encoding
 		else if ( encodingKey.equals( Key.encodingBase64 ) ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitAnd.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitAnd.java
@@ -33,8 +33,8 @@ public class BitAnd extends BIF {
 	public BitAnd() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number1 ),
-		    new Argument( true, "integer", Key.number2 )
+		    new Argument( true, "long", Key.number1 ),
+		    new Argument( true, "long", Key.number2 )
 		};
 	}
 
@@ -49,8 +49,8 @@ public class BitAnd extends BIF {
 	 * @argument.number2 Numeric value for bitwise AND.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number1	= arguments.getAsInteger( Key.number1 );
-		int	number2	= arguments.getAsInteger( Key.number2 );
+		long	number1	= arguments.getAsLong( Key.number1 );
+		long	number2	= arguments.getAsLong( Key.number2 );
 
 		return number1 & number2;
 	}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskClear.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskClear.java
@@ -34,7 +34,7 @@ public class BitMaskClear extends BIF {
 	public BitMaskClear() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number ),
+		    new Argument( true, "long", Key.number ),
 		    new Argument( true, "integer", Key.start ),
 		    new Argument( true, "integer", Key.length )
 		};
@@ -46,7 +46,7 @@ public class BitMaskClear extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.number 32-bit signed integer on which the mask clear operation is performed.
+	 * @argument.number 64-bit signed integer on which the mask clear operation is performed.
 	 * 
 	 * @argument.start Start bit for the clear mask (Integer in the range 0-31, inclusive).
 	 * 
@@ -55,9 +55,9 @@ public class BitMaskClear extends BIF {
 	 * @throws BoxRuntimeException If length or start is not in the range 0-31, inclusive.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number	= arguments.getAsInteger( Key.number );
-		int	start	= arguments.getAsInteger( Key.start );
-		int	length	= arguments.getAsInteger( Key.length );
+		long	number	= arguments.getAsLong( Key.number );
+		int		start	= arguments.getAsInteger( Key.start );
+		int		length	= arguments.getAsInteger( Key.length );
 
 		if ( start < 0 || start > 31 ) {
 			throw new BoxRuntimeException( "Start must be in the range 0-31, inclusive." );
@@ -68,7 +68,7 @@ public class BitMaskClear extends BIF {
 		}
 
 		// Create a bitmask with 'length' consecutive 1 bits starting from position 'start'
-		int bitmask = ( 1 << length ) - 1 << start;
+		long bitmask = ( 1L << length ) - 1 << start;
 
 		// Perform a bitwise mask clear operation on 'number' using the created bitmask
 		return number & ~bitmask;

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskRead.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskRead.java
@@ -34,7 +34,7 @@ public class BitMaskRead extends BIF {
 	public BitMaskRead() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number ),
+		    new Argument( true, "long", Key.number ),
 		    new Argument( true, "integer", Key.start ),
 		    new Argument( true, "integer", Key.length )
 		};
@@ -46,7 +46,7 @@ public class BitMaskRead extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.number 32-bit signed integer from which to read the mask.
+	 * @argument.number 64-bit signed integer from which to read the mask.
 	 * 
 	 * @argument.start Start bit for the read mask (Integer in the range 0-31, inclusive).
 	 * 
@@ -55,9 +55,9 @@ public class BitMaskRead extends BIF {
 	 * @throws BoxRuntimeException If length or start is not in the range 0-31, inclusive.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number	= arguments.getAsInteger( Key.number );
-		int	start	= arguments.getAsInteger( Key.start );
-		int	length	= arguments.getAsInteger( Key.length );
+		long	number	= arguments.getAsLong( Key.number );
+		int		start	= arguments.getAsInteger( Key.start );
+		int		length	= arguments.getAsInteger( Key.length );
 
 		if ( start < 0 || start > 31 ) {
 			throw new BoxRuntimeException( "Start must be in the range 0-31, inclusive." );
@@ -68,7 +68,7 @@ public class BitMaskRead extends BIF {
 		}
 
 		// Create a bitmask with 'length' consecutive 1 bits starting from position 'start'
-		int bitmask = ( 1 << length ) - 1 << start;
+		long bitmask = ( 1L << length ) - 1 << start;
 
 		// Perform a bitwise mask read operation on 'number' using the created bitmask
 		// The result is right-shifted to align the extracted bits to the right end

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskSet.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskSet.java
@@ -34,8 +34,8 @@ public class BitMaskSet extends BIF {
 	public BitMaskSet() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number ),
-		    new Argument( true, "integer", Key.mask ),
+		    new Argument( true, "long", Key.number ),
+		    new Argument( true, "long", Key.mask ),
 		    new Argument( true, "integer", Key.start ),
 		    new Argument( true, "integer", Key.length )
 		};
@@ -47,9 +47,9 @@ public class BitMaskSet extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.number Numeric value for the bitwise mask set.
+	 * @argument.number 64-bit signed integer value for the bitwise mask set.
 	 * 
-	 * @argument.mask Numeric value for the mask.
+	 * @argument.mask 64-bit signed integer value for the mask.
 	 * 
 	 * @argument.start Start bit for the set mask (Integer in the range 0-31, inclusive).
 	 * 
@@ -58,10 +58,10 @@ public class BitMaskSet extends BIF {
 	 * @throws BoxRuntimeException If length or start is not in the range 0-31, inclusive.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number	= arguments.getAsInteger( Key.number );
-		int	mask	= arguments.getAsInteger( Key.mask );
-		int	start	= arguments.getAsInteger( Key.start );
-		int	length	= arguments.getAsInteger( Key.length );
+		long	number	= arguments.getAsLong( Key.number );
+		long	mask	= arguments.getAsLong( Key.mask );
+		int		start	= arguments.getAsInteger( Key.start );
+		int		length	= arguments.getAsInteger( Key.length );
 
 		if ( start < 0 || start > 31 ) {
 			throw new BoxRuntimeException( "Start must be in the range 0-31, inclusive." );
@@ -72,10 +72,10 @@ public class BitMaskSet extends BIF {
 		}
 
 		// Create a bitmask with 'length' consecutive 1 bits starting from position 0
-		int bitmask = ( ( 1 << length ) - 1 ) << start;
+		long bitmask = ( ( 1L << length ) - 1 ) << start;
 
 		// Ensure 'mask' only contains 'length' bits by performing a bitwise AND with a bitmask
-		mask &= ( 1 << length ) - 1;
+		mask &= ( 1L << length ) - 1;
 
 		// Perform a bitwise mask set operation on 'number' using the created bitmask and adjusted 'mask'
 		return ( number & ~bitmask ) | ( mask << start );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitNot.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitNot.java
@@ -33,7 +33,7 @@ public class BitNot extends BIF {
 	public BitNot() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number )
+		    new Argument( true, "long", Key.number )
 		};
 	}
 
@@ -46,7 +46,7 @@ public class BitNot extends BIF {
 	 * @argument.number Numeric value for bitwise NOT.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int number = arguments.getAsInteger( Key.number );
+		long number = arguments.getAsLong( Key.number );
 
 		return ~number;
 	}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitOr.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitOr.java
@@ -33,8 +33,8 @@ public class BitOr extends BIF {
 	public BitOr() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number1 ),
-		    new Argument( true, "integer", Key.number2 )
+		    new Argument( true, "long", Key.number1 ),
+		    new Argument( true, "long", Key.number2 )
 		};
 	}
 
@@ -49,8 +49,8 @@ public class BitOr extends BIF {
 	 * @argument.number2 Numeric value for bitwise OR.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number1	= arguments.getAsInteger( Key.number1 );
-		int	number2	= arguments.getAsInteger( Key.number2 );
+		long	number1	= arguments.getAsLong( Key.number1 );
+		long	number2	= arguments.getAsLong( Key.number2 );
 
 		return number1 | number2;
 	}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitSh.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitSh.java
@@ -43,7 +43,7 @@ public class BitSh extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.number Numeric value to shift.
+	 * @argument.number 32-bit signed integer value to shift.
 	 *
 	 * @argument.count Number of bits to shift (Integer in the range 0-31, inclusive).
 	 *

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitXor.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/binary/BitXor.java
@@ -33,8 +33,8 @@ public class BitXor extends BIF {
 	public BitXor() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "integer", Key.number1 ),
-		    new Argument( true, "integer", Key.number2 )
+		    new Argument( true, "long", Key.number1 ),
+		    new Argument( true, "long", Key.number2 )
 		};
 	}
 
@@ -49,8 +49,8 @@ public class BitXor extends BIF {
 	 * @argument.number2 Numeric value for bitwise XOR.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		int	number1	= arguments.getAsInteger( Key.number1 );
-		int	number2	= arguments.getAsInteger( Key.number2 );
+		long	number1	= arguments.getAsLong( Key.number1 );
+		long	number2	= arguments.getAsLong( Key.number2 );
 
 		return number1 ^ number2;
 	}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Encrypt.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Encrypt.java
@@ -68,7 +68,7 @@ public class Encrypt extends BIF {
 	 *
 	 * @argument.algorithm The algorithm to use for encryption. Default is AES
 	 *
-	 * @argument.encoding The encoding type to use for encoding the encrypted data. Default is Base64
+	 * @argument.encoding The encoding type to use for encoding the encrypted data. Default is UUEncode
 	 *
 	 * @argument.IVorSalt The initialization vector or salt to use for encryption.
 	 *

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/encryption/Hmac.java
@@ -35,9 +35,6 @@ public class Hmac extends BIF {
 	private static final String		DEFAULT_ENCODING	= "utf-8";
 	private static final Integer	DEFAULT_ITERATIONS	= 1;
 
-	// The hash item object - non-local so we can reassign it in streams
-	private static Object			hashItem			= null;
-
 	/**
 	 * Constructor
 	 */

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListAppend.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListAppend.java
@@ -67,17 +67,24 @@ public class ListAppend extends BIF {
 	 * @argument.maxThreads number the maximum number of threads to use in the parallel filter
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Boolean	isMultiChar	= arguments.getAsBoolean( Key.multiCharacterDelimiter );
-		String	delimiter	= arguments.getAsString( Key.delimiter );
-		return ListUtil.asString(
-		    ListUtil.asDelimitedList(
-		        arguments.getAsString( Key.list ),
-		        arguments.getAsString( Key.delimiter ),
-		        arguments.getAsBoolean( Key.includeEmptyFields ),
-		        isMultiChar
-		    ).withDelimiter( delimiter, isMultiChar ).push( arguments.getAsString( Key.value ) ),
-		    delimiter
+		Boolean	isMultiChar		= arguments.getAsBoolean( Key.multiCharacterDelimiter );
+		String	delimiter		= arguments.getAsString( Key.delimiter );
+		Boolean	includeEmpty	= arguments.getAsBoolean( Key.includeEmptyFields );
+
+		// Tokenize both the incoming list and the value being appended with the same delimiter
+		// and empty-field policy so the two are treated consistently.
+		var		list			= ListUtil.asDelimitedList(
+		    arguments.getAsString( Key.list ),
+		    delimiter,
+		    includeEmpty,
+		    isMultiChar
+		).withDelimiter( delimiter, isMultiChar );
+
+		list.addAll(
+		    ListUtil.asList( arguments.getAsString( Key.value ), delimiter, includeEmpty, isMultiChar )
 		);
+
+		return ListUtil.asString( list, delimiter );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListPrepend.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/list/ListPrepend.java
@@ -67,15 +67,25 @@ public class ListPrepend extends BIF {
 	 * @argument.maxThreads number the maximum number of threads to use in the parallel filter
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Boolean	isMultiChar	= arguments.getAsBoolean( Key.multiCharacterDelimiter );
-		String	delimiter	= arguments.getAsString( Key.delimiter );
-		return ListUtil.asDelimitedList(
+		Boolean	isMultiChar		= arguments.getAsBoolean( Key.multiCharacterDelimiter );
+		String	delimiter		= arguments.getAsString( Key.delimiter );
+		Boolean	includeEmpty	= arguments.getAsBoolean( Key.includeEmptyFields );
+
+		// Tokenize both the incoming list and the value being prepended with the same delimiter
+		// and empty-field policy so the two are treated consistently.
+		var		list			= ListUtil.asDelimitedList(
 		    arguments.getAsString( Key.list ),
 		    delimiter,
-		    arguments.getAsBoolean( Key.includeEmptyFields ),
+		    includeEmpty,
 		    isMultiChar
-		).withDelimiter( delimiter, isMultiChar ).insertAt( 1, arguments.getAsString( Key.value ) )
-		    .asString();
+		).withDelimiter( delimiter, isMultiChar );
+
+		list.addAll(
+		    0,
+		    ListUtil.asList( arguments.getAsString( Key.value ), delimiter, includeEmpty, isMultiChar )
+		);
+
+		return list.asString();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseN.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseN.java
@@ -7,7 +7,7 @@ import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.bifs.BoxMember;
 import ortus.boxlang.runtime.context.IBoxContext;
-import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
+import ortus.boxlang.runtime.dynamic.casters.LongCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -56,6 +56,6 @@ public class FormatBaseN extends BIF {
 			return bigInt.toString( radix );
 		}
 
-		return Long.toString( IntegerCaster.cast( number ) & 0xffffffffL, radix );
+		return Long.toString( LongCaster.cast( number ) & 0xffffffffL, radix );
 	}
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/query/QueryAddRow.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/query/QueryAddRow.java
@@ -54,13 +54,13 @@ public class QueryAddRow extends BIF {
 	 *
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		Query					query		= arguments.getAsQuery( Key.query );
-		Object					rowData		= arguments.get( Key.rowData );
-		CastAttempt<Integer>	castAttempt	= IntegerCaster.attempt( rowData );
+		Query					query			= arguments.getAsQuery( Key.query );
+		Object					rowData			= arguments.get( Key.rowData );
+		CastAttempt<Integer>	IntegerAttempt	= IntegerCaster.attempt( rowData );
 
 		// If rowData is an integer, add that many empty rows
-		if ( castAttempt.wasSuccessful() ) {
-			return query.addRows( castAttempt.get() );
+		if ( IntegerAttempt.wasSuccessful() ) {
+			return query.addRows( IntegerAttempt.get() );
 		}
 
 		// Otherwise, add a single row with the provided data (if any)

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/set/StructKeySet.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/set/StructKeySet.java
@@ -54,7 +54,7 @@ public class StructKeySet extends BIF {
 		IStruct		struct	= arguments.getAsStruct( Key.struct );
 		BoxSet.Type	type	= BoxSet.parseType( arguments.getAsString( Key.type ) );
 		BoxSet		out		= new BoxSet( type, true, struct.isCaseSensitive() );
-		struct.keySet().forEach( k -> out.add( k.getName() ) );
+		struct.keySet().forEach( k -> out.add( k.getOriginalValue() ) );
 		return out;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/CreateObject.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/CreateObject.java
@@ -33,6 +33,7 @@ import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
 import ortus.boxlang.runtime.types.util.TypeUtil;
 
 @BoxBIF( description = "Create an instance of a Java class or component" )
@@ -109,11 +110,20 @@ public class CreateObject extends BIF {
 	 * @return The created object.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	type			= arguments.getAsString( Key.type );
-		String	className		= arguments.getAsString( Key.className );
-		Object	properties		= arguments.get( Key.properties );
-		Boolean	externalOnly	= arguments.getAsBoolean( Key.externalOnly );
-		Object	classLoader		= arguments.get( Key.classLoader );
+		String		type			= arguments.getAsString( Key.type );
+		String		className		= arguments.getAsString( Key.className );
+		Object		properties		= arguments.get( Key.properties );
+		Boolean		externalOnly	= arguments.getAsBoolean( Key.externalOnly );
+		Object		objclassLoader	= DynamicObject.unWrap( arguments.get( Key.classLoader ) );
+		ClassLoader	classLoader		= null;
+
+		// validate non-null class loader as proper type, error if not
+		if ( objclassLoader != null && objclassLoader instanceof ClassLoader cl ) {
+			classLoader = cl;
+		} else if ( objclassLoader != null ) {
+			throw new BoxValidationException(
+			    "Invalid class loader provided.  You passed an object of type [" + TypeUtil.getObjectName( objclassLoader ) + "]" );
+		}
 
 		return createObject(
 		    context,
@@ -122,7 +132,7 @@ public class CreateObject extends BIF {
 		    properties,
 		    arguments,
 		    externalOnly,
-		    classLoader == null ? null : ( ClassLoader ) classLoader
+		    classLoader
 		);
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/URLDecode.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/URLDecode.java
@@ -22,7 +22,6 @@ import java.io.UnsupportedEncodingException;
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
-import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -37,7 +36,7 @@ public class URLDecode extends BIF {
 	public URLDecode() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "any", Key.string ),
+		    new Argument( true, "string", Key.string ),
 		    new Argument( false, "string", Key.charset, "UTF-8" )
 		};
 	}
@@ -54,7 +53,7 @@ public class URLDecode extends BIF {
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		// TODO: Just stubbing this out to make TestBox work. We're going to look into transpiling this to use ESAPI's encodeForURL().
-		String	str		= StringCaster.cast( arguments.get( Key.string ) );
+		String	str		= arguments.getAsString( Key.string );
 		String	charset	= arguments.getAsString( Key.charset );
 		try {
 			return java.net.URLDecoder.decode( str, charset );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/URLDecode.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/URLDecode.java
@@ -22,6 +22,7 @@ import java.io.UnsupportedEncodingException;
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
@@ -53,7 +54,7 @@ public class URLDecode extends BIF {
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		// TODO: Just stubbing this out to make TestBox work. We're going to look into transpiling this to use ESAPI's encodeForURL().
-		String	str		= arguments.getAsString( Key.string );
+		String	str		= StringCaster.cast( arguments.get( Key.string ) );
 		String	charset	= arguments.getAsString( Key.charset );
 		try {
 			return java.net.URLDecoder.decode( str, charset );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/zip/Compress.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/zip/Compress.java
@@ -36,7 +36,8 @@ public class Compress extends BIF {
 	public Compress() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, Argument.STRING, Key.format, "zip", Set.of( Validator.valueOneOf( "zip", "gzip" ) ) ),
+		    new Argument( false, Argument.STRING, Key.format,
+		        Set.of( Validator.valueOneOf( "bzip", "bzip2", "gzip", "tar", "tar.bz", "tbz", "tbz2", "tgz", "tar.gz", "zip" ) ) ),
 		    new Argument( true, Argument.STRING, Key.source ),
 		    new Argument( true, Argument.STRING, Key.destination ),
 		    new Argument( false, Argument.BOOLEAN, Key.includeBaseFolder, true ),
@@ -53,7 +54,11 @@ public class Compress extends BIF {
 	 * the specified format:
 	 * <p>
 	 * - zip
-	 * - gzip (It will all files separately to the destination folder)
+	 * - gzip
+	 * - tar
+	 * - tgz/tar.gz (gzip-compressed tar)
+	 * - bzip/bzip2 (raw bzip2 stream)
+	 * - tbz/tbz2/tar.bz (bzip2-compressed tar)
 	 * <p>
 	 * The {@code includeBaseFolder} argument is used to include the base folder as the root
 	 * of the compressed file. The default is {@code true}.
@@ -69,7 +74,7 @@ public class Compress extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.format The format to use for the compression: zip or gzip. Default is zip.
+	 * @argument.format The format to use for the compression. If omitted, it is detected from the destination extension.
 	 *
 	 * @argument.source The absolute path to the source file or folder to compress.
 	 *
@@ -90,17 +95,18 @@ public class Compress extends BIF {
 	 * @return The absolute path to the compressed file.
 	 */
 	public String _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	format				= arguments.getAsString( Key.format );
-		String	source				= arguments.getAsString( Key.source );
-		String	destination			= arguments.getAsString( Key.destination );
-		boolean	includeBaseFolder	= BooleanCaster.cast( arguments.get( Key.includeBaseFolder ) );
-		boolean	overwrite			= BooleanCaster.cast( arguments.get( Key.overwrite ) );
-		Object	prefix				= arguments.get( Key.prefix );
-		Object	filter				= arguments.get( Key.filter );
-		Integer	compressionLevel	= arguments.getAsInteger( Key.compressionLevel );
+		String						format				= arguments.getAsString( Key.format );
+		String						source				= arguments.getAsString( Key.source );
+		String						destination			= arguments.getAsString( Key.destination );
+		ZipUtil.COMPRESSION_FORMAT	compressionFormat	= ZipUtil.detectFormat( format, destination );
+		boolean						includeBaseFolder	= BooleanCaster.cast( arguments.get( Key.includeBaseFolder ) );
+		boolean						overwrite			= BooleanCaster.cast( arguments.get( Key.overwrite ) );
+		Object						prefix				= arguments.get( Key.prefix );
+		Object						filter				= arguments.get( Key.filter );
+		Integer						compressionLevel	= arguments.getAsInteger( Key.compressionLevel );
 
 		return ZipUtil.compress(
-		    ZipUtil.COMPRESSION_FORMAT.valueOf( format.toUpperCase() ),
+		    compressionFormat,
 		    source,
 		    destination,
 		    includeBaseFolder,

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/zip/Extract.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/zip/Extract.java
@@ -36,7 +36,8 @@ public class Extract extends BIF {
 	public Extract() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, Argument.STRING, Key.format, Set.of( Validator.valueOneOf( "zip", "gzip" ) ) ),
+		    new Argument( false, Argument.STRING, Key.format,
+		        Set.of( Validator.valueOneOf( "bzip", "bzip2", "gzip", "tar", "tar.bz", "tbz", "tbz2", "tgz", "tar.gz", "zip" ) ) ),
 		    new Argument( true, Argument.STRING, Key.source ),
 		    new Argument( true, Argument.STRING, Key.destination ),
 		    new Argument( false, Argument.BOOLEAN, Key.overwrite, false ),
@@ -51,6 +52,10 @@ public class Extract extends BIF {
 	 * <p>
 	 * - zip
 	 * - gzip
+	 * - tar (raw TAR archive)
+	 * - tgz/tar.gz (gzip-compressed tar)
+	 * - bzip/bzip2 (raw bzip2 stream)
+	 * - tbz/tbz2/tar.bz (bzip2-compressed tar)
 	 * <p>
 	 * The {@code overwrite} argument is used to overwrite the destination
 	 * file if it already exists, else it will throw an exception. The default is {@code false}.
@@ -68,7 +73,7 @@ public class Extract extends BIF {
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.format The format to use for the compression: zip or gzip.
+	 * @argument.format The format to use for the compression. If omitted, it is detected from the source extension.
 	 *
 	 * @argument.source The absolute path to the source file or folder to compress.
 	 *
@@ -84,14 +89,15 @@ public class Extract extends BIF {
 	 *
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		String	format			= arguments.getAsString( Key.format );
-		String	source			= arguments.getAsString( Key.source );
-		String	destination		= arguments.getAsString( Key.destination );
-		Boolean	overwrite		= BooleanCaster.cast( arguments.get( Key.overwrite ) );
-		Boolean	recurse			= BooleanCaster.cast( arguments.get( Key.recurse ) );
+		String						format				= arguments.getAsString( Key.format );
+		String						source				= arguments.getAsString( Key.source );
+		String						destination			= arguments.getAsString( Key.destination );
+		ZipUtil.COMPRESSION_FORMAT	compressionFormat	= ZipUtil.detectFormat( format, source );
+		Boolean						overwrite			= BooleanCaster.cast( arguments.get( Key.overwrite ) );
+		Boolean						recurse				= BooleanCaster.cast( arguments.get( Key.recurse ) );
 
-		Array	entryPaths		= new Array();
-		Object	entryPathsValue	= arguments.get( Key.entryPaths );
+		Array						entryPaths			= new Array();
+		Object						entryPathsValue		= arguments.get( Key.entryPaths );
 		if ( entryPathsValue != null ) {
 			if ( entryPathsValue instanceof String ) {
 				entryPaths.add( entryPathsValue );
@@ -101,7 +107,7 @@ public class Extract extends BIF {
 		}
 
 		ZipUtil.extract(
-		    ZipUtil.COMPRESSION_FORMAT.valueOf( format.toUpperCase() ),
+		    compressionFormat,
 		    source,
 		    destination,
 		    overwrite,

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -719,9 +719,12 @@ public class Schedule extends Component {
 				// HTTP/Runnable-based tasks: wrap the callable itself
 				final Runnable original = callable;
 				task.call( () -> {
-					original.run();
-					if ( runCount.incrementAndGet() >= maxRuns ) {
-						finalTask.disable();
+					try {
+						original.run();
+					} finally {
+						if ( runCount.incrementAndGet() >= maxRuns ) {
+							finalTask.disable();
+						}
 					}
 				} );
 			} else {

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -608,9 +608,13 @@ public class Schedule extends Component {
 		    .unWrapBoxLangClass();
 
 		// DI, mirroring BoxScheduler.prepTarget()
-		instance.getVariablesScope().put( Key.scheduler, scheduler );
-		instance.getVariablesScope().put( Key.boxRuntime, rt );
-		instance.getVariablesScope().put( Key.logger, scheduler.getLogger() );
+		var variablesScope = instance.getVariablesScope();
+		variablesScope.put( Key.scheduler, scheduler );
+		variablesScope.put( Key.boxRuntime, rt );
+		variablesScope.put( Key.asyncService, rt.getAsyncService() );
+		variablesScope.put( Key.interceptorService, rt.getInterceptorService() );
+		variablesScope.put( Key.cacheService, rt.getCacheService() );
+		variablesScope.put( Key.logger, scheduler.getLogger() );
 
 		ScheduledTask task = scheduler.task( taskName, group ).call( DynamicObject.of( instance ), methodName );
 

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -71,7 +71,7 @@ import ortus.boxlang.runtime.validation.Validator;
  *
  * @attribute.class The dotted path/name of a BoxLang class to instantiate and invoke when the task fires, instead of making an HTTP request. Mutually exclusive with {@code url}; exactly one of the two is required for create/update/modify. The class
  *                  is instantiated once and reused for the life of the task. Only the {@code method} target is mandatory; the class may optionally define {@code before()}, {@code after(result)}, {@code onSuccess(result)}, and
- *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are (see the {@code boxlang-core-dev-async-tasks} skill) — each is only invoked if defined.
+	 *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are — each is only invoked if defined.
  *
  * @attribute.method The method to invoke on the {@code class} instance when the task fires. Defaults to "run". Ignored when {@code url} is used.
  *

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -71,7 +71,7 @@ import ortus.boxlang.runtime.validation.Validator;
  *
  * @attribute.class The dotted path/name of a BoxLang class to instantiate and invoke when the task fires, instead of making an HTTP request. Mutually exclusive with {@code url}; exactly one of the two is required for create/update/modify. The class
  *                  is instantiated once and reused for the life of the task. Only the {@code method} target is mandatory; the class may optionally define {@code before()}, {@code after(result)}, {@code onSuccess(result)}, and
-	 *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are — each is only invoked if defined.
+ *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are — each is only invoked if defined.
  *
  * @attribute.method The method to invoke on the {@code class} instance when the task fires. Defaults to "run". Ignored when {@code url} is used.
  *
@@ -608,7 +608,7 @@ public class Schedule extends Component {
 		    .unWrapBoxLangClass();
 
 		// DI, mirroring BoxScheduler.prepTarget()
-		var variablesScope = instance.getVariablesScope();
+		var				variablesScope	= instance.getVariablesScope();
 		variablesScope.put( Key.scheduler, scheduler );
 		variablesScope.put( Key.boxRuntime, rt );
 		variablesScope.put( Key.asyncService, rt.getAsyncService() );

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -604,7 +604,7 @@ public class Schedule extends Component {
 
 		IClassRunnable	instance		= ( IClassRunnable ) classLocator
 		    .load( runtimeContext, "bx:" + className, imports )
-		    .invokeConstructor( runtimeContext, Key.noInit )
+		    .invokeConstructor( runtimeContext )
 		    .unWrapBoxLangClass();
 
 		// DI, mirroring BoxScheduler.prepTarget()

--- a/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
+++ b/src/main/java/ortus/boxlang/runtime/components/async/Schedule.java
@@ -22,10 +22,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
+import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
 import ortus.boxlang.runtime.async.tasks.ScheduledTask;
 import ortus.boxlang.runtime.async.tasks.TaskRecord;
@@ -35,7 +38,10 @@ import ortus.boxlang.runtime.components.Component;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.ExpressionInterpreter;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.loader.ClassLocator;
 import ortus.boxlang.runtime.net.BoxHttpClient;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.HttpService;
 import ortus.boxlang.runtime.services.SchedulerService;
@@ -61,7 +67,13 @@ import ortus.boxlang.runtime.validation.Validator;
  *
  * @attribute.group Task group name for organizational purposes.
  *
- * @attribute.url The URL to request when the task fires (required for create/update/modify).
+ * @attribute.url The URL to request when the task fires. Mutually exclusive with {@code class}; exactly one of the two is required for create/update/modify.
+ *
+ * @attribute.class The dotted path/name of a BoxLang class to instantiate and invoke when the task fires, instead of making an HTTP request. Mutually exclusive with {@code url}; exactly one of the two is required for create/update/modify. The class
+ *                  is instantiated once and reused for the life of the task. Only the {@code method} target is mandatory; the class may optionally define {@code before()}, {@code after(result)}, {@code onSuccess(result)}, and
+ *                  {@code onError(exception)} life-cycle methods, dispatched the same way a BoxLang scheduler class's life-cycle methods are (see the {@code boxlang-core-dev-async-tasks} skill) — each is only invoked if defined.
+ *
+ * @attribute.method The method to invoke on the {@code class} instance when the task fires. Defaults to "run". Ignored when {@code url} is used.
  *
  * @attribute.interval Scheduling interval: "once", "daily", "weekly", "monthly", or seconds (>=60).
  *
@@ -144,6 +156,8 @@ public class Schedule extends Component {
 		    new Attribute( Key.scheduler, "string", DEFAULT_SCHEDULER_NAME ),
 		    new Attribute( Key.group, "string", "" ),
 		    new Attribute( Key.URL, "string" ),
+		    new Attribute( Key._CLASS, "string" ),
+		    new Attribute( Key.method, "string", "run" ),
 		    new Attribute( Key.interval, "string" ),
 		    new Attribute( Key.isDaily, "boolean", false ),
 		    new Attribute( Key.cronTime, "string" ),
@@ -280,13 +294,17 @@ public class Schedule extends Component {
 		String	schedulerName	= attributes.getAsString( Key.scheduler );
 		String	group			= attributes.getAsString( Key.group );
 		String	url				= attributes.getAsString( Key.URL );
+		String	className		= attributes.getAsString( Key._CLASS );
 		String	interval		= attributes.getAsString( Key.interval );
 		String	cronTime		= attributes.getAsString( Key.cronTime );
 		boolean	isDaily			= BooleanCaster.cast( attributes.getOrDefault( Key.isDaily, false ) );
+		boolean	hasUrl			= url != null && !url.isBlank();
+		boolean	hasClass		= className != null && !className.isBlank();
 
-		// Validate required attributes
-		if ( url == null || url.isBlank() ) {
-			throw new BoxRuntimeException( "The [url] attribute is required for schedule action [update]" );
+		// Validate required attributes: exactly one of [url] or [class] is required
+		if ( hasUrl == hasClass ) {
+			throw new BoxRuntimeException(
+			    "Exactly one of [url] or [class] is required for schedule action [update] - they are mutually exclusive" );
 		}
 
 		if ( cronTime == null && interval == null && !isDaily ) {
@@ -301,11 +319,15 @@ public class Schedule extends Component {
 			scheduler.removeTask( taskName );
 		}
 
-		// Build the HTTP callable
-		Runnable		callable	= buildTaskCallable( context, attributes );
-
-		// Register task and apply full configuration
-		ScheduledTask	task		= scheduler.task( taskName, group ).call( callable );
+		// Register task, either as a class-based task or an HTTP callable task
+		ScheduledTask	task;
+		Runnable		callable	= null;
+		if ( hasClass ) {
+			task = registerClassTask( scheduler, taskName, group, context, attributes );
+		} else {
+			callable	= buildTaskCallable( context, attributes );
+			task		= scheduler.task( taskName, group ).call( callable );
+		}
 		applyTaskConfiguration( task, callable, attributes, runtime.getRuntimeContext() );
 
 		// Start the task if the scheduler is already running
@@ -555,9 +577,75 @@ public class Schedule extends Component {
 	}
 
 	/**
-	 * Build a {@link Runnable} that performs an HTTP GET request to the configured URL.
-	 * Captures the runtime context (not the request context) for long-lived use.
+	 * Build and register a class-based scheduled task. The target class is instantiated once and
+	 * reused for the life of the task — the same "resolve once, dispatch life-cycle methods to it"
+	 * convention used by {@code BoxScheduler} (for BoxLang scheduler classes) and {@code ClassListener}
+	 * (for file watcher classes).
+	 *
+	 * @param scheduler The scheduler to register the task on.
+	 * @param taskName  The name of the task.
+	 * @param group     The task group.
+	 * @param context   The context used to resolve imports for class-name resolution.
+	 * @param taskDef   Struct of task fields — accepts both live attribute structs and persisted JSON structs.
+	 *
+	 * @return The configured, registered {@link ScheduledTask}.
 	 */
+	public static ScheduledTask registerClassTask( BaseScheduler scheduler, String taskName, String group, IBoxContext context, IStruct taskDef ) {
+		String	className	= taskDef.getAsString( Key._CLASS );
+		String	methodName	= taskDef.getAsString( Key.method );
+		if ( methodName == null || methodName.isBlank() ) {
+			methodName = "run";
+		}
+
+		BoxRuntime		rt				= BoxRuntime.getInstance();
+		IBoxContext		runtimeContext	= rt.getRuntimeContext();
+		ClassLocator	classLocator	= rt.getClassLocator();
+		var				imports			= context.getCurrentImports();
+
+		IClassRunnable	instance		= ( IClassRunnable ) classLocator
+		    .load( runtimeContext, "bx:" + className, imports )
+		    .invokeConstructor( runtimeContext, Key.noInit )
+		    .unWrapBoxLangClass();
+
+		// DI, mirroring BoxScheduler.prepTarget()
+		instance.getVariablesScope().put( Key.scheduler, scheduler );
+		instance.getVariablesScope().put( Key.boxRuntime, rt );
+		instance.getVariablesScope().put( Key.logger, scheduler.getLogger() );
+
+		ScheduledTask task = scheduler.task( taskName, group ).call( DynamicObject.of( instance ), methodName );
+
+		wireClassLifecycle( task, instance, runtimeContext );
+
+		return task;
+	}
+
+	/**
+	 * Wire optional life-cycle methods defined on a task class: {@code before()}, {@code after(result)},
+	 * {@code onSuccess(result)}, and {@code onError(exception)}. Each is only invoked if the class defines
+	 * it, following the same {@code containsKey}-guarded-dispatch convention as {@code BoxScheduler} and
+	 * {@code ClassListener}.
+	 *
+	 * @param task           The task to wire life-cycle hooks onto.
+	 * @param instance       The already-instantiated task class.
+	 * @param runtimeContext The runtime context used for invocation.
+	 */
+	private static void wireClassLifecycle( ScheduledTask task, IClassRunnable instance, IBoxContext runtimeContext ) {
+		var thisScope = instance.getThisScope();
+
+		if ( thisScope.containsKey( Key.before ) ) {
+			task.before( t -> instance.dereferenceAndInvoke( runtimeContext, Key.before, DynamicObject.EMPTY_ARGS, false ) );
+		}
+		if ( thisScope.containsKey( Key.after ) ) {
+			task.after( ( t, result ) -> instance.dereferenceAndInvoke( runtimeContext, Key.after, new Object[] { result.orElse( null ) }, false ) );
+		}
+		if ( thisScope.containsKey( Key.onSuccess ) ) {
+			task.onSuccess( ( t, result ) -> instance.dereferenceAndInvoke( runtimeContext, Key.onSuccess, new Object[] { result.orElse( null ) }, false ) );
+		}
+		if ( thisScope.containsKey( Key.onError ) ) {
+			task.onFailure( ( t, ex ) -> instance.dereferenceAndInvoke( runtimeContext, Key.onError, new Object[] { ex }, false ) );
+		}
+	}
+
 	/**
 	 * Apply the full task configuration (scheduling, callbacks, metadata) to an already-registered
 	 * {@link ScheduledTask}. Used by both {@code doUpdate} and {@code registerPersistedScheduleTasks}
@@ -584,6 +672,8 @@ public class Schedule extends Component {
 		Integer	retryCount		= taskDef.getAsInteger( Key.retryCount );
 		boolean	cluster			= BooleanCaster.cast( taskDef.getOrDefault( Key.cluster, false ) );
 		String	url				= taskDef.getAsString( Key.URL );
+		String	className		= taskDef.getAsString( Key._CLASS );
+		String	method			= taskDef.getAsString( Key.method );
 
 		// Apply scheduling
 		if ( cronTime != null && !cronTime.isBlank() ) {
@@ -621,13 +711,24 @@ public class Schedule extends Component {
 			final int			maxRuns		= repeat;
 			AtomicInteger		runCount	= new AtomicInteger( 0 );
 			final ScheduledTask	finalTask	= task;
-			final Runnable		original	= callable;
-			task.call( () -> {
-				original.run();
-				if ( runCount.incrementAndGet() >= maxRuns ) {
-					finalTask.disable();
-				}
-			} );
+			if ( callable != null ) {
+				// HTTP/Runnable-based tasks: wrap the callable itself
+				final Runnable original = callable;
+				task.call( () -> {
+					original.run();
+					if ( runCount.incrementAndGet() >= maxRuns ) {
+						finalTask.disable();
+					}
+				} );
+			} else {
+				// Class-based tasks have no Runnable to wrap: compose onto the after() hook instead,
+				// layering on top of any class-defined after() life-cycle method
+				task.after( composeAfter( task.getAfterTask(), ( t, result ) -> {
+					if ( runCount.incrementAndGet() >= maxRuns ) {
+						t.disable();
+					}
+				} ) );
+			}
 		}
 
 		// Apply exclude dates predicate
@@ -636,18 +737,18 @@ public class Schedule extends Component {
 			task.when( t -> !isExcludedDate( t.getNow(), excludeList ) );
 		}
 
-		// Wire onFailure callback based on onException
+		// Wire onFailure callback based on onException, composing with any class-defined onError() method
 		if ( "pause".equalsIgnoreCase( onException ) ) {
-			task.onFailure( ( t, e ) -> t.disable() );
+			task.onFailure( composeFailure( task.getOnTaskFailure(), ( t, e ) -> t.disable() ) );
 		} else if ( "invokeHandler".equalsIgnoreCase( onException ) && eventHandler != null && !eventHandler.isBlank() ) {
 			final String handler = eventHandler;
-			task.onFailure( ( t, ex ) -> httpGet( handler, null, runtimeContext ) );
+			task.onFailure( composeFailure( task.getOnTaskFailure(), ( t, ex ) -> httpGet( handler, null, runtimeContext ) ) );
 		}
 
-		// Wire after callback for oncomplete
+		// Wire after callback for oncomplete, composing with any class-defined after() method
 		if ( onComplete != null && !onComplete.isBlank() ) {
 			final String completeUrl = onComplete;
-			task.after( ( t, result ) -> httpGet( completeUrl, null, runtimeContext ) );
+			task.after( composeAfter( task.getAfterTask(), ( t, result ) -> httpGet( completeUrl, null, runtimeContext ) ) );
 		}
 
 		// Store metadata
@@ -657,6 +758,41 @@ public class Schedule extends Component {
 		task.setMetaKey( "eventhandler", eventHandler );
 		task.setMetaKey( "oncomplete", onComplete );
 		task.setMetaKey( "url", url );
+		task.setMetaKey( "class", className );
+		task.setMetaKey( "method", method );
+	}
+
+	/**
+	 * Compose two failure handlers so both run, in order, instead of the second silently
+	 * replacing the first. Used so a class's own {@code onError()} life-cycle method and the
+	 * {@code onException} attribute's HTTP-based handler can coexist.
+	 */
+	private static BiConsumer<ScheduledTask, Exception> composeFailure( BiConsumer<ScheduledTask, Exception> first,
+	    BiConsumer<ScheduledTask, Exception> second ) {
+		if ( first == null ) {
+			return second;
+		}
+		return ( t, e ) -> {
+			first.accept( t, e );
+			second.accept( t, e );
+		};
+	}
+
+	/**
+	 * Compose two "after" handlers so both run, in order, instead of the second silently
+	 * replacing the first. Used so a class's own {@code after()} life-cycle method, the
+	 * repeat-limit counter, and the {@code oncomplete} attribute's HTTP-based handler can
+	 * all coexist.
+	 */
+	private static BiConsumer<ScheduledTask, Optional<?>> composeAfter( BiConsumer<ScheduledTask, Optional<?>> first,
+	    BiConsumer<ScheduledTask, Optional<?>> second ) {
+		if ( first == null ) {
+			return second;
+		}
+		return ( t, r ) -> {
+			first.accept( t, r );
+			second.accept( t, r );
+		};
 	}
 
 	/**
@@ -834,6 +970,8 @@ public class Schedule extends Component {
 		    "group", record.group,
 		    "disabled", record.disabled,
 		    "url", meta.getOrDefault( Key.url, "" ),
+		    "class", meta.getOrDefault( Key._CLASS, "" ),
+		    "method", meta.getOrDefault( Key.method, "" ),
 		    "cronTime", meta.getOrDefault( Key.cronExpression, "" ),
 		    "retryCount", meta.getOrDefault( Key.retryCount, 3 ),
 		    "scheduledAt", record.scheduledAt,

--- a/src/main/java/ortus/boxlang/runtime/components/jdbc/StoredProc.java
+++ b/src/main/java/ortus/boxlang/runtime/components/jdbc/StoredProc.java
@@ -20,6 +20,7 @@ package ortus.boxlang.runtime.components.jdbc;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -350,35 +351,38 @@ public class StoredProc extends Component {
 	}
 
 	/**
-	 * Validate that all ProcResult components either have a resultSet attribute, or don't. Positional vs indexed.
-	 * Throw an exception if there is a mix of both.
-	 *
-	 * Return a map of resultSet index to ProcResult attribute struct. If they were positional, then assign them indexes starting at 1.
-	 * If they were indexed, then use the provided index. There may be gaps in the indexes. If more than one procresult used the same index, the last one wins (overwrite)
+	 * Return a map of resultSet index to ProcResult attribute struct. Explicit resultSet indexes are preserved, while missing
+	 * resultSet attributes are assigned the next available unused result-set index.
+	 * If more than one procresult uses the same explicit index, the last one wins (overwrite).
 	 *
 	 * @param procResults The array of proc result definitions
 	 *
 	 * @return Map of resultSet index to ProcResult attribute struct.
 	 */
 	private Map<Integer, IStruct> processProcResults( Array procResults ) {
-		boolean					hasPositional	= false;
-		boolean					hasIndexed		= false;
-		Map<Integer, IStruct>	resultMap		= new HashMap<>();
+		Map<Integer, IStruct>	resultMap				= new HashMap<>();
+		Set<Integer>			usedResultSetIndexes	= new HashSet<>();
+
+		// Reserve explicit indexes first so positional results never overwrite an explicitly indexed result.
 		for ( int i = 0; i < procResults.size(); i++ ) {
-			IStruct	attr		= ( IStruct ) procResults.get( i );
-			boolean	thisIndexed	= attr.containsKey( Key.resultSet );
-			if ( thisIndexed ) {
-				hasIndexed = true;
-				resultMap.put( IntegerCaster.cast( attr.get( Key.resultSet ) ), attr );
-			} else {
-				hasPositional = true;
-				resultMap.put( i + 1, attr );
+			IStruct attr = ( IStruct ) procResults.get( i );
+			if ( attr.containsKey( Key.resultSet ) ) {
+				int resultSetIndex = IntegerCaster.cast( attr.get( Key.resultSet ) );
+				resultMap.put( resultSetIndex, attr );
+				usedResultSetIndexes.add( resultSetIndex );
 			}
-			if ( hasPositional && hasIndexed ) {
-				// World's best error message. So descriptive!
-				throw new BoxRuntimeException( "Cannot mix positional and indexed ProcResult components in a StoredProc. "
-				    + " ProcParm [" + attr.getAsString( Key._name ) + "] is " + ( thisIndexed ? "indexed" : "positional" ) + ","
-				    + " but the " + ( resultMap.size() - 1 ) + " ProcResult component(s) above it are " + ( thisIndexed ? "positional" : "indexed" ) + "." );
+		}
+
+		int nextAvailableResultSetIndex = 1;
+		for ( int i = 0; i < procResults.size(); i++ ) {
+			IStruct attr = ( IStruct ) procResults.get( i );
+			if ( !attr.containsKey( Key.resultSet ) ) {
+				while ( usedResultSetIndexes.contains( nextAvailableResultSetIndex ) ) {
+					nextAvailableResultSetIndex++;
+				}
+				resultMap.put( nextAvailableResultSetIndex, attr );
+				usedResultSetIndexes.add( nextAvailableResultSetIndex );
+				nextAvailableResultSetIndex++;
 			}
 		}
 		return resultMap;

--- a/src/main/java/ortus/boxlang/runtime/components/jdbc/StoredProc.java
+++ b/src/main/java/ortus/boxlang/runtime/components/jdbc/StoredProc.java
@@ -414,6 +414,10 @@ public class StoredProc extends Component {
 				    procedure.getObject( i + 1 + paramOffset ),
 				    procedure
 				);
+				// Oracle uses refcursor type out params for proc results. In that case, null needs to stay undefined
+				if ( value == null && BLType == QueryColumnType.REFCURSOR ) {
+					continue;
+				}
 				if ( value == null && Compare.nullEqualsEmptyString ) {
 					value = "";
 				}

--- a/src/main/java/ortus/boxlang/runtime/components/system/Log.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Log.java
@@ -75,11 +75,6 @@ public class Log extends Component {
 			attributes.put( Key.applicationName, appContext.getApplication().getName() );
 		}
 		// Announce the log message
-
-		String text = ( String ) attributes.getOrDefault( Key.text, "" );
-		if ( text.contains( "Hello BX!" ) ) {
-			System.out.println( "log component received Hello BX! message.  Broadcasting interceptor with data: " + attributes.asString() );
-		}
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, attributes );
 		return DEFAULT_RETURN;
 	}

--- a/src/main/java/ortus/boxlang/runtime/components/system/Log.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Log.java
@@ -75,6 +75,11 @@ public class Log extends Component {
 			attributes.put( Key.applicationName, appContext.getApplication().getName() );
 		}
 		// Announce the log message
+
+		String text = ( String ) attributes.getOrDefault( Key.text, "" );
+		if ( text.contains( "Hello BX!" ) ) {
+			System.out.println( "log component received Hello BX! message.  Broadcasting interceptor with data: " + attributes.asString() );
+		}
 		interceptorService.announce( BoxEvent.LOG_MESSAGE, attributes );
 		return DEFAULT_RETURN;
 	}

--- a/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
@@ -33,6 +33,7 @@ import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.BoxFile;
 import ortus.boxlang.runtime.types.Closure;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.IStruct;
@@ -95,7 +96,7 @@ public class Loop extends Component {
 		    new Attribute( Key.step, "number", 1 ),
 
 		    // File loop attributes
-		    new Attribute( Key.file, "string", Set.of( Validator.requires( Key.index ) ) ),
+		    new Attribute( Key.file, "string", Set.of( Validator.requires( Key.item ) ) ),
 
 		    // List loop attributes
 		    new Attribute( Key.list, "string" ),
@@ -118,12 +119,10 @@ public class Loop extends Component {
 		    new Attribute( Key.label, "string", Set.of( Validator.NON_EMPTY ) ),
 
 		    // Times loop attributes
-		    new Attribute( Key.times, "integer", Set.of( Validator.min( 0 ) ) )
+		    new Attribute( Key.times, "integer", Set.of( Validator.min( 0 ) ) ),
 
-			/**
-			 * Future attributes to be implemented:
-			 * - characters: Number of characters to read per iteration for file loops
-			 */
+		    // Number of characters to read per iteration for file loops
+		    new Attribute( Key.characters, "integer", Set.of( Validator.min( 1 ) ) )
 		};
 	}
 
@@ -414,6 +413,10 @@ public class Loop extends Component {
 	 *                  or <code>index</code> to access the current iteration number.
 	 *                  <br>
 	 *                  <strong>Example:</strong> <code>&lt;bx:loop times="5" index="i"&gt;</code>
+	 * 
+	 * @attribute.characters Number of characters to read per iteration for file loops.
+	 *                       <br>
+	 *                       <strong>Example:</strong> <code>&lt;bx:loop file="example.txt" characters="100"&gt;</code>
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {
 		Array				array				= attributes.getAsArray( Key.array );
@@ -434,6 +437,7 @@ public class Loop extends Component {
 		String				label				= attributes.getAsString( Key.label );
 		Integer				times				= attributes.getAsInteger( Key.times );
 		Number				step				= attributes.getAsNumber( Key.step );
+		Integer				characters			= attributes.getAsInteger( Key.characters );
 
 		if ( times != null ) {
 			return _invokeTimes( context, times, item, index, body, executionState, label );
@@ -445,7 +449,7 @@ public class Loop extends Component {
 			return _invokeRange( context, from, to, step, index, body, executionState, label );
 		}
 		if ( file != null ) {
-			return _invokeFile( context, file, index, body, executionState, label );
+			return _invokeFile( context, file, index, body, executionState, label, item, characters );
 		}
 		if ( list != null ) {
 			if ( delimiters == null ) {
@@ -652,30 +656,45 @@ public class Loop extends Component {
 	 *
 	 * @throws RuntimeException if the file cannot be read or does not exist
 	 */
-	private BodyResult _invokeFile( IBoxContext context, String file, String index, ComponentBody body, IStruct executionState, String label ) {
-		String		fileContents	= StringCaster.cast( FileSystemUtil.read( file ) );
-		// loop over lines
-		String[]	lines			= fileContents.split( "\r?\n" );
-
-		// Loop over array, executing body every time
-		for ( int i = 0; i < lines.length; i++ ) {
-			String thisLine = lines[ i ];
-			// Set the index and item variables
-			ExpressionInterpreter.setVariable( context, index, thisLine );
-			// Run the code inside of the output loop
-			BodyResult bodyResult = processBody( context, body );
-			// IF there was a return statement inside our body, we early exit now
-			if ( bodyResult.isEarlyExit() ) {
-				if ( bodyResult.isContinue( label ) ) {
-					continue;
-				} else if ( bodyResult.isBreak( label ) ) {
-					break;
+	private BodyResult _invokeFile( IBoxContext context, String file, String index, ComponentBody body, IStruct executionState, String label, String item,
+	    Integer characters ) {
+		BoxFile boxFile = new BoxFile( FileSystemUtil.expandPath( context, file ).absolutePath().toString(), BoxFile.Mode.READ, null, false );
+		try {
+			int row = 1;
+			while ( !boxFile.isEOF() ) {
+				String content;
+				if ( characters != null ) {
+					content = StringCaster.cast( boxFile.read( characters ) );
+					if ( content.isEmpty() ) {
+						break;
+					}
 				} else {
-					return bodyResult;
+					content = boxFile.readLine();
+					if ( content == null ) {
+						break;
+					}
+				}
+
+				ExpressionInterpreter.setVariable( context, item, content );
+				if ( index != null ) {
+					ExpressionInterpreter.setVariable( context, index, row++ );
+				}
+
+				BodyResult bodyResult = processBody( context, body );
+				if ( bodyResult.isEarlyExit() ) {
+					if ( bodyResult.isContinue( label ) ) {
+						continue;
+					} else if ( bodyResult.isBreak( label ) ) {
+						break;
+					} else {
+						return bodyResult;
+					}
 				}
 			}
+			return DEFAULT_RETURN;
+		} finally {
+			boxFile.close();
 		}
-		return DEFAULT_RETURN;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
@@ -96,7 +96,7 @@ public class Loop extends Component {
 		    new Attribute( Key.step, "number", 1 ),
 
 		    // File loop attributes
-		    new Attribute( Key.file, "string", Set.of( Validator.requires( Key.item ) ) ),
+		    new Attribute( Key.file, "string", Set.of( Validator.requiresOneOf( Key.file, Key.item ) ) ),
 
 		    // List loop attributes
 		    new Attribute( Key.list, "string" ),
@@ -310,6 +310,7 @@ public class Loop extends Component {
 	 *                 <li><strong>Array loops:</strong> Contains the current array element</li>
 	 *                 <li><strong>List loops:</strong> Contains the current list item</li>
 	 *                 <li><strong>Collection loops:</strong> Contains the current collection key</li>
+	 *                 <li><strong>File loops:</strong> Contains the current line of content</li>
 	 *                 <li><strong>Times loops:</strong> If no index specified, contains the current iteration number</li>
 	 *                 </ul>
 	 *                 <br>
@@ -319,7 +320,7 @@ public class Loop extends Component {
 	 *                  <ul>
 	 *                  <li><strong>Array loops:</strong> Contains the 1-based array index</li>
 	 *                  <li><strong>Numeric range loops:</strong> Contains the current numeric value (required)</li>
-	 *                  <li><strong>File loops:</strong> Contains the current line content (required)</li>
+	 *                  <li><strong>File loops:</strong> Contains the current line of content unless "item" is specified. In that case, it contains the line number</li>
 	 *                  <li><strong>Times loops:</strong> Contains the current iteration number</li>
 	 *                  </ul>
 	 *                  <br>
@@ -343,10 +344,11 @@ public class Loop extends Component {
 	 *                 <strong>Example:</strong> <code>&lt;bx:loop from="0" to="20" step="2" index="even"&gt;</code>
 	 *
 	 * @attribute.file Absolute path to a text file to read line by line. Each iteration provides
-	 *                 one line of the file content in the <code>index</code> variable. The file
-	 *                 is automatically closed when the loop completes. Requires <code>index</code> attribute.
+	 *                 the line number in the <code>index</code> variable and the actual contents of the line in the <code>item</code> variable.
+	 *                 If <code>item</code> is not specified, the line content will be available in the <code>index</code> variable.
+	 *                 The file is automatically closed when the loop completes. Requires <code>index</code> attribute.
 	 *                 <br>
-	 *                 <strong>Example:</strong> <code>&lt;bx:loop file="/path/to/data.txt" index="line"&gt;</code>
+	 *                 <strong>Example:</strong> <code>&lt;bx:loop file="/path/to/data.txt" index="LineNo" item="lineContent" &gt;</code>
 	 *
 	 * @attribute.list A delimited string to process item by item. Each item becomes available
 	 *                 through the <code>item</code> or <code>index</code> variable. Use with
@@ -675,9 +677,18 @@ public class Loop extends Component {
 					}
 				}
 
-				ExpressionInterpreter.setVariable( context, item, content );
+				// item, if present, is a always the content.
+				if ( item != null ) {
+					ExpressionInterpreter.setVariable( context, item, content );
+				}
+				// index, if present, is either the index or the content depending on whether item is specified.
 				if ( index != null ) {
-					ExpressionInterpreter.setVariable( context, index, row++ );
+					if ( item != null ) {
+						ExpressionInterpreter.setVariable( context, index, row++ );
+					} else {
+						ExpressionInterpreter.setVariable( context, index, content );
+						row++;
+					}
 				}
 
 				BodyResult bodyResult = processBody( context, body );

--- a/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Loop.java
@@ -492,8 +492,7 @@ public class Loop extends Component {
 			}
 		}
 
-		throw new BoxRuntimeException( "CFLoop attributes not implemented yet! " + attributes.asString() );
-		// return DEFAULT_RETURN;
+		throw new BoxRuntimeException( "Invalid Loop attributes." + attributes.asString() );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/config/Configuration.java
+++ b/src/main/java/ortus/boxlang/runtime/config/Configuration.java
@@ -342,19 +342,19 @@ public class Configuration implements IConfigSegment {
 	public IStruct																executors							= new Struct();
 
 	/**
-	 * Valid BoxLang class extensions
+	 * Valid BoxLang class extensions, lowercased
 	 */
 	public Set<String>															validClassExtensions				= new HashSet<>();
 
 	/**
-	 * Valid core BoxLang template extensions.
+	 * Valid core BoxLang template extensions, lowercased.
 	 */
 	public Set<String>															coreTemplateExtensions				= new HashSet<>(
 	    Arrays.asList( "bxs", "bxm", "bxml", "cfm", "cfml", "cfs" )
 	);
 
 	/**
-	 * Valid BoxLang template extensions.
+	 * Valid BoxLang template extensions, lowercased.
 	 * Private because I want to force people to use getValidTemplateExtensions(), which includes the core ones
 	 */
 	private Set<String>															validTemplateExtensions				= new HashSet<>();
@@ -1102,7 +1102,7 @@ public class Configuration implements IConfigSegment {
 	}
 
 	/**
-	 * This returns all valid BoxLang extensions for classes and templates.
+	 * This returns all valid BoxLang extensions for classes and templates, lowercased.
 	 *
 	 * @return A set of all valid class extensions
 	 */
@@ -1114,8 +1114,8 @@ public class Configuration implements IConfigSegment {
 	}
 
 	/**
-	 * This returns all valid BoxLang class extensions as a Set.
-	 * THis includes core extensions and custom extensions
+	 * This returns all valid BoxLang class extensions as a Set, lowercased.
+	 * TThis includes core extensions and custom extensions, lowercased.
 	 *
 	 * @return A list of all valid class extensions
 	 */
@@ -1127,7 +1127,7 @@ public class Configuration implements IConfigSegment {
 	}
 
 	/**
-	 * This returns all valid BoxLang class extensions as a List.
+	 * This returns all valid BoxLang class extensions as a List, lowercased.
 	 *
 	 * @return A list of all valid class extensions
 	 */
@@ -1136,7 +1136,7 @@ public class Configuration implements IConfigSegment {
 	}
 
 	/**
-	 * This returns all valid BoxLang class extensions.
+	 * This returns all valid BoxLang class extensions, lowercased.
 	 *
 	 * @return A list of all valid class extensions
 	 */

--- a/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/BaseBoxContext.java
@@ -35,6 +35,7 @@ import ortus.boxlang.runtime.components.ComponentDescriptor;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.FunctionCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.interop.DynamicInteropService;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.loader.ImportDefinition;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
@@ -76,6 +77,11 @@ public class BaseBoxContext implements IBoxContext {
 	 * A flag to control whether null is considered undefined or not. Used by the compat module
 	 */
 	public static boolean									nullIsUndefined			= false;
+
+	/**
+	 * Allow class files to be included.
+	 */
+	public static boolean									allowIncludeClassFiles	= false;
 
 	/**
 	 * Used to prevent having to catch exceptions when looking up the scope lookup chain for a variable which may not exist
@@ -800,9 +806,21 @@ public class BaseBoxContext implements IBoxContext {
 			BoxTemplate template = RunnableLoader.getInstance().loadTemplateRelative( this, templatePath, externalOnly );
 
 			template.invoke( this );
+		} else if ( allowIncludeClassFiles && BoxRuntime.getInstance().getConfiguration().getValidClassExtensionsList().contains( ext ) ) {
+			// Load the class
+			Class<IBoxRunnable> clazz = RunnableLoader.getInstance().loadClass( FileSystemUtil.expandPath( this, templatePath ), this );
+			try {
+				// Instatiate it (JUST the Java constructor, nothing else)
+				IClassRunnable oClazz = ( IClassRunnable ) DynamicInteropService.getNoArgConstructorHandle( clazz ).invoke();
+				// Run the pseudoconstructor in our current context
+				oClazz.pseudoConstructor( this );
+			} catch ( Throwable e ) {
+				throw new BoxRuntimeException( "Error creating instance of class [" + templatePath + "]", e );
+			}
+
 		} else if ( BoxRuntime.getInstance().getConfiguration().getValidExtensions().contains( ext ) ) {
 			// Don't EVER allow a known script extension to be served
-			throw new BoxRuntimeException( "Template path [" + templatePath + "] has a known script extension [" + ext + "] and cannot be included" );
+			throw new BoxRuntimeException( "Template path [" + templatePath + "] with extension [" + ext + "] and cannot be included" );
 		} else {
 			// If this extension is not one we compile, then just read the contents and flush it to the buffer
 			writeToBuffer(

--- a/src/main/java/ortus/boxlang/runtime/context/ClassBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/ClassBoxContext.java
@@ -136,9 +136,9 @@ public class ClassBoxContext extends BaseBoxContext {
 	public ScopeSearchResult scopeFindNearby( Key key, IScope defaultScope, boolean shallow, boolean forAssign ) {
 
 		// Direct Scope
-		ScopeSearchResult thisSerach = scopeFindThis( key );
-		if ( thisSerach != null ) {
-			return thisSerach;
+		ScopeSearchResult thisSearch = scopeFindThis( key );
+		if ( thisSearch != null ) {
+			return thisSearch;
 		}
 
 		// Static Scope

--- a/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/FunctionBoxContext.java
@@ -321,9 +321,9 @@ public class FunctionBoxContext extends BaseBoxContext {
 			return new ScopeSearchResult( argumentsScope, argumentsScope, key, true );
 		}
 
-		ScopeSearchResult thisSerach = scopeFindThis( key );
-		if ( thisSerach != null ) {
-			return thisSerach;
+		ScopeSearchResult thisSearch = scopeFindThis( key );
+		if ( thisSearch != null ) {
+			return thisSearch;
 		}
 
 		ScopeSearchResult superSearch = scopeFindSuper( key );
@@ -396,12 +396,19 @@ public class FunctionBoxContext extends BaseBoxContext {
 		} else {
 
 			if ( shallow ) {
-				return parent.scopeFindNearby( key, defaultScope, true );
+				// This is this shallow, we no longer want to see any scopes inside of calling functions, but we do need to climb to the next closest
+				// non-function context such as a request context so we can see the variable scope there
+				IBoxContext thisParent = getParent();
+				while ( thisParent instanceof FunctionBoxContext ) {
+					thisParent = thisParent.getParent();
+				}
+				// now we've climbed all the way to what is most likely the request. This allows us to still see things like the top variable scope or other UDFs on the page
+				return thisParent.scopeFindNearby( key, defaultScope, true, forAssign );
 			}
 
 			// A UDF is "transparent" and can see everything in the parent scope as a
 			// "local" observer
-			return parent.scopeFindNearby( key, defaultScope, forAssign );
+			return parent.scopeFindNearby( key, defaultScope, false, forAssign );
 		}
 
 	}

--- a/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/runtime/context/RequestBoxContext.java
@@ -78,7 +78,6 @@ public abstract class RequestBoxContext extends BaseBoxContext implements IJDBCC
 	/**
 	 * The request class loader
 	 */
-	private ClassLoader											requestClassLoader		= null;
 
 	/**
 	 * Flag to enforce explicit output
@@ -281,15 +280,11 @@ public abstract class RequestBoxContext extends BaseBoxContext implements IJDBCC
 	 * @return The class loader
 	 */
 	public ClassLoader getRequestClassLoader() {
-		if ( this.requestClassLoader != null ) {
-			return this.requestClassLoader;
-		}
 		// Not using getApplicationListener() here so we don't cache a default class loader value
 		if ( this.applicationListener == null ) {
 			return getRuntime().getRuntimeLoader();
 		} else {
-			this.requestClassLoader = this.applicationListener.getRequestClassLoader( this );
-			return this.requestClassLoader;
+			return this.applicationListener.getRequestClassLoader( this );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
@@ -20,6 +20,7 @@ package ortus.boxlang.runtime.dynamic.casters;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -39,7 +40,12 @@ public class NumberCaster implements IBoxCaster {
 	 * If true, booleans will be treated as numbers, with true=1 and false=0
 	 * This is here for compat to toggle
 	 */
-	public static boolean booleansAreNumbers = false;
+	public static boolean			booleansAreNumbers		= false;
+
+	/**
+	 * Pre-compiled regex to quickly test if a string contains at least one numeric digit.
+	 */
+	private static final Pattern	CONTAINS_DIGIT_PATTERN	= Pattern.compile( ".*\\d.*" );
 
 	/**
 	 * Tests to see if the value can be cast to a Number.
@@ -166,7 +172,7 @@ public class NumberCaster implements IBoxCaster {
 		}
 
 		// Last ditch effort-- if it's a string and castDates is true, see if it's a string that can be cast to a date that can be cast to a number
-		if ( castDates && object instanceof String s ) {
+		if ( castDates && object instanceof String s && CONTAINS_DIGIT_PATTERN.matcher( s ).matches() ) {
 			var dateAttempt = DateTimeCaster.attempt( s );
 			if ( dateAttempt.wasSuccessful() ) {
 				return DateTimeHelper.toFractionalDays( dateAttempt.get().toEpochMillis() );

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
@@ -20,7 +20,6 @@ package ortus.boxlang.runtime.dynamic.casters;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -40,24 +39,35 @@ public class NumberCaster implements IBoxCaster {
 	 * If true, booleans will be treated as numbers, with true=1 and false=0
 	 * This is here for compat to toggle
 	 */
-	public static boolean			booleansAreNumbers		= false;
-
-	/**
-	 * Pre-compiled regex to quickly test if a string contains at least one numeric digit.
-	 */
-	private static final Pattern	CONTAINS_DIGIT_PATTERN	= Pattern.compile( ".*\\d.*" );
+	public static boolean booleansAreNumbers = false;
 
 	/**
 	 * Tests to see if the value can be cast to a Number.
 	 * Returns a {@code CastAttempt<T>} which will contain the result if casting was
 	 * was successfull, or can be interogated to proceed otherwise.
 	 *
-	 * @param object The value to cast to a Number
+	 * @param object    The value to cast to a Number
+	 * @param castDates If true, attempt to cast date-like objects to numbers
 	 *
 	 * @return The Number value
 	 */
 	public static CastAttempt<Number> attempt( Object object, boolean castDates ) {
 		return CastAttempt.ofNullable( cast( object, false, castDates ) );
+	}
+
+	/**
+	 * Tests to see if the value can be cast to a Number.
+	 * Returns a {@code CastAttempt<T>} which will contain the result if casting was
+	 * was successfull, or can be interogated to proceed otherwise.
+	 *
+	 * @param object          The value to cast to a Number
+	 * @param castDates       If true, attempt to cast date-like objects to numbers
+	 * @param castStringDates If true, attempt to cast string representations of dates to numbers
+	 *
+	 * @return The Number value
+	 */
+	public static CastAttempt<Number> attempt( Object object, boolean castDates, boolean castStringDates ) {
+		return CastAttempt.ofNullable( cast( object, false, castDates, castStringDates ) );
 	}
 
 	/**
@@ -96,6 +106,17 @@ public class NumberCaster implements IBoxCaster {
 	}
 
 	/**
+	 * Used to cast anything to a Number, throwing exception if we fail
+	 *
+	 * @param object The value to cast to a Number
+	 *
+	 * @return The Number value
+	 */
+	public static Number cast( boolean castDates, boolean castStringDates, Object object ) {
+		return cast( object, true, castDates, castStringDates );
+	}
+
+	/**
 	 * Used to cast anything to a Number
 	 *
 	 * @param object The value to cast to a Number
@@ -110,12 +131,27 @@ public class NumberCaster implements IBoxCaster {
 	/**
 	 * Used to cast anything to a Number
 	 *
-	 * @param object The value to cast to a Number
-	 * @param fail   If true, throw exception if we fail
+	 * @param object    The value to cast to a Number
+	 * @param fail      If true, throw exception if we fail
+	 * @param castDates If true, attempt to cast date-like objects to numbers
 	 *
 	 * @return The Number value
 	 */
 	public static Number cast( Object object, Boolean fail, boolean castDates ) {
+		return cast( object, fail, castDates, false );
+	}
+
+	/**
+	 * Used to cast anything to a Number
+	 *
+	 * @param object          The value to cast to a Number
+	 * @param fail            If true, throw exception if we fail
+	 * @param castDates       If true, attempt to cast date-like objects to numbers
+	 * @param castStringDates If true, attempt to cast string representations of dates to numbers
+	 *
+	 * @return The Number value
+	 */
+	public static Number cast( Object object, Boolean fail, boolean castDates, boolean castStringDates ) {
 		if ( object == null ) {
 			return 0;
 		}
@@ -172,7 +208,7 @@ public class NumberCaster implements IBoxCaster {
 		}
 
 		// Last ditch effort-- if it's a string and castDates is true, see if it's a string that can be cast to a date that can be cast to a number
-		if ( castDates && object instanceof String s && CONTAINS_DIGIT_PATTERN.matcher( s ).matches() ) {
+		if ( castDates && object instanceof String s ) {
 			var dateAttempt = DateTimeCaster.attempt( s );
 			if ( dateAttempt.wasSuccessful() ) {
 				return DateTimeHelper.toFractionalDays( dateAttempt.get().toEpochMillis() );

--- a/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
+++ b/src/main/java/ortus/boxlang/runtime/dynamic/casters/NumberCaster.java
@@ -208,7 +208,7 @@ public class NumberCaster implements IBoxCaster {
 		}
 
 		// Last ditch effort-- if it's a string and castDates is true, see if it's a string that can be cast to a date that can be cast to a number
-		if ( castDates && object instanceof String s ) {
+		if ( castStringDates && object instanceof String s ) {
 			var dateAttempt = DateTimeCaster.attempt( s );
 			if ( dateAttempt.wasSuccessful() ) {
 				return DateTimeHelper.toFractionalDays( dateAttempt.get().toEpochMillis() );

--- a/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
+++ b/src/main/java/ortus/boxlang/runtime/events/BoxEvent.java
@@ -222,6 +222,7 @@ public enum BoxEvent {
 	ON_HTTP_REQUEST( "onHTTPRequest" ),
 	ON_HTTP_RAW_RESPONSE( "onHTTPRawResponse" ),
 	ON_HTTP_RESPONSE( "onHTTPResponse" ),
+	ON_HTTP_ERROR( "onHTTPError" ),
 
 	/**
 	 * Custom Event for Route Modification when in a Web Context

--- a/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
+++ b/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
@@ -81,10 +81,6 @@ public class Logging extends BaseInterceptor {
 		String	file			= ( String ) data.getOrDefault( Key.file, "" );
 		Object	applicationName	= data.get( Key.applicationName );
 
-		if ( text.contains( "Hello BX!" ) ) {
-			System.out.println( "Logging interceptor received Hello BX! message to logger: " + data.asString() );
-		}
-
 		// If the text is empty, then don't log anything
 		if ( text.isEmpty() ) {
 			return;

--- a/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
+++ b/src/main/java/ortus/boxlang/runtime/interceptors/Logging.java
@@ -81,6 +81,10 @@ public class Logging extends BaseInterceptor {
 		String	file			= ( String ) data.getOrDefault( Key.file, "" );
 		Object	applicationName	= data.get( Key.applicationName );
 
+		if ( text.contains( "Hello BX!" ) ) {
+			System.out.println( "Logging interceptor received Hello BX! message to logger: " + data.asString() );
+		}
+
 		// If the text is empty, then don't log anything
 		if ( text.isEmpty() ) {
 			return;

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
@@ -473,7 +473,7 @@ public class DynamicInteropService {
 	 *
 	 * @return A cached MethodHandle for the no-arg constructor
 	 */
-	private static MethodHandle getNoArgConstructorHandle( Class<?> targetClass ) {
+	public static MethodHandle getNoArgConstructorHandle( Class<?> targetClass ) {
 		return noArgConstructorCache.computeIfAbsent( targetClass, clazz -> {
 			try {
 				return METHOD_LOOKUP.unreflectConstructor( clazz.getConstructor() );

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
@@ -544,7 +544,7 @@ public class DynamicObject implements IReferenceable, Serializable {
 	}
 
 	/**
-	 * Unwrap an object if it's inside a ClassInvoker instance
+	 * Unwrap an object if it's inside a DynamicObject instance
 	 *
 	 * @param param The object to unwrap
 	 *

--- a/src/main/java/ortus/boxlang/runtime/interop/proxies/GenericProxy.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/proxies/GenericProxy.java
@@ -48,7 +48,9 @@ public class GenericProxy extends BaseProxy implements InvocationHandler {
 				args = new Object[] {};
 			}
 
-			if ( method != null && method.isDefault() ) {
+			// If this is a default method and NOT overriden in our class, then invoke the default implementation
+			if ( method != null && method.isDefault()
+			    && ! ( isClassRunnableTarget() && getDynamicTarget().getThisScope().containsKey( Key.of( method.getName() ) ) ) ) {
 				return InvocationHandler.invokeDefault( proxy, method, args );
 			}
 

--- a/src/main/java/ortus/boxlang/runtime/jdbc/qoq/QoQPreparedStatement.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/qoq/QoQPreparedStatement.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -72,62 +73,52 @@ public class QoQPreparedStatement extends QoQStatement implements java.sql.Prepa
 
 	@Override
 	public void setNull( int parameterIndex, int sqlType ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setNull'" );
+		setObject( parameterIndex, null, sqlType );
 	}
 
 	@Override
 	public void setBoolean( int parameterIndex, boolean x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setBoolean'" );
+		setObject( parameterIndex, x, Types.BOOLEAN );
 	}
 
 	@Override
 	public void setByte( int parameterIndex, byte x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setByte'" );
+		setObject( parameterIndex, x, Types.TINYINT );
 	}
 
 	@Override
 	public void setShort( int parameterIndex, short x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setShort'" );
+		setObject( parameterIndex, x, Types.SMALLINT );
 	}
 
 	@Override
 	public void setInt( int parameterIndex, int x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setInt'" );
+		setObject( parameterIndex, x, Types.INTEGER );
 	}
 
 	@Override
 	public void setLong( int parameterIndex, long x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setLong'" );
+		setObject( parameterIndex, x, Types.BIGINT );
 	}
 
 	@Override
 	public void setFloat( int parameterIndex, float x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setFloat'" );
+		setObject( parameterIndex, x, Types.REAL );
 	}
 
 	@Override
 	public void setDouble( int parameterIndex, double x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setDouble'" );
+		setObject( parameterIndex, x, Types.DOUBLE );
 	}
 
 	@Override
 	public void setBigDecimal( int parameterIndex, BigDecimal x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setBigDecimal'" );
+		setObject( parameterIndex, x, Types.DECIMAL );
 	}
 
 	@Override
 	public void setString( int parameterIndex, String x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setString'" );
+		setObject( parameterIndex, x, Types.VARCHAR );
 	}
 
 	@Override
@@ -138,20 +129,17 @@ public class QoQPreparedStatement extends QoQStatement implements java.sql.Prepa
 
 	@Override
 	public void setDate( int parameterIndex, Date x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setDate'" );
+		setObject( parameterIndex, x, Types.DATE );
 	}
 
 	@Override
 	public void setTime( int parameterIndex, Time x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setTime'" );
+		setObject( parameterIndex, x, Types.TIME );
 	}
 
 	@Override
 	public void setTimestamp( int parameterIndex, Timestamp x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setTimestamp'" );
+		setObject( parameterIndex, x, Types.TIMESTAMP );
 	}
 
 	@Override
@@ -205,8 +193,7 @@ public class QoQPreparedStatement extends QoQStatement implements java.sql.Prepa
 
 	@Override
 	public void setObject( int parameterIndex, Object x ) throws SQLException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException( "Unimplemented method 'setObject'" );
+		setObject( parameterIndex, x, Types.JAVA_OBJECT );
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/loader/ClassLocator.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/ClassLocator.java
@@ -18,7 +18,6 @@
 package ortus.boxlang.runtime.loader;
 
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,7 +40,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ClassNotFoundBoxLangException;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.util.BLCollector;
-import ortus.boxlang.runtime.util.EncryptionUtil;
+import ortus.boxlang.runtime.util.ClassLoaderUtil;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
 
@@ -662,7 +661,7 @@ public class ClassLocator extends ClassLoader {
 		        .map( item -> FileSystemUtil.expandPath( context, ( String ) item ).absolutePath().toString() )
 		        .collect( BLCollector.toArray() )
 		);
-		String				loaderCacheKey	= EncryptionUtil.hash( Arrays.toString( loadPathsUrls ) );
+		String				loaderCacheKey	= ClassLoaderUtil.hashSorted( loadPathsUrls );
 		DynamicClassLoader	classLoader		= this.classLoaders.computeIfAbsent(
 		    loaderCacheKey,
 		    key -> {

--- a/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
@@ -45,6 +45,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.exceptions.BoxIOException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.util.ClassLoaderUtil;
 
 public class DynamicClassLoader extends URLClassLoader implements IModuleClassLoader {
 
@@ -103,6 +104,8 @@ public class DynamicClassLoader extends URLClassLoader implements IModuleClassLo
 	    "org.slf4j"
 	);
 
+	private String											URLHash;
+
 	/**
 	 * Construct the class loader
 	 *
@@ -137,6 +140,7 @@ public class DynamicClassLoader extends URLClassLoader implements IModuleClassLo
 		Objects.requireNonNull( parent, "Parent class loader cannot be null" );
 		this.parent		= parent;
 		this.nameAsKey	= name;
+		this.URLHash	= ClassLoaderUtil.hashSorted( urls );
 	}
 
 	/**
@@ -598,6 +602,14 @@ public class DynamicClassLoader extends URLClassLoader implements IModuleClassLo
 	 */
 	public ConcurrentHashMap<String, MethodRecord> getMethodHandleCache() {
 		return methodHandleCache;
+	}
+
+	/**
+	 * Get URLHash which reprents the unique set of jar/class files loaded in this ClassLoader
+	 * This is to be able to tell if another DynamicClassLoader has the same set of jar/class files loaded, even if they were a different version of the jar.
+	 */
+	public String getURLHash() {
+		return URLHash;
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/DynamicClassLoader.java
@@ -490,6 +490,8 @@ public class DynamicClassLoader extends URLClassLoader implements IModuleClassLo
 	/**
 	 * Static method that takes in a path and returns an array
 	 * of URLs of all the JARs in the path
+	 * 
+	 * Accepts a folder or a specific jar or class file path
 	 *
 	 * @param targetPath The path to search for JARs
 	 *
@@ -498,9 +500,14 @@ public class DynamicClassLoader extends URLClassLoader implements IModuleClassLo
 	public static URL[] getJarURLs( Path targetPath ) throws IOException {
 		// Ensure the path is a directory and that it exists
 		if ( Files.exists( targetPath ) && !Files.isDirectory( targetPath ) ) {
-			throw new BoxRuntimeException(
-			    String.format( "The requested path [%s] to discover jar's and classes must be a valid directory", targetPath )
-			);
+			// If path is already a jar or class file, then return it directly
+			if ( targetPath.toString().endsWith( ".jar" ) || targetPath.toString().endsWith( ".class" ) ) {
+				return new URL[] { targetPath.toUri().toURL() };
+			} else {
+				throw new BoxRuntimeException(
+				    String.format( "The requested path [%s] to discover jar's and classes must be a valid directory", targetPath )
+				);
+			}
 		}
 
 		// Stream all files recursively, filtering for .jar and .class files

--- a/src/main/java/ortus/boxlang/runtime/loader/resolvers/BoxResolver.java
+++ b/src/main/java/ortus/boxlang/runtime/loader/resolvers/BoxResolver.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.Strings;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.RequestBoxContext;
 import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.loader.ClassLocation;
 import ortus.boxlang.runtime.loader.ClassLocator;
@@ -490,7 +491,6 @@ public class BoxResolver extends BaseResolver {
 		    } )
 		    // Map it to a ClassLocation object
 		    .map( possibleMatch -> {
-			    // System.out.println( "found: " + possibleMatch.absolutePath().toAbsolutePath().toString() );
 			    // System.out.println( "found package: " + possibleMatch.getPackage().toString() );
 			    return new ClassLocation(
 			        possibleMatch.getBoxFQN().getClassName(),
@@ -526,15 +526,15 @@ public class BoxResolver extends BaseResolver {
 	    String name,
 	    List<ImportDefinition> imports,
 	    boolean loadClass ) {
-
 		// Check if the class exists in the directory of the currently-executing template
-		ResolvedFilePath resolvedFilePath = context.findClosestTemplate();
+		ResolvedFilePath	resolvedFilePath	= context.findClosestTemplate();
+		Path				parentPath			= null;
 		if ( resolvedFilePath != null ) {
 			Path template = resolvedFilePath.absolutePath();
 
 			if ( template != null && !template.toString().equalsIgnoreCase( "unknown" ) ) {
 				// Get the parent directory of the template, verify it exists, else we are done
-				Path parentPath = template.getParent();
+				parentPath = template.getParent();
 				if ( parentPath != null ) {
 					// See if path exists in this parent directory with a valid extension
 					Path targetPath = findExistingPathWithValidExtension( parentPath, slashName );
@@ -560,6 +560,40 @@ public class BoxResolver extends BaseResolver {
 			}
 		}
 
+		// We're not done yet! Now we check if the class exists relative to the base template path
+		RequestBoxContext requestContext = context.getRequestContext();
+		// If we have a request context...
+		if ( requestContext != null ) {
+			ResolvedFilePath baseTemplatePath = requestContext.getApplicationListener().getBaseTemplatePath();
+			// and it has a base template path...
+			if ( baseTemplatePath != null && baseTemplatePath.absolutePath() != null ) {
+				Path thisParentPath = baseTemplatePath.absolutePath().getParent();
+				// which is different from where we've already looked....
+				if ( parentPath == null || !thisParentPath.equals( parentPath ) ) {
+					// Then searchy serachy...
+					Path targetPath = findExistingPathWithValidExtension( thisParentPath, slashName );
+					if ( targetPath != null ) {
+						ResolvedFilePath newResolvedFilePath = FileSystemUtil.contractPath(
+						    context,
+						    targetPath.toString(),
+						    baseTemplatePath.mappingName()
+						);
+						return Optional.of( new ClassLocation(
+						    newResolvedFilePath.getBoxFQN().getClassName(),
+						    targetPath.toAbsolutePath().toString(),
+						    newResolvedFilePath.getBoxFQN().getPackageString(),
+						    ClassLocator.TYPE_BX,
+						    null,
+						    "",
+						    true,
+						    context.getApplicationName(),
+						    newResolvedFilePath
+						) );
+					}
+				}
+
+			}
+		}
 		return Optional.empty();
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -506,6 +506,10 @@ public class LoggingService {
 		}
 
 		// Compute and get the logger
+		if ( message != null && message.contains( "Hello BX!" ) ) {
+			System.out.println( "Logging Hello BX! message to logger: " + logger );
+
+		}
 		BoxLangLogger oLogger = getLogger( logger );
 
 		// Log according to the level

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -506,10 +506,6 @@ public class LoggingService {
 		}
 
 		// Compute and get the logger
-		if ( message != null && message.contains( "Hello BX!" ) ) {
-			System.out.println( "Logging Hello BX! message to logger: " + logger );
-
-		}
 		BoxLangLogger oLogger = getLogger( logger );
 
 		// Log according to the level
@@ -795,7 +791,6 @@ public class LoggingService {
 	 * @return The logger requested
 	 */
 	private BoxLangLogger createLogger( Key loggerKey, String loggerFilePath ) {
-		System.out.println( "Creating logger for key: " + loggerKey.getName() + " with file path: " + loggerFilePath );
 		LoggerContext	targetContext	= getLoggerContext();
 		Logger			oLogger			= targetContext.getLogger( loggerKey.getName().toUpperCase() );
 
@@ -808,7 +803,6 @@ public class LoggingService {
 		// Seed the properties
 		oLogger.setLevel( configLevel );
 		oLogger.setAdditive( loggerConfig.additive );
-		System.out.println( "Logger [" + loggerKey.getName() + "] level set to: " + configLevel );
 		// Only build/attach appenders when the logger is not effectively disabled
 		if ( configLevel != Level.OFF ) {
 			Appender<ILoggingEvent> loggerAppender = getOrBuildAppender( loggerFilePath, targetContext, loggerConfig );

--- a/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
+++ b/src/main/java/ortus/boxlang/runtime/logging/LoggingService.java
@@ -791,6 +791,7 @@ public class LoggingService {
 	 * @return The logger requested
 	 */
 	private BoxLangLogger createLogger( Key loggerKey, String loggerFilePath ) {
+		System.out.println( "Creating logger for key: " + loggerKey.getName() + " with file path: " + loggerFilePath );
 		LoggerContext	targetContext	= getLoggerContext();
 		Logger			oLogger			= targetContext.getLogger( loggerKey.getName().toUpperCase() );
 
@@ -803,7 +804,7 @@ public class LoggingService {
 		// Seed the properties
 		oLogger.setLevel( configLevel );
 		oLogger.setAdditive( loggerConfig.additive );
-
+		System.out.println( "Logger [" + loggerKey.getName() + "] level set to: " + configLevel );
 		// Only build/attach appenders when the logger is not effectively disabled
 		if ( configLevel != Level.OFF ) {
 			Appender<ILoggingEvent> loggerAppender = getOrBuildAppender( loggerFilePath, targetContext, loggerConfig );

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -39,7 +39,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -84,16 +86,17 @@ public class BoxHttpClient {
 	 * ------------------------------------------------------------------------------
 	 */
 
-	public static final String											HTTP_1						= "HTTP/1.1";
-	public static final String											HTTP_2						= "HTTP/2";
-	public static final String											DEFAULT_USER_AGENT			= "BoxLang-HttpClient/1.0";
-	public static final String											DEFAULT_CHARSET				= StandardCharsets.UTF_8.name();
-	public static final String											DEFAULT_METHOD				= "GET";
-	public static final int												DEFAULT_CONNECTION_TIMEOUT	= 15;
-	public static final int												DEFAULT_READ_TIMEOUT		= 15;
-	public static final int												DEFAULT_REQUEST_TIMEOUT		= 0;
-	public static final boolean											DEFAULT_THROW_ON_ERROR		= false;
-	private static final Set<String>									JAVA_RESTRICTED_HEADERS		= Set.of(
+	public static final String											HTTP_1							= "HTTP/1.1";
+	public static final int												MAX_OBSERVED_HOSTS				= 100;
+	public static final String											HTTP_2							= "HTTP/2";
+	public static final String											DEFAULT_USER_AGENT				= "BoxLang-HttpClient/1.0";
+	public static final String											DEFAULT_CHARSET					= StandardCharsets.UTF_8.name();
+	public static final String											DEFAULT_METHOD					= "GET";
+	public static final int												DEFAULT_CONNECTION_TIMEOUT		= 15;
+	public static final int												DEFAULT_READ_TIMEOUT			= 15;
+	public static final int												DEFAULT_REQUEST_TIMEOUT			= 0;
+	public static final boolean											DEFAULT_THROW_ON_ERROR			= false;
+	private static final Set<String>									JAVA_RESTRICTED_HEADERS			= Set.of(
 	    "connection",
 	    "content-length",
 	    "expect",
@@ -102,9 +105,9 @@ public class BoxHttpClient {
 	);
 
 	// HTTP Status Codes
-	public static final int												STATUS_REQUEST_TIMEOUT		= 408;
-	public static final int												STATUS_INTERNAL_ERROR		= 500;
-	public static final int												STATUS_BAD_GATEWAY			= 502;
+	public static final int												STATUS_REQUEST_TIMEOUT			= 408;
+	public static final int												STATUS_INTERNAL_ERROR			= 500;
+	public static final int												STATUS_BAD_GATEWAY				= 502;
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -112,8 +115,8 @@ public class BoxHttpClient {
 	 * ------------------------------------------------------------------------------
 	 */
 
-	private static final BoxRuntime										runtime						= BoxRuntime.getInstance();
-	private static final InterceptorService								interceptorService			= runtime.getInterceptorService();
+	private static final BoxRuntime										runtime							= BoxRuntime.getInstance();
+	private static final InterceptorService								interceptorService				= runtime.getInterceptorService();
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -136,37 +139,45 @@ public class BoxHttpClient {
 	 */
 	private final BoxLangLogger											logger;
 
+	private final String												clientKey;
+	private final String												httpVersion;
+	private final boolean												followRedirects;
+	private final Integer												connectTimeoutSeconds;
+	private final Set<String>											observedHosts					= ConcurrentHashMap.newKeySet();
+	private final Object												observationLock					= new Object();
+	private volatile boolean											observedHostsTruncated;
+
 	/**
 	 * Tracks the last date + time the client was used.
 	 * Uses AtomicReference for thread-safe updates without synchronization.
 	 */
-	private final java.util.concurrent.atomic.AtomicReference<Instant>	lastUsedTimestamp			= new java.util.concurrent.atomic.AtomicReference<>(
+	private final java.util.concurrent.atomic.AtomicReference<Instant>	lastUsedTimestamp				= new java.util.concurrent.atomic.AtomicReference<>(
 	    null );
 
 	/**
 	 * Statistics tracking for this client.
 	 * Uses AtomicLong for thread-safe updates without synchronization.
 	 */
-	private final java.util.concurrent.atomic.AtomicLong				totalRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				successfulRequests			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				totalRequests					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				successfulRequests				= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				failedRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				timeoutFailures				= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				failedRequests					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				timeoutFailures					= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				connectionFailures			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				connectionFailures				= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				tlsFailures					= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				httpProtocolFailures		= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				tlsFailures						= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				httpProtocolFailures			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesReceived				= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesSent					= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				totalExecutionTimeMs		= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				bytesReceived					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				bytesSent						= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				totalExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				minExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				minExecutionTimeMs				= new java.util.concurrent.atomic.AtomicLong(
 	    Long.MAX_VALUE );
-	private final java.util.concurrent.atomic.AtomicLong				maxExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				maxExecutionTimeMs				= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final Instant												createdAt					= Instant.now();
+	private final Instant												createdAt						= Instant.now();
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -181,9 +192,33 @@ public class BoxHttpClient {
 	 * @param httpService The HttpService managing this client.
 	 */
 	public BoxHttpClient( HttpClient httpClient, HttpService httpService ) {
-		this.httpClient		= httpClient;
-		this.httpService	= httpService;
-		this.logger			= this.httpService.getLogger();
+		this( httpClient, httpService, null, null, false, null );
+	}
+
+	/**
+	 * Constructor to create a BoxHttpClient with configuration metadata.
+	 *
+	 * @param httpClient            The underlying HttpClient to be used for HTTP operations.
+	 * @param httpService           The HttpService managing this client.
+	 * @param clientKey             The cache key for this client.
+	 * @param httpVersion           The configured HTTP version.
+	 * @param followRedirects       Whether redirects are followed.
+	 * @param connectTimeoutSeconds The configured connection timeout in seconds, or null when unbounded.
+	 */
+	public BoxHttpClient(
+	    HttpClient httpClient,
+	    HttpService httpService,
+	    String clientKey,
+	    String httpVersion,
+	    boolean followRedirects,
+	    Integer connectTimeoutSeconds ) {
+		this.httpClient				= httpClient;
+		this.httpService			= httpService;
+		this.logger					= this.httpService.getLogger();
+		this.clientKey				= clientKey;
+		this.httpVersion			= httpVersion;
+		this.followRedirects		= followRedirects;
+		this.connectTimeoutSeconds	= connectTimeoutSeconds;
 	}
 
 	/**
@@ -267,6 +302,25 @@ public class BoxHttpClient {
 	}
 
 	/**
+	 * Record the requested host and request timeout before network execution starts.
+	 *
+	 * @param request The prepared request to observe.
+	 * @param requestTimeout The configured request timeout in seconds, or null if unbounded.
+	 */
+	private void observeRequest( HttpRequest request, Integer requestTimeout ) {
+		String host = request.uri().getHost();
+		synchronized ( this.observationLock ) {
+			if ( host != null && !this.observedHosts.contains( host ) ) {
+				if ( this.observedHosts.size() < MAX_OBSERVED_HOSTS ) {
+					this.observedHosts.add( host );
+				} else {
+					this.observedHostsTruncated = true;
+				}
+			}
+		}
+	}
+
+	/**
 	 * Get statistics for this HTTP client.
 	 *
 	 * @return A Struct containing usage statistics
@@ -274,6 +328,13 @@ public class BoxHttpClient {
 	public IStruct getStatistics() {
 		long minTime = this.minExecutionTimeMs.get();
 		return Struct.ofNonConcurrent(
+		    "clientKey", this.clientKey,
+		    "httpVersion", this.httpVersion,
+		    "followRedirects", this.followRedirects,
+		    "connectTimeoutSeconds", this.connectTimeoutSeconds != null ? this.connectTimeoutSeconds : 0,
+		    "connectTimeoutConfigured", this.connectTimeoutSeconds != null,
+		    "observedHosts", new ArrayList<>( this.observedHosts ),
+		    "observedHostsTruncated", this.observedHostsTruncated,
 		    Key.averageExecutionTimeMs, this.getAverageExecutionTimeMs(),
 		    Key.bytesReceived, this.bytesReceived.get(),
 		    Key.bytesSent, this.bytesSent.get(),
@@ -490,7 +551,6 @@ public class BoxHttpClient {
 		// Basic Authentication
 		private String											username;
 		private String											password;
-		// Only basic for now, maybe in the future NTLM, but that's legacy, kept here
 		// just in case, but never used
 		private String											authType			= "BASIC";
 
@@ -700,9 +760,9 @@ public class BoxHttpClient {
 		/**
 		 * Multipart mode
 		 *
-		 * @param multipart Whether the request is multipart
+		 * @param multipart Whether the request is multipart.
 		 *
-		 * @return
+		 * @return This builder for chaining.
 		 */
 		public BoxHttpRequest multipart( boolean multipart ) {
 			this.multipart = multipart;
@@ -1721,6 +1781,7 @@ public class BoxHttpClient {
 				 * This is used by streaming and buffered modes
 				 */
 				prepareRequest();
+				BoxHttpClient.this.observeRequest( this.targetHttpRequest, this.timeout );
 
 				/**
 				 * ------------------------------------------------------------------------------

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -38,6 +38,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -92,6 +93,13 @@ public class BoxHttpClient {
 	public static final int												DEFAULT_READ_TIMEOUT		= 15;
 	public static final int												DEFAULT_REQUEST_TIMEOUT		= 0;
 	public static final boolean											DEFAULT_THROW_ON_ERROR		= false;
+	private static final Set<String>									JAVA_RESTRICTED_HEADERS		= Set.of(
+	    "connection",
+	    "content-length",
+	    "expect",
+	    "host",
+	    "upgrade"
+	);
 
 	// HTTP Status Codes
 	public static final int												STATUS_REQUEST_TIMEOUT		= 408;
@@ -1427,6 +1435,10 @@ public class BoxHttpClient {
 					// We need to use `setHeader` to overwrite any previously set headers
 					case "header" -> {
 						String headerName = StringCaster.cast( param.get( Key._NAME ) );
+						if ( headerName != null && JAVA_RESTRICTED_HEADERS.contains( headerName.toLowerCase() ) ) {
+							logger.trace( "Ignoring restricted header [{}] for Java HttpClient compatibility", headerName );
+							continue;
+						}
 						// We need to downgrade our HTTP version if a TE header is present and is not
 						// `trailers`
 						// because HTTP/2 does not support the TE header with any other values

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -1750,7 +1750,7 @@ public class BoxHttpClient {
 		 *     .method( "POST" )
 		 *     .header( "Content-Type", "application/json" )
 		 *     .onComplete( result -> {
-		 * 							} )
+		 * 	} )
 		 *     .send();
 		 *
 		 * IStruct result = request.getHttpResult();

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -1959,6 +1959,30 @@ public class BoxHttpClient {
 						BoxHttpClient.this.bytesReceived.addAndGet( ( ( byte[] ) fileContent ).length );
 					}
 				}
+
+				/**
+				 * ------------------------------------------------------------------------------
+				 * ON HTTP RESPONSE EVENT (ERROR PATH)
+				 * ------------------------------------------------------------------------------
+				 * When a network-level failure occurs (timeout, DNS, connection error, etc.)
+				 * the success-path announcements inside invokeBuffered/invokeStreaming are
+				 * never reached. We announce ON_HTTP_RESPONSE here so that interceptors
+				 * subscribed to that event can observe ALL requests, not only successful ones.
+				 *
+				 * Interceptors must null-check the {@code response} key — it will be
+				 * {@code null} on error paths where no raw HttpResponse was received.
+				 * The {@code result} struct is fully populated by {@link #ensureDefaultResponseKeys()}
+				 * before this point, so its shape is stable regardless of failure type.
+				 */
+				if ( this.error ) {
+					interceptorService.announce(
+					    BoxEvent.ON_HTTP_RESPONSE,
+					    ( java.util.function.Supplier<IStruct> ) () -> Struct.ofNonConcurrent(
+					        Key.result, this.httpResult,
+					        Key.response, null,
+					        Key.httpClient, BoxHttpClient.this,
+					        Key.chunkCount, 0 ) );
+				}
 			}
 
 			return this;

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -1663,7 +1663,7 @@ public class BoxHttpClient {
 		 *     .method( "POST" )
 		 *     .header( "Content-Type", "application/json" )
 		 *     .onComplete( result -> {
-		 * 							} )
+		 * 	} )
 		 *     .send();
 		 *
 		 * IStruct result = request.getHttpResult();

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -1962,26 +1962,23 @@ public class BoxHttpClient {
 
 				/**
 				 * ------------------------------------------------------------------------------
-				 * ON HTTP RESPONSE EVENT (ERROR PATH)
+				 * ON HTTP ERROR EVENT
 				 * ------------------------------------------------------------------------------
 				 * When a network-level failure occurs (timeout, DNS, connection error, etc.)
 				 * the success-path announcements inside invokeBuffered/invokeStreaming are
-				 * never reached. We announce ON_HTTP_RESPONSE here so that interceptors
-				 * subscribed to that event can observe ALL requests, not only successful ones.
+				 * never reached. We announce ON_HTTP_ERROR here so that interceptors can
+				 * observe and react to failed requests (e.g. host attribution, circuit-breaking,
+				 * tracing).
 				 *
-				 * Interceptors must null-check the {@code response} key — it will be
-				 * {@code null} on error paths where no raw HttpResponse was received.
 				 * The {@code result} struct is fully populated by {@link #ensureDefaultResponseKeys()}
 				 * before this point, so its shape is stable regardless of failure type.
 				 */
 				if ( this.error ) {
 					interceptorService.announce(
-					    BoxEvent.ON_HTTP_RESPONSE,
+					    BoxEvent.ON_HTTP_ERROR,
 					    ( java.util.function.Supplier<IStruct> ) () -> Struct.ofNonConcurrent(
 					        Key.result, this.httpResult,
-					        Key.response, null,
-					        Key.httpClient, BoxHttpClient.this,
-					        Key.chunkCount, 0 ) );
+					        Key.httpClient, BoxHttpClient.this ) );
 				}
 			}
 

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -60,6 +60,7 @@ import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.Function;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.JSONUtil;
@@ -1662,7 +1663,7 @@ public class BoxHttpClient {
 		 *     .method( "POST" )
 		 *     .header( "Content-Type", "application/json" )
 		 *     .onComplete( result -> {
-		 * 	} )
+		 * 							} )
 		 *     .send();
 		 *
 		 * IStruct result = request.getHttpResult();
@@ -1905,6 +1906,9 @@ public class BoxHttpClient {
 					    Duration.between( this.startTime.toInstant(), Instant.now() ).toMillis() );
 				}
 
+				// Always provide a stable result shape, even for low-level failures.
+				ensureDefaultResponseKeys();
+
 				// Update statistics based on request outcome
 				if ( this.error ) {
 					BoxHttpClient.this.failedRequests.incrementAndGet();
@@ -1987,6 +1991,67 @@ public class BoxHttpClient {
 
 			// Return the result struct
 			return this.httpResult;
+		}
+
+		/**
+		 * Ensure all expected response keys exist, regardless of success or failure mode.
+		 */
+		private void ensureDefaultResponseKeys() {
+			if ( !this.httpResult.containsKey( Key.responseHeader ) ) {
+				this.httpResult.put( Key.responseHeader, new Struct( false ) );
+			}
+			if ( !this.httpResult.containsKey( Key.header ) ) {
+				this.httpResult.put( Key.header, "" );
+			}
+
+			if ( !this.httpResult.containsKey( Key.statusCode ) ) {
+				this.httpResult.put( Key.statusCode, STATUS_INTERNAL_ERROR );
+			}
+			if ( !this.httpResult.containsKey( Key.status_code ) ) {
+				this.httpResult.put( Key.status_code, this.httpResult.get( Key.statusCode ) );
+			}
+			if ( !this.httpResult.containsKey( Key.statusText ) ) {
+				this.httpResult.put( Key.statusText, "Internal Server Error" );
+			}
+			if ( !this.httpResult.containsKey( Key.status_text ) ) {
+				this.httpResult.put( Key.status_text, this.httpResult.get( Key.statusText ) );
+			}
+
+			if ( !this.httpResult.containsKey( Key.fileContent ) ) {
+				this.httpResult.put( Key.fileContent, "" );
+			}
+			if ( !this.httpResult.containsKey( Key.errorDetail ) ) {
+				this.httpResult.put( Key.errorDetail, "" );
+			}
+
+			if ( !this.httpResult.containsKey( Key.HTTP_Version ) ) {
+				this.httpResult.put( Key.HTTP_Version, "" );
+			}
+			if ( !this.httpResult.containsKey( Key.mimetype ) ) {
+				this.httpResult.put( Key.mimetype, "" );
+			}
+			if ( !this.httpResult.containsKey( Key.charset ) ) {
+				this.httpResult.put( Key.charset, this.charset != null ? this.charset : DEFAULT_CHARSET );
+			}
+			if ( !this.httpResult.containsKey( Key.text ) ) {
+				this.httpResult.put( Key.text, true );
+			}
+			if ( !this.httpResult.containsKey( Key.cookies ) ) {
+				this.httpResult.put( Key.cookies, new Query() );
+			}
+
+			if ( !this.httpResult.containsKey( Key.request ) ) {
+				this.httpResult.put( Key.request, new Struct( false ) );
+			}
+			if ( !this.httpResult.containsKey( Key.stream ) ) {
+				this.httpResult.put( Key.stream, false );
+			}
+			if ( !this.httpResult.containsKey( Key.sse ) ) {
+				this.httpResult.put( Key.sse, false );
+			}
+			if ( !this.httpResult.containsKey( Key.executionTime ) ) {
+				this.httpResult.put( Key.executionTime, 0L );
+			}
 		}
 
 		/**

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -18,7 +18,9 @@
 package ortus.boxlang.runtime.net;
 
 import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.URISyntaxException;
@@ -86,7 +88,6 @@ public class BoxHttpClient {
 	 */
 
 	public static final String											HTTP_1						= "HTTP/1.1";
-	public static final int												MAX_OBSERVED_HOSTS			= 100;
 	public static final String											HTTP_2						= "HTTP/2";
 	public static final String											DEFAULT_USER_AGENT			= "BoxLang-HttpClient/1.0";
 	public static final String											DEFAULT_CHARSET				= StandardCharsets.UTF_8.name();
@@ -143,8 +144,6 @@ public class BoxHttpClient {
 	private final boolean												followRedirects;
 	private final Integer												connectTimeoutSeconds;
 	private final Set<String>											observedHosts				= ConcurrentHashMap.newKeySet();
-	private final Object												observationLock				= new Object();
-	private volatile boolean											observedHostsTruncated;
 
 	/**
 	 * Tracks the last date + time the client was used.
@@ -157,19 +156,24 @@ public class BoxHttpClient {
 	 * Statistics tracking for this client.
 	 * Uses AtomicLong for thread-safe updates without synchronization.
 	 */
-	private final java.util.concurrent.atomic.AtomicLong				totalRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				totalRequests				= new java.util.concurrent.atomic.AtomicLong(
+	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				successfulRequests			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				failedRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				failedRequests				= new java.util.concurrent.atomic.AtomicLong(
+	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				timeoutFailures				= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				connectionFailures			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				tlsFailures					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				tlsFailures					= new java.util.concurrent.atomic.AtomicLong(
+	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				httpProtocolFailures		= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesReceived				= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesSent					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				bytesReceived				= new java.util.concurrent.atomic.AtomicLong(
+	    0 );
+	private final java.util.concurrent.atomic.AtomicLong				bytesSent					= new java.util.concurrent.atomic.AtomicLong(
+	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				totalExecutionTimeMs		= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
 	private final java.util.concurrent.atomic.AtomicLong				minExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
@@ -301,21 +305,14 @@ public class BoxHttpClient {
 	}
 
 	/**
-	 * Record the requested host and request timeout before network execution starts.
+	 * Record the requested host before network execution starts.
 	 *
-	 * @param request        The prepared request to observe.
-	 * @param requestTimeout The configured request timeout in seconds, or null if unbounded.
+	 * @param request The prepared request to observe.
 	 */
-	private void observeRequest( HttpRequest request, Integer requestTimeout ) {
+	private void observeRequest( HttpRequest request ) {
 		String host = request.uri().getHost();
-		synchronized ( this.observationLock ) {
-			if ( host != null && !this.observedHosts.contains( host ) ) {
-				if ( this.observedHosts.size() < MAX_OBSERVED_HOSTS ) {
-					this.observedHosts.add( host );
-				} else {
-					this.observedHostsTruncated = true;
-				}
-			}
+		if ( host != null ) {
+			this.observedHosts.add( host );
 		}
 	}
 
@@ -333,7 +330,6 @@ public class BoxHttpClient {
 		    "connectTimeoutSeconds", this.connectTimeoutSeconds != null ? this.connectTimeoutSeconds : 0,
 		    "connectTimeoutConfigured", this.connectTimeoutSeconds != null,
 		    "observedHosts", new ArrayList<>( this.observedHosts ),
-		    "observedHostsTruncated", this.observedHostsTruncated,
 		    Key.averageExecutionTimeMs, this.getAverageExecutionTimeMs(),
 		    Key.bytesReceived, this.bytesReceived.get(),
 		    Key.bytesSent, this.bytesSent.get(),
@@ -533,6 +529,8 @@ public class BoxHttpClient {
 		private String											method				= DEFAULT_METHOD;
 		// Request timeout in seconds
 		private Integer											timeout				= DEFAULT_REQUEST_TIMEOUT;
+		// Maximum characters retained in fileContent for streaming : 1 MB by default
+		private int												streamContentLimit	= 1_048_576;
 		// The User-Agent header
 		private String											userAgent			= DEFAULT_USER_AGENT;
 		// The Charset to use
@@ -578,6 +576,8 @@ public class BoxHttpClient {
 		private boolean											error				= false;
 		private String											errorMessage		= null;
 		private Throwable										requestException	= null;
+		private long											receivedBytes		= 0;
+		private boolean											streamTruncated		= false;
 
 		/**
 		 * ------------------------------------------------------------------------------
@@ -879,6 +879,22 @@ public class BoxHttpClient {
 		 */
 		public BoxHttpRequest timeout( Integer timeout ) {
 			this.timeout = timeout;
+			return this;
+		}
+
+		/**
+		 * Set the maximum number of characters retained in fileContent for a streaming response.
+		 * Chunk callbacks continue receiving the complete response after this limit is reached.
+		 *
+		 * @param maxLength Maximum retained characters; must be greater than zero
+		 *
+		 * @return This builder for chaining
+		 */
+		public BoxHttpRequest maxStreamingContentLength( int maxLength ) {
+			if ( maxLength <= 0 ) {
+				throw new IllegalArgumentException( "Maximum streaming content length must be greater than zero" );
+			}
+			this.streamContentLimit = maxLength;
 			return this;
 		}
 
@@ -1577,7 +1593,7 @@ public class BoxHttpClient {
 		private void setupBasicAuth( HttpRequest.Builder requestBuilder ) {
 			String	auth		= ( this.username != null ? this.username : "" ) + ":"
 			    + ( this.password != null ? this.password : "" );
-			String	encodedAuth	= Base64.getEncoder().encodeToString( auth.getBytes() );
+			String	encodedAuth	= Base64.getEncoder().encodeToString( auth.getBytes( StandardCharsets.UTF_8 ) );
 			requestBuilder.header( "Authorization", "Basic " + encodedAuth );
 		}
 
@@ -1734,7 +1750,7 @@ public class BoxHttpClient {
 		 *     .method( "POST" )
 		 *     .header( "Content-Type", "application/json" )
 		 *     .onComplete( result -> {
-		 * 	} )
+		 * 							} )
 		 *     .send();
 		 *
 		 * IStruct result = request.getHttpResult();
@@ -1780,7 +1796,7 @@ public class BoxHttpClient {
 				 * This is used by streaming and buffered modes
 				 */
 				prepareRequest();
-				BoxHttpClient.this.observeRequest( this.targetHttpRequest, this.timeout );
+				BoxHttpClient.this.observeRequest( this.targetHttpRequest );
 
 				/**
 				 * ------------------------------------------------------------------------------
@@ -2010,14 +2026,9 @@ public class BoxHttpClient {
 					} while ( !BoxHttpClient.this.maxExecutionTimeMs.compareAndSet( currentMax, executionTime ) );
 				}
 
-				// Track bytes received (from fileContent if available)
-				if ( this.httpResult.containsKey( Key.fileContent ) ) {
-					Object fileContent = this.httpResult.get( Key.fileContent );
-					if ( fileContent instanceof String ) {
-						BoxHttpClient.this.bytesReceived.addAndGet( ( ( String ) fileContent ).getBytes().length );
-					} else if ( fileContent instanceof byte[] ) {
-						BoxHttpClient.this.bytesReceived.addAndGet( ( ( byte[] ) fileContent ).length );
-					}
+				// Track bytes consumed directly from the HTTP response body.
+				if ( this.receivedBytes > 0 ) {
+					BoxHttpClient.this.bytesReceived.addAndGet( this.receivedBytes );
 				}
 
 				/**
@@ -2321,8 +2332,9 @@ public class BoxHttpClient {
 			    response.statusCode() );
 
 			// Determine binary response handling
-			byte[]	responseBytes	= response.body();
-			Object	responseBody	= null;
+			byte[] responseBytes = response.body();
+			this.receivedBytes = responseBytes == null ? 0 : responseBytes.length;
+			Object responseBody = null;
 
 			// Process body if not null
 			if ( responseBytes != null && responseBytes.length > 0 ) {
@@ -2441,65 +2453,70 @@ public class BoxHttpClient {
 			 * control)
 			 * Because it could be SSE or regular streaming, we need to handle both cases
 			 */
-			HttpResponse<java.io.InputStream>	response			= httpClient
+			HttpResponse<InputStream>	response		= httpClient
 			    .sendAsync(
 			        this.targetHttpRequest,
 			        HttpResponse.BodyHandlers.ofInputStream() )
 			    .get();
+			CountingInputStream			responseBody	= new CountingInputStream( response.body() );
+			try ( responseBody ) {
 
-			/**
-			 * ------------------------------------------------------------------------------
-			 * PROCESS RESPONSE HEADERS AND METADATA
-			 * ------------------------------------------------------------------------------
-			 */
+				/**
+				 * ------------------------------------------------------------------------------
+				 * PROCESS RESPONSE HEADERS AND METADATA
+				 * ------------------------------------------------------------------------------
+				 */
 
-			// Process response headers and metadata
-			HttpHeaders							httpHeaders			= Optional
-			    .ofNullable( response.headers() )
-			    .orElse( HttpHeaders.of( Map.of(), ( a, b ) -> true ) );
-			IStruct								headers				= HttpResponseHelper.transformToResponseHeaderStruct( httpHeaders.map() );
+				// Process response headers and metadata
+				HttpHeaders	httpHeaders			= Optional
+				    .ofNullable( response.headers() )
+				    .orElse( HttpHeaders.of( Map.of(), ( a, b ) -> true ) );
+				IStruct		headers				= HttpResponseHelper.transformToResponseHeaderStruct( httpHeaders.map() );
 
-			// Prepare HTTP response metadata
-			String								httpVersionString	= HttpResponseHelper.getHttpVersionString( response.version() );
+				// Prepare HTTP response metadata
+				String		httpVersionString	= HttpResponseHelper.getHttpVersionString( response.version() );
 
-			// Populate standard response metadata
-			HttpResponseHelper.populateResponseMetadata( this.httpResult, headers, httpVersionString,
-			    response.statusCode() );
+				// Populate standard response metadata
+				HttpResponseHelper.populateResponseMetadata( this.httpResult, headers, httpVersionString,
+				    response.statusCode() );
 
-			// Process Content-Type header and extract charset for streaming
-			String	contentType		= HttpResponseHelper.extractFirstHeaderByName( headers, Key.contentType );
-			String	charset			= HttpResponseHelper.processContentType( this.httpResult, headers, contentType, this.charset );
-			String	contentEncoding	= HttpResponseHelper.extractFirstHeaderByName( headers, Key.contentEncoding );
+				// Process Content-Type header and extract charset for streaming
+				String	contentType		= HttpResponseHelper.extractFirstHeaderByName( headers, Key.contentType );
+				String	charset			= HttpResponseHelper.processContentType( this.httpResult, headers, contentType, this.charset );
+				String	contentEncoding	= HttpResponseHelper.extractFirstHeaderByName( headers, Key.contentEncoding );
 
-			// Determine if SSE mode (auto-detect or forced)
-			boolean	isSSE			= this.forceSSE || ( contentType != null && contentType.contains( "text/event-stream" ) );
+				// Determine if SSE mode (auto-detect or forced)
+				boolean	isSSE			= this.forceSSE || ( contentType != null && contentType.contains( "text/event-stream" ) );
 
-			// Execution Markers
-			this.httpResult.put( Key.stream, true );
-			this.httpResult.put( Key.sse, isSSE );
+				// Execution Markers
+				this.httpResult.put( Key.stream, true );
+				this.httpResult.put( Key.sse, isSSE );
 
-			/**
-			 * ------------------------------------------------------------------------------
-			 * ON HTTP RAW RESPONSE EVENT
-			 * ------------------------------------------------------------------------------
-			 */
-			interceptorService.announce(
-			    BoxEvent.ON_HTTP_RAW_RESPONSE,
-			    ( java.util.function.Supplier<IStruct> ) () -> Struct.ofNonConcurrent(
-			        Key.result, this.httpResult,
-			        Key.response, response,
-			        Key.httpClient, BoxHttpClient.this,
-			        Key.httpRequest, this.targetHttpRequest ) );
+				/**
+				 * ------------------------------------------------------------------------------
+				 * ON HTTP RAW RESPONSE EVENT
+				 * ------------------------------------------------------------------------------
+				 */
+				interceptorService.announce(
+				    BoxEvent.ON_HTTP_RAW_RESPONSE,
+				    ( java.util.function.Supplier<IStruct> ) () -> Struct.ofNonConcurrent(
+				        Key.result, this.httpResult,
+				        Key.response, response,
+				        Key.httpClient, BoxHttpClient.this,
+				        Key.httpRequest, this.targetHttpRequest ) );
 
-			/**
-			 * ------------------------------------------------------------------------------
-			 * PROCESS STREAMING RESPONSE BY MODE
-			 * ------------------------------------------------------------------------------
-			 */
-			if ( isSSE ) {
-				processSSEStream( response, headers, charset, contentEncoding );
-			} else {
-				processRegularStream( response, headers, charset, contentEncoding );
+				/**
+				 * ------------------------------------------------------------------------------
+				 * PROCESS STREAMING RESPONSE BY MODE
+				 * ------------------------------------------------------------------------------
+				 */
+				if ( isSSE ) {
+					processSSEStream( response, responseBody, headers, charset, contentEncoding );
+				} else {
+					processRegularStream( response, responseBody, headers, charset, contentEncoding );
+				}
+			} finally {
+				this.receivedBytes = responseBody.getCount();
 			}
 		}
 
@@ -2507,6 +2524,7 @@ public class BoxHttpClient {
 		 * Process an SSE (Server-Sent Events) stream
 		 *
 		 * @param response        The HTTP response with InputStream body
+		 * @param responseBody    The protected response body stream
 		 * @param headers         The response headers struct
 		 * @param charset         The charset to use for reading
 		 * @param contentEncoding The content encoding (ignored for SSE, always text)
@@ -2514,7 +2532,8 @@ public class BoxHttpClient {
 		 * @throws IOException If an I/O error occurs
 		 */
 		private void processSSEStream(
-		    HttpResponse<java.io.InputStream> response,
+		    HttpResponse<InputStream> response,
+		    CountingInputStream responseBody,
 		    IStruct headers,
 		    String charset,
 		    String contentEncoding ) throws IOException {
@@ -2532,8 +2551,7 @@ public class BoxHttpClient {
 			// Read SSE stream (always UTF-8 text, no decoding)
 			// Try with Resources to ensure streams are closed properly
 			try (
-			    java.io.InputStream rawInputStream = response.body();
-			    java.io.InputStreamReader reader = new java.io.InputStreamReader( rawInputStream,
+			    java.io.InputStreamReader reader = new java.io.InputStreamReader( responseBody,
 			        Charset.forName( charset ) );
 			    java.io.BufferedReader bufferedReader = new java.io.BufferedReader( reader ) ) {
 
@@ -2559,14 +2577,18 @@ public class BoxHttpClient {
 									this.lastEventId = sseEvent.id();
 								}
 
-								// Accumulate data for final result
-								accumulatedData.append( sseEvent.data() ).append( System.lineSeparator() );
+								// Retain a bounded prefix while callbacks continue receiving all events.
+								this.streamTruncated |= appendTruncated(
+								    accumulatedData,
+								    sseEvent.data() + System.lineSeparator(),
+								    this.streamContentLimit
+								);
 
 								// Log the SSE event details
-								streamLogger.trace( "SSE Event #{}: type={}, id={}",
-								    eventCount.get(),
-								    sseEvent.event() != null ? sseEvent.event() : "message",
-								    sseEvent.id() != null ? sseEvent.id() : "none" );
+								// streamLogger.trace( "SSE Event #{}: type={}, id={}",
+								// eventCount.get(),
+								// sseEvent.event() != null ? sseEvent.event() : "message",
+								// sseEvent.id() != null ? sseEvent.id() : "none" );
 
 								// Invoke onChunk callback with SSE event
 								context.invokeFunction(
@@ -2611,6 +2633,7 @@ public class BoxHttpClient {
 			// Finalize httpResult
 			String finalContent = accumulatedData.toString();
 			this.httpResult.put( Key.fileContent, finalContent );
+			this.httpResult.put( "streamContentTruncated", this.streamTruncated );
 			this.httpResult.put( Key.errorDetail, "" );
 			this.httpResult.put( Key.executionTime, Duration.between( startTime.toInstant(), Instant.now() ).toMillis() );
 			this.httpResult.put( Key.totalEvents, eventCount.get() );
@@ -2651,6 +2674,7 @@ public class BoxHttpClient {
 		 * Process a regular (non-SSE) streaming response
 		 *
 		 * @param response        The HTTP response with InputStream body
+		 * @param responseBody    The protected response body stream
 		 * @param headers         The response headers struct
 		 * @param charset         The charset to use for reading
 		 * @param contentEncoding The content encoding (gzip, deflate, etc.)
@@ -2658,7 +2682,8 @@ public class BoxHttpClient {
 		 * @throws IOException If an I/O error occurs
 		 */
 		private void processRegularStream(
-		    HttpResponse<java.io.InputStream> response,
+		    HttpResponse<InputStream> response,
+		    CountingInputStream responseBody,
 		    IStruct headers,
 		    String charset,
 		    String contentEncoding ) throws IOException {
@@ -2671,12 +2696,12 @@ public class BoxHttpClient {
 			StringBuilder	accumulatedContent	= new StringBuilder();
 			AtomicLong		chunkCount			= new AtomicLong( 0 );
 			AtomicBoolean	streamingError		= new AtomicBoolean( false );
+			AtomicLong		totalContentLength	= new AtomicLong( 0 );
 
 			// Read the response body line by line with proper charset and decoding
 			// Try with Resources to ensure streams are closed properly
 			try (
-			    java.io.InputStream rawInputStream = response.body();
-			    java.io.InputStream decodedInputStream = HttpResponseHelper.decodeInputStream( rawInputStream,
+			    java.io.InputStream decodedInputStream = HttpResponseHelper.decodeInputStream( responseBody,
 			        contentEncoding );
 			    java.io.InputStreamReader reader = new java.io.InputStreamReader( decodedInputStream,
 			        Charset.forName( charset ) );
@@ -2692,11 +2717,16 @@ public class BoxHttpClient {
 					}
 
 					try {
-						long currentChunk = chunkCount.incrementAndGet();
-						streamLogger.trace( "Processing chunk #{}", currentChunk );
+						long	currentChunk	= chunkCount.incrementAndGet();
+						long	totalLength		= totalContentLength.addAndGet( line.length() + System.lineSeparator().length() );
+						// streamLogger.trace( "Processing chunk #{}", currentChunk );
 
-						// Accumulate content for final result
-						accumulatedContent.append( line ).append( System.lineSeparator() );
+						// Retain a bounded prefix while callbacks continue receiving all chunks.
+						this.streamTruncated |= appendTruncated(
+						    accumulatedContent,
+						    line + System.lineSeparator(),
+						    this.streamContentLimit
+						);
 
 						// Invoke onChunk callback with regular chunk data
 						context.invokeFunction(
@@ -2704,7 +2734,7 @@ public class BoxHttpClient {
 						    new Object[] {
 						        currentChunk, // chunkNumber
 						        line, // content
-						        accumulatedContent.length(), // totalBytes
+						        totalLength, // totalBytes (cumulative decoded characters for compatibility)
 						        this.httpResult, // httpResult
 						        BoxHttpClient.this, // httpClient
 						        response // rawResponse
@@ -2733,6 +2763,7 @@ public class BoxHttpClient {
 
 			String finalContent = accumulatedContent.toString();
 			this.httpResult.put( Key.fileContent, finalContent );
+			this.httpResult.put( "streamContentTruncated", this.streamTruncated );
 			this.httpResult.put( Key.errorDetail, "" );
 			this.httpResult.put( Key.executionTime, Duration.between( startTime.toInstant(), Instant.now() ).toMillis() );
 
@@ -2771,6 +2802,56 @@ public class BoxHttpClient {
 				        BoxHttpClient.this, // httpClient
 				        chunkCount.get()
 				    } );
+			}
+		}
+
+		/**
+		 * Append up to the configured limit and report whether content was truncated.
+		 */
+		private boolean appendTruncated( StringBuilder target, String content, int maxLength ) {
+			int remaining = maxLength - target.length();
+			if ( remaining <= 0 ) {
+				return !content.isEmpty();
+			}
+			if ( content.length() <= remaining ) {
+				target.append( content );
+				return false;
+			}
+			target.append( content, 0, remaining );
+			return true;
+		}
+
+		/**
+		 * Counts raw response bytes while preserving normal stream close behavior.
+		 */
+		private final class CountingInputStream extends FilterInputStream {
+
+			private long count;
+
+			private CountingInputStream( InputStream inputStream ) {
+				super( inputStream );
+			}
+
+			@Override
+			public int read() throws IOException {
+				int value = super.read();
+				if ( value >= 0 ) {
+					this.count++;
+				}
+				return value;
+			}
+
+			@Override
+			public int read( byte[] buffer, int offset, int length ) throws IOException {
+				int bytesRead = super.read( buffer, offset, length );
+				if ( bytesRead > 0 ) {
+					this.count += bytesRead;
+				}
+				return bytesRead;
+			}
+
+			private long getCount() {
+				return this.count;
 			}
 		}
 	} // End of BoxHttpRequest class

--- a/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
+++ b/src/main/java/ortus/boxlang/runtime/net/BoxHttpClient.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -86,17 +85,17 @@ public class BoxHttpClient {
 	 * ------------------------------------------------------------------------------
 	 */
 
-	public static final String											HTTP_1							= "HTTP/1.1";
-	public static final int												MAX_OBSERVED_HOSTS				= 100;
-	public static final String											HTTP_2							= "HTTP/2";
-	public static final String											DEFAULT_USER_AGENT				= "BoxLang-HttpClient/1.0";
-	public static final String											DEFAULT_CHARSET					= StandardCharsets.UTF_8.name();
-	public static final String											DEFAULT_METHOD					= "GET";
-	public static final int												DEFAULT_CONNECTION_TIMEOUT		= 15;
-	public static final int												DEFAULT_READ_TIMEOUT			= 15;
-	public static final int												DEFAULT_REQUEST_TIMEOUT			= 0;
-	public static final boolean											DEFAULT_THROW_ON_ERROR			= false;
-	private static final Set<String>									JAVA_RESTRICTED_HEADERS			= Set.of(
+	public static final String											HTTP_1						= "HTTP/1.1";
+	public static final int												MAX_OBSERVED_HOSTS			= 100;
+	public static final String											HTTP_2						= "HTTP/2";
+	public static final String											DEFAULT_USER_AGENT			= "BoxLang-HttpClient/1.0";
+	public static final String											DEFAULT_CHARSET				= StandardCharsets.UTF_8.name();
+	public static final String											DEFAULT_METHOD				= "GET";
+	public static final int												DEFAULT_CONNECTION_TIMEOUT	= 15;
+	public static final int												DEFAULT_READ_TIMEOUT		= 15;
+	public static final int												DEFAULT_REQUEST_TIMEOUT		= 0;
+	public static final boolean											DEFAULT_THROW_ON_ERROR		= false;
+	private static final Set<String>									JAVA_RESTRICTED_HEADERS		= Set.of(
 	    "connection",
 	    "content-length",
 	    "expect",
@@ -105,9 +104,9 @@ public class BoxHttpClient {
 	);
 
 	// HTTP Status Codes
-	public static final int												STATUS_REQUEST_TIMEOUT			= 408;
-	public static final int												STATUS_INTERNAL_ERROR			= 500;
-	public static final int												STATUS_BAD_GATEWAY				= 502;
+	public static final int												STATUS_REQUEST_TIMEOUT		= 408;
+	public static final int												STATUS_INTERNAL_ERROR		= 500;
+	public static final int												STATUS_BAD_GATEWAY			= 502;
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -115,8 +114,8 @@ public class BoxHttpClient {
 	 * ------------------------------------------------------------------------------
 	 */
 
-	private static final BoxRuntime										runtime							= BoxRuntime.getInstance();
-	private static final InterceptorService								interceptorService				= runtime.getInterceptorService();
+	private static final BoxRuntime										runtime						= BoxRuntime.getInstance();
+	private static final InterceptorService								interceptorService			= runtime.getInterceptorService();
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -143,41 +142,41 @@ public class BoxHttpClient {
 	private final String												httpVersion;
 	private final boolean												followRedirects;
 	private final Integer												connectTimeoutSeconds;
-	private final Set<String>											observedHosts					= ConcurrentHashMap.newKeySet();
-	private final Object												observationLock					= new Object();
+	private final Set<String>											observedHosts				= ConcurrentHashMap.newKeySet();
+	private final Object												observationLock				= new Object();
 	private volatile boolean											observedHostsTruncated;
 
 	/**
 	 * Tracks the last date + time the client was used.
 	 * Uses AtomicReference for thread-safe updates without synchronization.
 	 */
-	private final java.util.concurrent.atomic.AtomicReference<Instant>	lastUsedTimestamp				= new java.util.concurrent.atomic.AtomicReference<>(
+	private final java.util.concurrent.atomic.AtomicReference<Instant>	lastUsedTimestamp			= new java.util.concurrent.atomic.AtomicReference<>(
 	    null );
 
 	/**
 	 * Statistics tracking for this client.
 	 * Uses AtomicLong for thread-safe updates without synchronization.
 	 */
-	private final java.util.concurrent.atomic.AtomicLong				totalRequests					= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				successfulRequests				= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				totalRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				successfulRequests			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				failedRequests					= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				timeoutFailures					= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				failedRequests				= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				timeoutFailures				= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				connectionFailures				= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				connectionFailures			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				tlsFailures						= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				httpProtocolFailures			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				tlsFailures					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				httpProtocolFailures		= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesReceived					= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				bytesSent						= new java.util.concurrent.atomic.AtomicLong( 0 );
-	private final java.util.concurrent.atomic.AtomicLong				totalExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				bytesReceived				= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				bytesSent					= new java.util.concurrent.atomic.AtomicLong( 0 );
+	private final java.util.concurrent.atomic.AtomicLong				totalExecutionTimeMs		= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final java.util.concurrent.atomic.AtomicLong				minExecutionTimeMs				= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				minExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
 	    Long.MAX_VALUE );
-	private final java.util.concurrent.atomic.AtomicLong				maxExecutionTimeMs				= new java.util.concurrent.atomic.AtomicLong(
+	private final java.util.concurrent.atomic.AtomicLong				maxExecutionTimeMs			= new java.util.concurrent.atomic.AtomicLong(
 	    0 );
-	private final Instant												createdAt						= Instant.now();
+	private final Instant												createdAt					= Instant.now();
 
 	/**
 	 * ------------------------------------------------------------------------------
@@ -304,7 +303,7 @@ public class BoxHttpClient {
 	/**
 	 * Record the requested host and request timeout before network execution starts.
 	 *
-	 * @param request The prepared request to observe.
+	 * @param request        The prepared request to observe.
 	 * @param requestTimeout The configured request timeout in seconds, or null if unbounded.
 	 */
 	private void observeRequest( HttpRequest request, Integer requestTimeout ) {

--- a/src/main/java/ortus/boxlang/runtime/net/HttpResponseHelper.java
+++ b/src/main/java/ortus/boxlang/runtime/net/HttpResponseHelper.java
@@ -147,6 +147,12 @@ public class HttpResponseHelper {
 					    metadataValue = StringCaster.cast( DoubleCaster.cast( metadataValue ) / 60 / 60 / 24 );
 				    }
 
+				    // Ensure empty strings in keys matching all remaining columns
+				    for ( Key name : cookies.getColumns().keySet() ) {
+					    if ( !cookieStruct.containsKey( name ) ) {
+						    cookieStruct.put( name, "" );
+					    }
+				    }
 				    cookieStruct.put( metadataType, metadataValue );
 			    } );
 		}

--- a/src/main/java/ortus/boxlang/runtime/operators/Divide.java
+++ b/src/main/java/ortus/boxlang/runtime/operators/Divide.java
@@ -40,7 +40,7 @@ public class Divide implements IOperator {
 	 * @return The the result
 	 */
 	public static Number invoke( Object left, Object right ) {
-		return invoke( NumberCaster.cast( true, left ), NumberCaster.cast( true, right ) );
+		return invoke( NumberCaster.cast( true, true, left ), NumberCaster.cast( true, true, right ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/operators/Minus.java
+++ b/src/main/java/ortus/boxlang/runtime/operators/Minus.java
@@ -54,7 +54,7 @@ public class Minus implements IOperator {
 				return bsl.difference( rs.get() );
 			}
 		}
-		return invoke( NumberCaster.cast( true, left ), NumberCaster.cast( true, right ) );
+		return invoke( NumberCaster.cast( true, true, left ), NumberCaster.cast( true, true, right ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/operators/Multiply.java
+++ b/src/main/java/ortus/boxlang/runtime/operators/Multiply.java
@@ -55,7 +55,7 @@ public class Multiply implements IOperator {
 				return ls.get().intersection( bsr );
 			}
 		}
-		return invoke( NumberCaster.cast( true, left ), NumberCaster.cast( true, right ) );
+		return invoke( NumberCaster.cast( true, true, left ), NumberCaster.cast( true, true, right ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/operators/Plus.java
+++ b/src/main/java/ortus/boxlang/runtime/operators/Plus.java
@@ -59,7 +59,7 @@ public class Plus implements IOperator {
 				return ls.get().union( bsr );
 			}
 		}
-		return invoke( NumberCaster.cast( true, left ), NumberCaster.cast( true, right ) );
+		return invoke( NumberCaster.cast( true, true, left ), NumberCaster.cast( true, true, right ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/runnables/BoxClassSupport.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/BoxClassSupport.java
@@ -58,7 +58,6 @@ import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
 import ortus.boxlang.runtime.types.exceptions.KeyNotFoundException;
 import ortus.boxlang.runtime.types.meta.BoxMeta;
 import ortus.boxlang.runtime.types.meta.ClassMeta;
-import ortus.boxlang.runtime.types.util.StringUtil;
 import ortus.boxlang.runtime.types.util.TypeUtil;
 import ortus.boxlang.runtime.util.ArgumentUtil;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
@@ -246,9 +245,7 @@ public class BoxClassSupport {
 	public static Boolean canOutput( IStruct annotations, String className ) {
 		return castOutputAnnotation( annotations.getOrDefault(
 		    Key.output,
-		    // output defaults to true for Application.bx, but false for all others
-		    // Strip just the class name from the FQN foo.com.bar.Application
-		    ( className.length() == 11 && className.equalsIgnoreCase( "application" ) ) || StringUtil.endsWithIgnoreCase( className, ".application" )
+		    "raw"
 		) );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -191,6 +191,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		cftoken								= Key.of( "cftoken" );
 	public static final Key		cfvar								= Key.of( "cfvar" );
 	public static final Key		chars								= Key.of( "chars" );
+	public static final Key		characters							= Key.of( "characters" );
 	public static final Key		charset								= Key.of( "charset" );
 	public static final Key		charsetOrBufferSize					= Key.of( "charsetOrBufferSize" );
 	public static final Key		childname							= Key.of( "childname" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -93,6 +93,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		additive							= Key.of( "additive" );
 	public static final Key		addnewline							= Key.of( "addnewline" );
 	public static final Key		addToken							= Key.of( "addToken" );
+	public static final Key		after								= Key.of( "after" );
 	public static final Key		afterAnyTask						= Key.of( "afterAnyTask" );
 	public static final Key		algorithm							= Key.of( "algorithm" );
 	public static final Key		all									= Key.of( "all" );
@@ -137,6 +138,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		autoCreate							= Key.of( "autoCreate" );
 	public static final Key		base64_or_object					= Key.of( "base64_or_object" );
 	public static final Key		baseTag								= Key.of( "baseTag" );
+	public static final Key		before								= Key.of( "before" );
 	public static final Key		beforeAnyTask						= Key.of( "beforeAnyTask" );
 	public static final Key		bif									= Key.of( "bif" );
 	public static final Key		bigdecimal							= Key.of( "bigdecimal" );
@@ -701,6 +703,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		onSessionStart						= Key.of( "onSessionStart" );
 	public static final Key		onShutdown							= Key.of( "onShutdown" );
 	public static final Key		onStartup							= Key.of( "onStartup" );
+	public static final Key		onSuccess							= Key.of( "onSuccess" );
 	public static final Key		onUnload							= Key.of( "onUnload" );
 	public static final Key		operation							= Key.of( "operation" );
 	public static final Key		options								= Key.of( "options" );

--- a/src/main/java/ortus/boxlang/runtime/services/HttpService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/HttpService.java
@@ -449,7 +449,14 @@ public class HttpService extends BaseService {
 			}
 
 			// Create our BoxHttpClient wrapper and cache it
-			BoxHttpClient newClient = new BoxHttpClient( builder.build(), this );
+			BoxHttpClient newClient = new BoxHttpClient(
+			    builder.build(),
+			    this,
+			    clientKey,
+			    httpVersion,
+			    followRedirects,
+			    connectTimeout
+			);
 			this.logger.trace( "HTTP client created and cached with key: {}", clientKey );
 			return putClient( Key.of( clientKey ), newClient );
 		}

--- a/src/main/java/ortus/boxlang/runtime/services/HttpService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/HttpService.java
@@ -25,9 +25,6 @@ import java.net.http.HttpClient;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -35,7 +32,9 @@ import javax.net.ssl.SSLContext;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.executors.BoxExecutor;
+import ortus.boxlang.runtime.cache.providers.ICacheProvider;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.Attempt;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.net.BoxHttpClient;
 import ortus.boxlang.runtime.net.soap.BoxSoapClient;
@@ -54,29 +53,49 @@ import ortus.boxlang.runtime.util.EncryptionUtil;
 public class HttpService extends BaseService {
 
 	/**
-	 * Concurrent map that stores all HTTP reusable clients
+	 * Default HTTP connection timeout in seconds
 	 */
-	private final ConcurrentMap<Key, BoxHttpClient>										clients						= new ConcurrentHashMap<>();
+	public static final int		DEFAULT_HTTP_TIMEOUT_SECONDS		= 30;
 
 	/**
-	 * Concurrent map that stores all SOAP/WSDL clients
+	 * Default last access timeout (idle timeout) in seconds
 	 */
-	private final ConcurrentMap<String, ortus.boxlang.runtime.net.soap.BoxSoapClient>	soapClients					= new ConcurrentHashMap<>();
+	public static final int		DEFAULT_LAST_ACCESS_TIMEOUT_SECONDS	= 60;
+
+	/**
+	 * Name of the cache used to store HTTP and SOAP clients
+	 */
+	public static final Key		HTTP_CLIENTS_CACHE_NAME				= Key.of( "bxHttpClients" );
+
+	/**
+	 * Key prefix for HTTP clients in the cache
+	 */
+	public static final String	HTTP_CLIENT_KEY_PREFIX				= "bxHttp-";
+
+	/**
+	 * Key prefix for SOAP clients in the cache
+	 */
+	public static final String	SOAP_CLIENT_KEY_PREFIX				= "bxSoap-";
+
+	/**
+	 * Cache that stores all HTTP and SOAP reusable clients
+	 */
+	private ICacheProvider		httpClientCache;
 
 	/**
 	 * Shutdown timeout in seconds
 	 */
-	private static final Long															SHUTDOWN_TIMEOUT_SECONDS	= 10L;
+	private static final Long	SHUTDOWN_TIMEOUT_SECONDS			= 10L;
 
 	/**
 	 * The main HTTP logger
 	 */
-	private BoxLangLogger																logger;
+	private BoxLangLogger		logger;
 
 	/**
 	 * The HTTP Executor used by all clients
 	 */
-	private BoxExecutor																	httpExecutor;
+	private BoxExecutor			httpExecutor;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -117,8 +136,7 @@ public class HttpService extends BaseService {
 			this.logger.info( "+ Http Service graceful shutdown initiated" );
 			this.httpExecutor.shutdownAndAwaitTermination( SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS );
 		}
-		this.clients.clear();
-		this.soapClients.clear();
+		this.httpClientCache.clearAll();
 		this.logger.info( "+ Http Service shutdown complete" );
 	}
 
@@ -129,6 +147,19 @@ public class HttpService extends BaseService {
 		if ( System.getProperty( "jdk.httpclient.allowRestrictedHeaders" ) == null ) {
 			System.setProperty( "jdk.httpclient.allowRestrictedHeaders", "host,content-length" );
 		}
+
+		// Create the HTTP clients cache if it doesn't exist
+		this.httpClientCache = runtime
+		    .getCacheService()
+		    .createCacheIfAbsent(
+		        HTTP_CLIENTS_CACHE_NAME,
+		        Key.boxCacheProvider,
+		        Struct.of(
+		            "defaultTimeout", DEFAULT_LAST_ACCESS_TIMEOUT_SECONDS,
+		            "defaultLastAccessTimeout", DEFAULT_HTTP_TIMEOUT_SECONDS
+		        )
+		    );
+
 		this.logger.info( "+ Http Service started" );
 	}
 
@@ -166,7 +197,9 @@ public class HttpService extends BaseService {
 	 * How many HTTP clients are currently managed
 	 */
 	public int getClientCount() {
-		return this.clients.size();
+		return ( int ) this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( HTTP_CLIENT_KEY_PREFIX ) )
+		    .count();
 	}
 
 	/**
@@ -175,7 +208,7 @@ public class HttpService extends BaseService {
 	 * @param key The client key
 	 */
 	public boolean hasClient( Key key ) {
-		return this.clients.containsKey( key );
+		return this.httpClientCache.lookupQuiet( key.getName() );
 	}
 
 	/**
@@ -186,7 +219,9 @@ public class HttpService extends BaseService {
 	 * @return The HttpClient instance, or null if not found
 	 */
 	public BoxHttpClient getClient( Key key ) {
-		return this.clients.get( key );
+		return ( BoxHttpClient ) this.httpClientCache
+		    .get( key.getName() )
+		    .orElse( null );
 	}
 
 	/**
@@ -196,7 +231,12 @@ public class HttpService extends BaseService {
 	 * @param client The HttpClient instance
 	 */
 	public BoxHttpClient putClient( Key key, BoxHttpClient client ) {
-		this.clients.put( key, client );
+		this.httpClientCache.set(
+		    key.getName(),
+		    client,
+		    DEFAULT_HTTP_TIMEOUT_SECONDS,
+		    DEFAULT_LAST_ACCESS_TIMEOUT_SECONDS
+		);
 		return client;
 	}
 
@@ -206,7 +246,7 @@ public class HttpService extends BaseService {
 	 * @param key The client key
 	 */
 	public HttpService removeClient( Key key ) {
-		this.clients.remove( key );
+		this.httpClientCache.clear( key.getName() );
 		return this;
 	}
 
@@ -219,9 +259,9 @@ public class HttpService extends BaseService {
 	 */
 	public Array getAllClientKeys() {
 		Array keys = new Array();
-		for ( Key key : this.clients.keySet() ) {
-			keys.add( key.getName() );
-		}
+		this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( HTTP_CLIENT_KEY_PREFIX ) )
+		    .forEach( keys::add );
 		return keys;
 	}
 
@@ -245,22 +285,31 @@ public class HttpService extends BaseService {
 	 */
 	public IStruct getAllClientStats() {
 		IStruct allStats = new Struct( false );
-		for ( Key key : this.clients.keySet() ) {
-			allStats.put( key.getName(), getClientStats( key ) );
-		}
+		this.httpClientCache
+		    .getKeysStream()
+		    .filter( k -> k.startsWith( HTTP_CLIENT_KEY_PREFIX ) )
+		    .forEach( key -> {
+			    this.httpClientCache.getQuiet( key ).ifPresent( clientObj -> {
+				    if ( clientObj instanceof BoxHttpClient client ) {
+					    allStats.put( key, client.getStatistics() );
+				    }
+			    } );
+		    } );
 		return allStats;
 	}
 
 	/**
 	 * Clear all cached HTTP clients
 	 * <p>
-	 * This method removes all cached clients from the service.
+	 * This method removes all cached HTTP clients from the service.
 	 * Useful for testing or when you need to force recreation of all clients.
 	 *
 	 * @return This HttpService instance for method chaining
 	 */
 	public HttpService clearAllClients() {
-		this.clients.clear();
+		this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( HTTP_CLIENT_KEY_PREFIX ) )
+		    .forEach( this.httpClientCache::clear );
 		return this;
 	}
 
@@ -300,7 +349,7 @@ public class HttpService extends BaseService {
 		}
 
 		// Build a unique key for this client configuration
-		Key clientKey = buildClientKey(
+		String clientKey = buildClientKey(
 		    httpVersion,
 		    followRedirects,
 		    connectTimeout,
@@ -313,94 +362,97 @@ public class HttpService extends BaseService {
 		);
 
 		// Return cached client if it exists
-		if ( hasClient( clientKey ) ) {
-			synchronized ( this.clients ) {
-				if ( hasClient( clientKey ) ) {
-					this.logger.trace( "Reusing cached HTTP client with key: {}", clientKey );
-					return getClient( clientKey );
+		if ( hasClient( Key.of( clientKey ) ) ) {
+			this.logger.trace( "Reusing cached HTTP client with key: {}", clientKey );
+			return getClient( Key.of( clientKey ) );
+		}
+
+		// Double-checked locking for thread safety
+		synchronized ( this ) {
+			if ( hasClient( Key.of( clientKey ) ) ) {
+				this.logger.trace( "Reusing cached HTTP client with key: {}", clientKey );
+				return getClient( Key.of( clientKey ) );
+			}
+			this.logger.trace( "Building new HTTP client with key: {}", clientKey );
+
+			// Create HttpClient builder
+			HttpClient.Builder builder = HttpClient.newBuilder()
+			    // Configure Executor
+			    .executor( this.httpExecutor.executor() )
+			    // Configure redirect policy
+			    .followRedirects( followRedirects ? HttpClient.Redirect.NORMAL : HttpClient.Redirect.NEVER )
+			    // Configure HTTP version
+			    .version( httpVersion.equalsIgnoreCase( BoxHttpClient.HTTP_1 )
+			        ? HttpClient.Version.HTTP_1_1
+			        : HttpClient.Version.HTTP_2
+			    );
+
+			// Configure connect timeout
+			if ( connectTimeout != null ) {
+				builder.connectTimeout( Duration.ofSeconds( connectTimeout ) );
+			}
+
+			// Configure proxy
+			if ( proxyServer != null && !proxyServer.isEmpty() && proxyPort != null ) {
+				builder.proxy( ProxySelector.of( new InetSocketAddress( proxyServer, proxyPort ) ) );
+
+				// Configure proxy authentication if credentials provided
+				if ( proxyUser != null && !proxyUser.isEmpty() && proxyPassword != null && !proxyPassword.isEmpty() ) {
+					builder.authenticator( new Authenticator() {
+
+						@Override
+						protected PasswordAuthentication getPasswordAuthentication() {
+							return new PasswordAuthentication( proxyUser, proxyPassword.toCharArray() );
+						}
+					} );
 				}
 			}
-		}
 
-		// Build a new HttpClient with the specified configuration
-		this.logger.trace( "Building new HTTP client with key: {}", clientKey );
-
-		// Create HttpClient builder
-		HttpClient.Builder builder = HttpClient.newBuilder()
-		    // Configure Executor
-		    .executor( this.httpExecutor.executor() )
-		    // Configure redirect policy
-		    .followRedirects( followRedirects ? HttpClient.Redirect.NORMAL : HttpClient.Redirect.NEVER )
-		    // Configure HTTP version
-		    .version( httpVersion.equalsIgnoreCase( BoxHttpClient.HTTP_1 )
-		        ? HttpClient.Version.HTTP_1_1
-		        : HttpClient.Version.HTTP_2
-		    );
-
-		// Configure connect timeout
-		if ( connectTimeout != null ) {
-			builder.connectTimeout( Duration.ofSeconds( connectTimeout ) );
-		}
-
-		// Configure proxy
-		if ( proxyServer != null && !proxyServer.isEmpty() && proxyPort != null ) {
-			builder.proxy( ProxySelector.of( new InetSocketAddress( proxyServer, proxyPort ) ) );
-
-			// Configure proxy authentication if credentials provided
-			if ( proxyUser != null && !proxyUser.isEmpty() && proxyPassword != null && !proxyPassword.isEmpty() ) {
-				builder.authenticator( new Authenticator() {
-
-					@Override
-					protected PasswordAuthentication getPasswordAuthentication() {
-						return new PasswordAuthentication( proxyUser, proxyPassword.toCharArray() );
+			// Configure client certificate (SSL/TLS)
+			if ( clientCertPath != null ) {
+				try {
+					// Verify the certificate file exists before attempting to load
+					java.io.File certFile = new java.io.File( clientCertPath );
+					if ( !certFile.exists() ) {
+						throw new BoxRuntimeException( "Client certificate file not found: " + clientCertPath );
 					}
-				} );
-			}
-		}
+					if ( !certFile.canRead() ) {
+						throw new BoxRuntimeException( "Client certificate file is not readable: " + clientCertPath );
+					}
 
-		// Configure client certificate (SSL/TLS)
-		if ( clientCertPath != null ) {
-			try {
-				// Verify the certificate file exists before attempting to load
-				java.io.File certFile = new java.io.File( clientCertPath );
-				if ( !certFile.exists() ) {
-					throw new BoxRuntimeException( "Client certificate file not found: " + clientCertPath );
-				}
-				if ( !certFile.canRead() ) {
-					throw new BoxRuntimeException( "Client certificate file is not readable: " + clientCertPath );
-				}
+					// Load the client certificate keystore using EncryptionUtil
+					KeyStore keyStore = EncryptionUtil.loadPKCS12KeyStore( clientCertPath, clientCertPass );
+					if ( keyStore == null ) {
+						throw new BoxRuntimeException(
+						    "Failed to load client certificate keystore (check password or file format): " + clientCertPath
+						);
+					}
 
-				// Load the client certificate keystore using EncryptionUtil
-				KeyStore keyStore = EncryptionUtil.loadPKCS12KeyStore( clientCertPath, clientCertPass );
-				if ( keyStore == null ) {
+					KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance( KeyManagerFactory.getDefaultAlgorithm() );
+					keyManagerFactory.init( keyStore, clientCertPass != null ? clientCertPass.toCharArray() : null );
+
+					SSLContext sslContext = SSLContext.getInstance( "TLS" );
+					sslContext.init( keyManagerFactory.getKeyManagers(), null, new SecureRandom() );
+
+					builder.sslContext( sslContext );
+				} catch ( BoxRuntimeException e ) {
+					// Re-throw BoxRuntimeException as-is (these are our validation errors)
+					this.logger.error( "Client certificate configuration error: {}", e.getMessage() );
+					throw e;
+				} catch ( Exception e ) {
+					this.logger.error( "Failed to configure client certificate: {}", clientCertPath, e );
 					throw new BoxRuntimeException(
-					    "Failed to load client certificate keystore (check password or file format): " + clientCertPath
+					    "Failed to configure client certificate: " + clientCertPath,
+					    e
 					);
 				}
-
-				KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance( KeyManagerFactory.getDefaultAlgorithm() );
-				keyManagerFactory.init( keyStore, clientCertPass != null ? clientCertPass.toCharArray() : null );
-
-				SSLContext sslContext = SSLContext.getInstance( "TLS" );
-				sslContext.init( keyManagerFactory.getKeyManagers(), null, new SecureRandom() );
-
-				builder.sslContext( sslContext );
-			} catch ( BoxRuntimeException e ) {
-				// Re-throw BoxRuntimeException as-is (these are our validation errors)
-				this.logger.error( "Client certificate configuration error: {}", e.getMessage() );
-				throw e;
-			} catch ( Exception e ) {
-				this.logger.error( "Failed to configure client certificate: {}", clientCertPath, e );
-				throw new BoxRuntimeException(
-				    "Failed to configure client certificate: " + clientCertPath,
-				    e
-				);
 			}
-		}
 
-		// Create our BoxHttpClient wrapper
-		this.logger.trace( "HTTP client created and cached with key: {}", clientKey );
-		return putClient( clientKey, new BoxHttpClient( builder.build(), this ) );
+			// Create our BoxHttpClient wrapper and cache it
+			BoxHttpClient newClient = new BoxHttpClient( builder.build(), this );
+			this.logger.trace( "HTTP client created and cached with key: {}", clientKey );
+			return putClient( Key.of( clientKey ), newClient );
+		}
 	}
 
 	/**
@@ -420,9 +472,9 @@ public class HttpService extends BaseService {
 	 * @param clientCertPath  The path to the client certificate
 	 * @param clientCertPass  The client certificate password
 	 *
-	 * @return A unique Key identifying this client configuration
+	 * @return A unique String key identifying this client configuration
 	 */
-	public Key buildClientKey(
+	public String buildClientKey(
 	    String httpVersion,
 	    boolean followRedirects,
 	    Integer connectTimeout,
@@ -460,8 +512,8 @@ public class HttpService extends BaseService {
 		// Generate SHA-256 hash of the configuration string using EncryptionUtil
 		String hash = EncryptionUtil.hash( keyBuilder.toString(), "SHA-256" );
 
-		// Build the key
-		return Key.of( "bx-http-" + hash );
+		// Build the key with HTTP prefix
+		return HTTP_CLIENT_KEY_PREFIX + hash;
 	}
 
 	/**
@@ -482,18 +534,20 @@ public class HttpService extends BaseService {
 	 * @throws ortus.boxlang.runtime.types.exceptions.BoxRuntimeException If WSDL parsing or client creation fails
 	 */
 	public BoxSoapClient getOrCreateSoapClient( String wsdlUrl, IBoxContext context ) {
+		String			soapKey	= SOAP_CLIENT_KEY_PREFIX + wsdlUrl;
+
 		// Check if we already have a cached client for this WSDL
-		BoxSoapClient cachedClient = this.soapClients.get( wsdlUrl );
-		if ( cachedClient != null ) {
+		Attempt<Object>	cached	= this.httpClientCache.getQuiet( soapKey );
+		if ( cached.isPresent() && cached.get() instanceof BoxSoapClient soapClient ) {
 			this.logger.trace( "Reusing cached SOAP client for WSDL: {}", wsdlUrl );
-			return cachedClient;
+			return soapClient;
 		}
 
 		// Double-checked locking for thread safety
-		synchronized ( this.soapClients ) {
-			cachedClient = this.soapClients.get( wsdlUrl );
-			if ( cachedClient != null ) {
-				return cachedClient;
+		synchronized ( this ) {
+			cached = this.httpClientCache.getQuiet( soapKey );
+			if ( cached.isPresent() && cached.get() instanceof BoxSoapClient soapClient ) {
+				return soapClient;
 			}
 
 			this.logger.trace( "Creating new SOAP client for WSDL: {}", wsdlUrl );
@@ -502,7 +556,12 @@ public class HttpService extends BaseService {
 			BoxSoapClient newClient = BoxSoapClient.fromWsdl( wsdlUrl, this, context );
 
 			// Cache and return
-			this.soapClients.put( wsdlUrl, newClient );
+			this.httpClientCache.set(
+			    soapKey,
+			    newClient,
+			    DEFAULT_HTTP_TIMEOUT_SECONDS,
+			    DEFAULT_LAST_ACCESS_TIMEOUT_SECONDS
+			);
 			this.logger.trace( "Created and cached SOAP client for WSDL: {}", wsdlUrl );
 
 			return newClient;
@@ -517,7 +576,10 @@ public class HttpService extends BaseService {
 	 * @return The SoapClient instance, or null if not cached
 	 */
 	public BoxSoapClient getSoapClient( String wsdlUrl ) {
-		return this.soapClients.get( wsdlUrl );
+		String soapKey = SOAP_CLIENT_KEY_PREFIX + wsdlUrl;
+		return ( BoxSoapClient ) this.httpClientCache
+		    .getQuiet( soapKey )
+		    .orElse( null );
 	}
 
 	/**
@@ -528,7 +590,8 @@ public class HttpService extends BaseService {
 	 * @return True if a client is cached for this WSDL
 	 */
 	public boolean hasSoapClient( String wsdlUrl ) {
-		return this.soapClients.containsKey( wsdlUrl );
+		String soapKey = SOAP_CLIENT_KEY_PREFIX + wsdlUrl;
+		return this.httpClientCache.lookupQuiet( soapKey );
 	}
 
 	/**
@@ -539,7 +602,8 @@ public class HttpService extends BaseService {
 	 * @return This HttpService instance for method chaining
 	 */
 	public HttpService removeSoapClient( String wsdlUrl ) {
-		this.soapClients.remove( wsdlUrl );
+		String soapKey = SOAP_CLIENT_KEY_PREFIX + wsdlUrl;
+		this.httpClientCache.clear( soapKey );
 		return this;
 	}
 
@@ -549,7 +613,9 @@ public class HttpService extends BaseService {
 	 * @return This HttpService instance for method chaining
 	 */
 	public HttpService clearAllSoapClients() {
-		this.soapClients.clear();
+		this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( SOAP_CLIENT_KEY_PREFIX ) )
+		    .forEach( this.httpClientCache::clear );
 		return this;
 	}
 
@@ -559,7 +625,9 @@ public class HttpService extends BaseService {
 	 * @return The number of cached SOAP clients
 	 */
 	public int getSoapClientCount() {
-		return this.soapClients.size();
+		return ( int ) this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( SOAP_CLIENT_KEY_PREFIX ) )
+		    .count();
 	}
 
 	/**
@@ -572,7 +640,7 @@ public class HttpService extends BaseService {
 	 * @throws ortus.boxlang.runtime.types.exceptions.BoxRuntimeException If no client is cached for this WSDL
 	 */
 	public IStruct getSoapClientStats( String wsdlUrl ) {
-		BoxSoapClient client = this.soapClients.get( wsdlUrl );
+		BoxSoapClient client = getSoapClient( wsdlUrl );
 		if ( client == null ) {
 			throw new ortus.boxlang.runtime.types.exceptions.BoxRuntimeException( "No SOAP client found for WSDL: " + wsdlUrl );
 		}
@@ -586,9 +654,16 @@ public class HttpService extends BaseService {
 	 */
 	public IStruct getAllSoapClientStats() {
 		IStruct allStats = new Struct( false );
-		for ( Map.Entry<String, ortus.boxlang.runtime.net.soap.BoxSoapClient> entry : this.soapClients.entrySet() ) {
-			allStats.put( entry.getKey(), entry.getValue().getStatistics() );
-		}
+		this.httpClientCache.getKeysStream()
+		    .filter( k -> k.startsWith( SOAP_CLIENT_KEY_PREFIX ) )
+		    .forEach( key -> {
+			    Attempt<Object> result = this.httpClientCache.getQuiet( key );
+			    if ( result.isPresent() && result.get() instanceof BoxSoapClient soapClient ) {
+				    // Strip prefix for display
+				    String wsdlUrl = key.substring( SOAP_CLIENT_KEY_PREFIX.length() );
+				    allStats.put( wsdlUrl, soapClient.getStatistics() );
+			    }
+		    } );
 		return allStats;
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/SchedulerService.java
@@ -268,12 +268,20 @@ public class SchedulerService extends BaseService {
 			// Decrypt credentials before passing to the callable builder
 			decryptTaskCredentials( taskDef );
 
-			// Build callable and register the task
-			Runnable										callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext,
-			    taskDef );
+			String											group		= taskDef.getAsString( Key.group );
+			String											className	= taskDef.getAsString( Key._CLASS );
+			ortus.boxlang.runtime.async.tasks.ScheduledTask	scheduledTask;
+			Runnable										callable	= null;
 
-			String											group			= taskDef.getAsString( Key.group );
-			ortus.boxlang.runtime.async.tasks.ScheduledTask	scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+			if ( className != null && !className.isBlank() ) {
+				// Class-based task: instantiate once and wire life-cycle methods (identical to doUpdate)
+				scheduledTask = ortus.boxlang.runtime.components.async.Schedule.registerClassTask(
+				    scheduler, taskName, group != null ? group : "", runtimeContext, taskDef );
+			} else {
+				// Build callable and register the task
+				callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
+				scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+			}
 
 			// Apply full configuration (identical to doUpdate — repeat, exclude, callbacks, metadata, scheduling)
 			ortus.boxlang.runtime.components.async.Schedule.applyTaskConfiguration( scheduledTask, callable, taskDef, runtimeContext );
@@ -729,9 +737,18 @@ public class SchedulerService extends BaseService {
 
 				decryptTaskCredentials( taskDef );
 
-				Runnable		callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
-				String			group			= taskDef.getAsString( Key.group );
-				ScheduledTask	scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+				String			group		= taskDef.getAsString( Key.group );
+				String			className	= taskDef.getAsString( Key._CLASS );
+				ScheduledTask	scheduledTask;
+				Runnable		callable	= null;
+
+				if ( className != null && !className.isBlank() ) {
+					scheduledTask = ortus.boxlang.runtime.components.async.Schedule.registerClassTask(
+					    scheduler, taskName, group != null ? group : "", runtimeContext, taskDef );
+				} else {
+					callable		= ortus.boxlang.runtime.components.async.Schedule.buildTaskCallable( runtimeContext, taskDef );
+					scheduledTask	= scheduler.task( taskName, group != null ? group : "" ).call( callable );
+				}
 
 				ortus.boxlang.runtime.components.async.Schedule.applyTaskConfiguration( scheduledTask, callable, taskDef, runtimeContext );
 
@@ -872,6 +889,8 @@ public class SchedulerService extends BaseService {
 			    "scheduler", scheduler,
 			    "group", attributes.getAsString( Key.group ),
 			    "url", attributes.getAsString( Key.URL ),
+			    "class", attributes.getAsString( Key._CLASS ),
+			    "method", attributes.getAsString( Key.method ),
 			    "interval", attributes.getAsString( Key.interval ),
 			    "cronTime", attributes.getAsString( Key.cronTime ),
 			    "startDate", attributes.getAsString( Key.startDate ),

--- a/src/main/java/ortus/boxlang/runtime/types/BoxFile.java
+++ b/src/main/java/ortus/boxlang/runtime/types/BoxFile.java
@@ -439,8 +439,12 @@ public class BoxFile implements IType, IReferenceable, IBoxBinaryRepresentable {
 	public Object read( Integer len ) {
 		try {
 			if ( this.reader != null ) {
-				CharBuffer buffer = CharBuffer.allocate( len );
-				this.reader.read( buffer );
+				CharBuffer	buffer	= CharBuffer.allocate( len );
+				int			read	= this.reader.read( buffer );
+				if ( read == -1 ) {
+					return "";
+				}
+				buffer.flip();
 				return buffer.toString();
 			} else if ( this.byteChannel != null ) {
 				ByteBuffer buffer = ByteBuffer.allocate( len );

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -84,6 +84,11 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 			}
 		}
 
+		/**
+		 * Returns a human-readable label for this struct type.
+		 *
+		 * @return The display name for this enum constant
+		 */
 		public String getHumanReadableName() {
 			// return the opposite of the case statement above
 			switch ( this ) {
@@ -209,14 +214,18 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Remove a value from the struct by a Key object
 	 *
-	 * @param key The String key to remove
+	 * @param key The string key to remove
+	 *
+	 * @return The previous value associated with the key, or null if not present
 	 */
 	public Object remove( String key );
 
 	/**
 	 * Remove a value from the struct by a Key object
 	 *
-	 * @param key The String key to remove
+	 * @param key The key to remove
+	 *
+	 * @return The previous value associated with the key, or null if not present
 	 */
 	public Object remove( Key key );
 
@@ -224,7 +233,7 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 * Copies all of the mappings from the specified map to this map (optional operation).
 	 * This method will automatically convert the keys to Key objects
 	 *
-	 * @param map
+	 * @param map The source map whose entries will be added
 	 */
 	public void addAll( Map<? extends Object, ? extends Object> map );
 
@@ -244,23 +253,29 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 
 	/**
 	 * Get the wrapped map used in the implementation
+	 *
+	 * @return The underlying map backing this struct
 	 */
 	public Map<? extends Object, Object> getWrapped();
 
 	/**
 	 * Get the type of struct
 	 *
-	 * @return The type of struct according to the {@Link Type} enum
+	 * @return The type of struct according to the {@link TYPES} enum
 	 */
 	public TYPES getType();
 
 	/**
 	 * Returns a boolean as to whether the struct instance is case sensitive
+	 *
+	 * @return True if key lookups are case-sensitive, false otherwise
 	 */
 	public Boolean isCaseSensitive();
 
 	/**
 	 * Returns a boolean as to whether the struct assignments are soft referenced
+	 *
+	 * @return True if stored values are wrapped as soft references, false otherwise
 	 */
 	public Boolean isSoftReferenced();
 
@@ -270,8 +285,12 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	public Set<Entry<Key, Object>> entrySet();
 
 	/**
-	 * Convenience method for getting cast as {@Link Key}
+	 * Convenience method for getting cast as {@link Key}.
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Key}
 	 */
 	default Key getAsKey( Key key ) {
 		return ( Key ) DynamicObject.unWrap( get( key ) );
@@ -280,6 +299,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Array
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Array}
 	 */
 	default Array getAsArray( Key key ) {
 		return ( Array ) DynamicObject.unWrap( get( key ) );
@@ -288,6 +311,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as BoxSet
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link BoxSet}
 	 */
 	default BoxSet getAsSet( Key key ) {
 		return ( BoxSet ) DynamicObject.unWrap( get( key ) );
@@ -296,6 +323,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Struct
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link IStruct}
 	 */
 	default IStruct getAsStruct( Key key ) {
 		return ( IStruct ) DynamicObject.unWrap( get( key ) );
@@ -304,6 +335,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as DateTime
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link DateTime}
 	 */
 	default DateTime getAsDateTime( Key key ) {
 		return ( DateTime ) DynamicObject.unWrap( get( key ) );
@@ -312,6 +347,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as String
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link String}
 	 */
 	default String getAsString( Key key ) {
 		return ( String ) DynamicObject.unWrap( get( key ) );
@@ -320,6 +359,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Char
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Character}
 	 */
 	default Character getAsChar( Key key ) {
 		return ( Character ) DynamicObject.unWrap( get( key ) );
@@ -328,6 +371,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Double
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Double}
 	 */
 	default Double getAsDouble( Key key ) {
 		return ( Double ) DynamicObject.unWrap( get( key ) );
@@ -336,6 +383,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Number
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Number}
 	 */
 	default Number getAsNumber( Key key ) {
 		return ( Number ) DynamicObject.unWrap( get( key ) );
@@ -344,6 +395,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Long
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Long}
 	 */
 	default Long getAsLong( Key key ) {
 		return ( Long ) DynamicObject.unWrap( get( key ) );
@@ -352,6 +407,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Integer
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Integer}
 	 */
 	default Integer getAsInteger( Key key ) {
 		return ( Integer ) DynamicObject.unWrap( get( key ) );
@@ -360,6 +419,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Boolean
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Boolean}
 	 */
 	default Boolean getAsBoolean( Key key ) {
 		return ( Boolean ) DynamicObject.unWrap( get( key ) );
@@ -368,6 +431,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Function
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Function}
 	 */
 	default Function getAsFunction( Key key ) {
 		return ( Function ) DynamicObject.unWrap( get( key ) );
@@ -376,6 +443,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Query
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Query}
 	 */
 	default Query getAsQuery( Key key ) {
 		return ( Query ) DynamicObject.unWrap( get( key ) );
@@ -384,6 +455,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as XML
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link XML}
 	 */
 	default XML getAsXML( Key key ) {
 		return ( XML ) DynamicObject.unWrap( get( key ) );
@@ -392,6 +467,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as Optional
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Optional}
 	 */
 	@SuppressWarnings( "unchecked" )
 	default Optional<Object> getAsOptional( Key key ) {
@@ -401,6 +480,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as BoxLang Attempt
 	 * If the value is not already an attempt, it will be wrapped in an Attempt
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The resolved value as an {@link Attempt}
 	 */
 	@SuppressWarnings( "unchecked" )
 	default Attempt<Object> getAsAttempt( Key key ) {
@@ -433,6 +516,10 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as BoxRunnable
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link IClassRunnable}
 	 */
 	default IClassRunnable getAsClassRunnable( Key key ) {
 		return ( IClassRunnable ) DynamicObject.unWrap( get( key ) );
@@ -441,19 +528,47 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	/**
 	 * Convenience method for getting cast as BoxInterface
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link BoxInterface}
 	 */
 	default BoxInterface getAsBoxInterface( Key key ) {
 		return ( BoxInterface ) DynamicObject.unWrap( get( key ) );
 	}
 
+	/**
+	 * Convenience method for getting cast as {@link BoxFile}.
+	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable.
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link BoxFile}
+	 */
 	default BoxFile getAsBoxFile( Key key ) {
 		return ( BoxFile ) DynamicObject.unWrap( get( key ) );
 	}
 
+	/**
+	 * Convenience method for getting cast as {@link Stream}.
+	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable.
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link Stream}
+	 */
 	default Stream<?> getAsStream( Key key ) {
 		return ( Stream<?> ) DynamicObject.unWrap( get( key ) );
 	}
 
+	/**
+	 * Convenience method for getting cast as {@link BoxStringBuilder}.
+	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable.
+	 *
+	 * @param key The key to retrieve
+	 *
+	 * @return The value cast to {@link BoxStringBuilder}
+	 */
 	default BoxStringBuilder getAsBoxStringBuilder( Key key ) {
 		return ( BoxStringBuilder ) DynamicObject.unWrap( get( key ) );
 	}

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -502,7 +502,7 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 * @param <T>   The type parameter for the Attempt
 	 * @param key   The key to get
 	 * @param clazz The class to cast the Attempt value to
-	 * 
+	 *
 	 * @return The Attempt containing the value cast to the specified type
 	 */
 	default <T> Attempt<T> getAsAttempt( Key key, Class<T> clazz ) {

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -285,6 +285,27 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	public Set<Entry<Key, Object>> entrySet();
 
 	/**
+	 * Returns a stream of the struct entries.
+	 *
+	 * @return A stream of key/value entries
+	 */
+	public Stream<Entry<Key, Object>> stream();
+
+	/**
+	 * Returns a stream of struct keys.
+	 *
+	 * @return A stream of keys
+	 */
+	public Stream<Key> keyStream();
+
+	/**
+	 * Returns a stream of struct values.
+	 *
+	 * @return A stream of values
+	 */
+	public Stream<Object> valueStream();
+
+	/**
 	 * Convenience method for getting cast as {@link Key}.
 	 * Does NOT perform BoxLang casting, only Java cast so the object needs to actually be castable
 	 *

--- a/src/main/java/ortus/boxlang/runtime/types/IStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/IStruct.java
@@ -289,21 +289,27 @@ public interface IStruct extends Map<Key, Object>, IType, IReferenceable {
 	 *
 	 * @return A stream of key/value entries
 	 */
-	public Stream<Entry<Key, Object>> stream();
+	public default Stream<Entry<Key, Object>> stream() {
+		return entrySet().stream();
+	}
 
 	/**
 	 * Returns a stream of struct keys.
 	 *
 	 * @return A stream of keys
 	 */
-	public Stream<Key> keyStream();
+	public default Stream<Key> keyStream() {
+		return keySet().stream();
+	}
 
 	/**
 	 * Returns a stream of struct values.
 	 *
 	 * @return A stream of values
 	 */
-	public Stream<Object> valueStream();
+	public default Stream<Object> valueStream() {
+		return values().stream();
+	}
 
 	/**
 	 * Convenience method for getting cast as {@link Key}.

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -544,7 +544,11 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 		int			index		= getColumn( name ).getIndex();
 		Object[]	columnData	= new Object[ size.get() ];
 		for ( int i = 0; i < size.get(); i++ ) {
-			columnData[ i ] = data.get( i )[ index ];
+			Object value = data.get( i )[ index ];
+			if ( queryNullToEmpty && value == null ) {
+				value = "";
+			}
+			columnData[ i ] = value;
 		}
 		return columnData;
 	}
@@ -977,13 +981,16 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 		Object[]	rowData	= new Object[ columns.size() ];
 		int			i		= 0;
 		for ( QueryColumn column : columns.values() ) {
-			// Missing keys in the struct go in the query as an empty string (CF compat)
-			Object value = row.containsKey( column.getName() ) ? row.get( column.getName() ) : "";
+			// Missing values are null
+			Object value = row.containsKey( column.getName() ) ? row.get( column.getName() ) : null;
+			// This allows nulls which were turned into empty strings in the struct to be turned back into nulls
+			if ( queryNullToEmpty && !QueryColumnType.isStringType( column.getType() ) && value instanceof String castValue && castValue.isEmpty() ) {
+				value = null;
+			}
 			rowData[ i ] = context != null ? QueryColumnType.toSQLType( column.getType(), value, context, null ) : value;
 			i++;
 		}
-		// We're ignoring extra keys in the struct that aren't query columns. Lucee
-		// compat, but not CF compat.
+		// We're ignoring extra keys in the struct that aren't query columns.
 		return addRow( rowData );
 	}
 
@@ -1031,7 +1038,36 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 		Object[]	row		= data.get( index );
 		int			i		= 0;
 		for ( QueryColumn column : columns.values() ) {
-			struct.put( column.getName(), row[ i ] );
+			Object value = row[ i ];
+			if ( queryNullToEmpty && value == null ) {
+				value = "";
+			}
+			struct.put( column.getName(), value );
+			i++;
+		}
+		return struct;
+	}
+
+	/**
+	 * Get data for a row as a Struct. 0-based index!
+	 * Data is copied, so re-assignments into the struct will not be reflected in
+	 * the query.
+	 * Mutating a complex object in the array will be reflected in the query.
+	 * This method does not convert null values to empty strings.
+	 *
+	 * @param index row index, starting at 0
+	 *
+	 * @return array of row data
+	 */
+	public IStruct getRowAsStructRaw( int index ) {
+		validateRow( index );
+		IStruct		struct	= new Struct( IStruct.TYPES.LINKED );
+		Object[]	row		= data.get( index );
+		int			i		= 0;
+		for ( QueryColumn column : columns.values() ) {
+			Object value = row[ i ];
+			// Do not convert null to empty string for raw access
+			struct.put( column.getName(), value );
 			i++;
 		}
 		return struct;
@@ -1047,8 +1083,12 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	 */
 	public Object getCell( Key columnName, int rowIndex ) {
 		validateRow( rowIndex );
-		int columnIndex = getColumn( columnName ).getIndex();
-		return data.get( rowIndex )[ columnIndex ];
+		int		columnIndex	= getColumn( columnName ).getIndex();
+		Object	value		= data.get( rowIndex )[ columnIndex ];
+		if ( queryNullToEmpty && value == null ) {
+			return "";
+		}
+		return value;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -337,6 +337,25 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	}
 
 	/**
+	 * Here for CF compat. Returns the 1-based index of the given column name
+	 * 
+	 * @param name column name
+	 * 
+	 * @return 1-based index of the column, or 0 if not found
+	 */
+	public int findColumn( String name ) {
+		Key	keyName	= Key.of( name );
+		int	index	= 1; // 1-based index
+		for ( Key key : columns.keySet() ) {
+			if ( key.equals( keyName ) ) {
+				return index;
+			}
+			index++;
+		}
+		return 0;
+	}
+
+	/**
 	 * Clone the columns of this query and return a new QueryColumn map.
 	 * Note, the columns will STILL point to the original query object and will have the original indexes.
 	 */

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -783,7 +783,8 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	}
 
 	/**
-	 * Add a row to the query
+	 * Add a row to the query. I do NOT cast incoming values to the column types; they are added as-is.
+	 * Only call this if you have trusted data.
 	 *
 	 * @param row row data as array of objects
 	 *

--- a/src/main/java/ortus/boxlang/runtime/types/Query.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Query.java
@@ -1524,7 +1524,7 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	 *
 	 * @return A copy of the current query.
 	 */
-	@Deprecated
+	@Deprecated( forRemoval = true )
 	public Query duplicate() {
 		return duplicate( RequestBoxContext.getCurrent() );
 	}
@@ -1549,7 +1549,7 @@ public class Query implements IType, IReferenceable, Collection<IStruct>, Serial
 	 *
 	 * @return A copy of the current query.
 	 */
-	@Deprecated
+	@Deprecated( forRemoval = true )
 	public Query duplicate( boolean deep ) {
 		return duplicate( deep, RequestBoxContext.getCurrent() );
 	}

--- a/src/main/java/ortus/boxlang/runtime/types/QueryColumn.java
+++ b/src/main/java/ortus/boxlang/runtime/types/QueryColumn.java
@@ -371,7 +371,12 @@ public class QueryColumn implements IReferenceable, Serializable {
 		if ( query.isEmpty() ) {
 			return "";
 		}
-		return this.query.getData().get( row )[ index ];
+		Object value = this.query.getData().get( row )[ index ];
+
+		if ( Query.queryNullToEmpty && value == null ) {
+			return "";
+		}
+		return value;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/Struct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Struct.java
@@ -200,7 +200,7 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 
 	/**
 	 * Create a default struct
-	 * 
+	 *
 	 * @param concurrent Whether to use a concurrent map implementation
 	 */
 	public Struct( boolean concurrent ) {
@@ -596,7 +596,7 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 
 	/**
 	 * Set a value in the struct by a Key object.
-	 * 
+	 *
 	 * I exist since I can be used internally to bypass overridden put() methods in subclasses
 	 * such as ArgumentScope, which have undesirable behaviors in scenarios such as putAll().
 	 *
@@ -916,7 +916,7 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 
 	/**
 	 * Get the BoxLang type name for this type
-	 * 
+	 *
 	 * @return The BoxLang type name
 	 */
 	@Override

--- a/src/main/java/ortus/boxlang/runtime/types/Struct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Struct.java
@@ -37,10 +37,8 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import ortus.boxlang.runtime.BoxRuntime;
-import ortus.boxlang.runtime.bifs.BoxMemberExpose;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
 import ortus.boxlang.runtime.context.ClassBoxContext;
 import ortus.boxlang.runtime.context.FunctionBoxContext;
@@ -749,16 +747,6 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 	}
 
 	/**
-	 * Returns a stream of struct keys.
-	 *
-	 * @return The stream of keys
-	 */
-	@BoxMemberExpose
-	public Stream<Key> keyStream() {
-		return keySet().stream();
-	}
-
-	/**
 	 * Returns a {@link Collection} view of the values contained in this map.
 	 */
 	@Override
@@ -766,26 +754,6 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 		return wrapped.values().stream()
 		    .map( this::unWrapNullInternal )
 		    .collect( Collectors.toList() );
-	}
-
-	/**
-	 * Returns a stream of struct values.
-	 *
-	 * @return The stream of values
-	 */
-	@BoxMemberExpose
-	public Stream<Object> valueStream() {
-		return values().stream();
-	}
-
-	/**
-	 * Returns a stream of struct entries.
-	 *
-	 * @return The stream of key/value entries
-	 */
-	@BoxMemberExpose
-	public Stream<Entry<Key, Object>> stream() {
-		return entrySet().stream();
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/Struct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/Struct.java
@@ -37,8 +37,10 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.bifs.BoxMemberExpose;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
 import ortus.boxlang.runtime.context.ClassBoxContext;
 import ortus.boxlang.runtime.context.FunctionBoxContext;
@@ -747,13 +749,43 @@ public class Struct implements IStruct, IListenable<IStruct>, Serializable {
 	}
 
 	/**
+	 * Returns a stream of struct keys.
+	 *
+	 * @return The stream of keys
+	 */
+	@BoxMemberExpose
+	public Stream<Key> keyStream() {
+		return keySet().stream();
+	}
+
+	/**
 	 * Returns a {@link Collection} view of the values contained in this map.
 	 */
 	@Override
 	public Collection<Object> values() {
 		return wrapped.values().stream()
-		    .map( entry -> unWrapNullInternal( entry ) )
+		    .map( this::unWrapNullInternal )
 		    .collect( Collectors.toList() );
+	}
+
+	/**
+	 * Returns a stream of struct values.
+	 *
+	 * @return The stream of values
+	 */
+	@BoxMemberExpose
+	public Stream<Object> valueStream() {
+		return values().stream();
+	}
+
+	/**
+	 * Returns a stream of struct entries.
+	 *
+	 * @return The stream of key/value entries
+	 */
+	@BoxMemberExpose
+	public Stream<Entry<Key, Object>> stream() {
+		return entrySet().stream();
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/exceptions/BoxRuntimeException.java
+++ b/src/main/java/ortus/boxlang/runtime/types/exceptions/BoxRuntimeException.java
@@ -30,7 +30,7 @@ public class BoxRuntimeException extends BoxLangException {
 	/**
 	 * Custom error message; information that the default exception handler does not display.
 	 */
-	protected Object extendedInfo = "";
+	public Object extendedInfo = "";
 
 	/**
 	 * Constructor

--- a/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableQuery.java
@@ -365,6 +365,7 @@ public class UnmodifiableQuery extends Query implements IUnmodifiable {
 	 */
 	@Override
 	@Deprecated
+	@SuppressWarnings( "removal" )
 	public UnmodifiableQuery duplicate() {
 		return duplicate( false, RequestBoxContext.getCurrent() );
 	}

--- a/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableQuery.java
+++ b/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableQuery.java
@@ -366,7 +366,19 @@ public class UnmodifiableQuery extends Query implements IUnmodifiable {
 	@Override
 	@Deprecated
 	public UnmodifiableQuery duplicate() {
-		return duplicate( RequestBoxContext.getCurrent() );
+		return duplicate( false, RequestBoxContext.getCurrent() );
+	}
+
+	/**
+	 * Duplicate the current query.
+	 *
+	 * @param deep    If true, nested objects will be duplicated as well.
+	 * @param context The box context.
+	 *
+	 * @return A copy of the current query.
+	 */
+	public UnmodifiableQuery duplicate( boolean deep, IBoxContext context ) {
+		return super.duplicate( deep, context ).toUnmodifiable();
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableStruct.java
+++ b/src/main/java/ortus/boxlang/runtime/types/unmodifiable/UnmodifiableStruct.java
@@ -105,7 +105,7 @@ public class UnmodifiableStruct extends Struct implements IUnmodifiable {
 	}
 
 	/**
-	 * To Modifiable
+	 * To Modifiable. Returns a new struct instance, does not mutate the current instance. The new struct will be of the same type as the current instance.
 	 *
 	 * @return The Modifiable type
 	 */

--- a/src/main/java/ortus/boxlang/runtime/types/util/BLCollector.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/BLCollector.java
@@ -155,6 +155,7 @@ public class BLCollector {
 	 *
 	 * @return The collector that collects into a Query
 	 */
+	@SuppressWarnings( "null" )
 	public static Collector<IStruct, Query, Query> toQuery( Query template, IBoxContext context ) {
 		return Collector.of(
 		    // supplier
@@ -163,6 +164,35 @@ public class BLCollector {
 		    },
 		    // accumulator
 		    ( query, row ) -> query.addRow( row, context ),
+		    // combiner
+		    ( left, right ) -> {
+			    left.addAll( right );
+			    return left;
+		    }, // combiner
+		    Collector.Characteristics.IDENTITY_FINISH,
+		    Collector.Characteristics.CONCURRENT
+		);
+	}
+
+	/**
+	 * Returns a Collector that collects the input elements into a Query, casting values to the appropriate column types
+	 * if a context is provided. This is the same as toQuery(), but it does not perform any type casting on the values, assuming that the types are already trusted.
+	 * This is more performant on a large result set, but should only be used when deconstructing a query and re-building with known good values.
+	 *
+	 * @param template The template Query to use for the new Query
+	 * @param context  The context to use for type casting, or null to skip casting
+	 *
+	 * @return The collector that collects into a Query
+	 */
+	@SuppressWarnings( "null" )
+	public static Collector<IStruct, Query, Query> toQueryTrustedTypes( Query template, IBoxContext context ) {
+		return Collector.of(
+		    // supplier
+		    () -> {
+			    return new Query( template.getColumns() );
+		    },
+		    // accumulator
+		    ( query, row ) -> query.addRow( row, null ),
 		    // combiner
 		    ( left, right ) -> {
 			    left.addAll( right );

--- a/src/main/java/ortus/boxlang/runtime/types/util/QueryUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/QueryUtil.java
@@ -123,7 +123,8 @@ public class QueryUtil {
 		Stream<IStruct> queryStream = query
 		    .intStream()
 		    .filter( test )
-		    .mapToObj( query::getRowAsStruct );
+		    // Filtering a query must not convert internal nulls to empty strings incompat mode, so get raw struct
+		    .mapToObj( query::getRowAsStructRaw );
 
 		// Let's do it!
 		if ( parallel ) {

--- a/src/main/java/ortus/boxlang/runtime/types/util/QueryUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/QueryUtil.java
@@ -134,11 +134,12 @@ public class QueryUtil {
 
 			BoxExecutor executor = AsyncService.chooseParallelExecutor( "QueryFilter_", maxThreads, virtual );
 
-			return QueryCaster.cast( executor.submitAndGet( () -> queryStream.parallel().collect( BLCollector.toQuery( query, callbackContext ) ) ) );
+			return QueryCaster
+			    .cast( executor.submitAndGet( () -> queryStream.parallel().collect( BLCollector.toQueryTrustedTypes( query, callbackContext ) ) ) );
 		}
 
 		// If parallel is false, just use the regular stream
-		return queryStream.collect( BLCollector.toQuery( query, callbackContext ) );
+		return queryStream.collect( BLCollector.toQueryTrustedTypes( query, callbackContext ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/util/ClassLoaderUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/ClassLoaderUtil.java
@@ -1,0 +1,57 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.util;
+
+import java.net.URL;
+import java.util.Arrays;
+
+/**
+ * Utilities for producing stable class-loader cache keys.
+ */
+public final class ClassLoaderUtil {
+
+	private ClassLoaderUtil() {
+	}
+
+	/**
+	 * Hashes values in canonical sorted order.
+	 *
+	 * @param values The values to hash
+	 *
+	 * @return A stable hash for the values regardless of input order
+	 */
+	public static String hashSorted( Object[] values ) {
+		String[] sortedValues = Arrays.stream( values )
+		    .map( Object::toString )
+		    .sorted()
+		    .toArray( String[]::new );
+		return EncryptionUtil.hash( Arrays.toString( sortedValues ) );
+	}
+
+	/**
+	 * Hashes URLs in canonical sorted order.
+	 *
+	 * @param urls The URLs to hash
+	 *
+	 * @return A stable hash for the URLs regardless of input order
+	 */
+	public static String hashSorted( URL[] urls ) {
+		return hashSorted( ( Object[] ) urls );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/util/EncryptionUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/EncryptionUtil.java
@@ -1158,8 +1158,7 @@ public final class EncryptionUtil {
 	 * <p>
 	 * UUencode encodes binary data using a printable ASCII character set with values
 	 * offset by 32 (space = 0, underscore = 63). Data is processed in 45-byte chunks.
-	 * Each chunk is prefixed with a length character (ASCII 32 + byte count),
-	 * and the encoded stream is terminated with a backtick (ASCII 96).
+	 * Each chunk is prefixed with a length character (ASCII 32 + byte count).
 	 *
 	 * @param src The byte array to encode
 	 *
@@ -1167,7 +1166,7 @@ public final class EncryptionUtil {
 	 */
 	public static String uuEncode( byte[] src ) {
 		if ( src == null || src.length == 0 ) {
-			return "`";
+			return "";
 		}
 
 		StringBuilder	sb	= new StringBuilder();
@@ -1176,8 +1175,7 @@ public final class EncryptionUtil {
 		while ( i < src.length ) {
 			int chunkLen = Math.min( 45, src.length - i );
 			// Write length character: (chunkLen + 32) as a printable char
-			// Zero-length chunks use backtick (96)
-			sb.append( ( char ) ( chunkLen == 0 ? 96 : chunkLen + 32 ) );
+			sb.append( ( char ) ( chunkLen + 32 ) );
 
 			// Process 3-byte groups
 			int j = i;

--- a/src/main/java/ortus/boxlang/runtime/util/EncryptionUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/EncryptionUtil.java
@@ -807,7 +807,7 @@ public final class EncryptionUtil {
 		}
 		// UU encoding
 		else if ( encodingKey.equals( Key.encodingUU ) ) {
-			return Base64.getMimeEncoder().encodeToString( obj );
+			return uuEncode( obj );
 		}
 		// Base64 encoding
 		else if ( encodingKey.equals( Key.encodingBase64 ) ) {
@@ -842,7 +842,7 @@ public final class EncryptionUtil {
 		}
 		// UU encoding
 		else if ( encodingKey.equals( Key.encodingUU ) ) {
-			return Base64.getMimeDecoder().decode( encoded );
+			return uuDecode( encoded );
 		}
 		// Base64 encoding
 		else if ( encodingKey.equals( Key.encodingBase64 ) ) {
@@ -1151,6 +1151,140 @@ public final class EncryptionUtil {
 			// Return null on error - caller can decide how to handle
 			return null;
 		}
+	}
+
+	/**
+	 * Encodes a byte array into Unix UUencode format.
+	 * <p>
+	 * UUencode encodes binary data using a printable ASCII character set with values
+	 * offset by 32 (space = 0, underscore = 63). Data is processed in 45-byte chunks.
+	 * Each chunk is prefixed with a length character (ASCII 32 + byte count),
+	 * and the encoded stream is terminated with a backtick (ASCII 96).
+	 *
+	 * @param src The byte array to encode
+	 *
+	 * @return The UUencoded string
+	 */
+	public static String uuEncode( byte[] src ) {
+		if ( src == null || src.length == 0 ) {
+			return "`";
+		}
+
+		StringBuilder	sb	= new StringBuilder();
+		int				i	= 0;
+
+		while ( i < src.length ) {
+			int chunkLen = Math.min( 45, src.length - i );
+			// Write length character: (chunkLen + 32) as a printable char
+			// Zero-length chunks use backtick (96)
+			sb.append( ( char ) ( chunkLen == 0 ? 96 : chunkLen + 32 ) );
+
+			// Process 3-byte groups
+			int j = i;
+			while ( j + 3 <= i + chunkLen ) {
+				int	a	= src[ j ] & 0xFF;
+				int	b	= src[ j + 1 ] & 0xFF;
+				int	c	= src[ j + 2 ] & 0xFF;
+
+				sb.append( ( char ) ( ( ( a >>> 2 ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( ( ( a << 4 ) | ( b >>> 4 ) ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( ( ( b << 2 ) | ( c >>> 6 ) ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( c & 0x3F ) + 32 ) );
+
+				j += 3;
+			}
+
+			// Handle remaining 1 or 2 bytes
+			int remaining = i + chunkLen - j;
+			if ( remaining == 1 ) {
+				int a = src[ j ] & 0xFF;
+				sb.append( ( char ) ( ( ( a >>> 2 ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( ( a << 4 ) & 0x3F ) + 32 ) );
+			} else if ( remaining == 2 ) {
+				int	a	= src[ j ] & 0xFF;
+				int	b	= src[ j + 1 ] & 0xFF;
+				sb.append( ( char ) ( ( ( a >>> 2 ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( ( ( a << 4 ) | ( b >>> 4 ) ) & 0x3F ) + 32 ) );
+				sb.append( ( char ) ( ( ( b << 2 ) & 0x3F ) + 32 ) );
+			}
+
+			i += chunkLen;
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * Decodes a Unix UUencoded string back into a byte array.
+	 * <p>
+	 * This reverses the encoding performed by {@link #uuEncode(byte[])}.
+	 * The input must be properly formatted UUencode data with length characters
+	 * and terminated by a backtick character.
+	 *
+	 * @param encoded The UUencoded string
+	 *
+	 * @return The decoded byte array
+	 */
+	public static byte[] uuDecode( String encoded ) {
+		if ( encoded == null || encoded.isEmpty() || encoded.equals( "`" ) ) {
+			return new byte[ 0 ];
+		}
+
+		ByteArrayOutputStream	out	= new ByteArrayOutputStream();
+		int						pos	= 0;
+
+		while ( pos < encoded.length() ) {
+			char	lengthChar	= encoded.charAt( pos++ );
+			int		chunkLen	= lengthChar - 32;
+
+			// Space (32) means zero length / end-of-data
+			if ( chunkLen == 0 ) {
+				break;
+			}
+
+			if ( chunkLen < 0 || chunkLen > 45 ) {
+				throw new BoxRuntimeException( "Invalid UUencode length character: " + ( int ) lengthChar );
+			}
+
+			// Number of encoded characters for this chunk: ceil(bytes * 4 / 3)
+			int	encodedLen	= ( chunkLen * 4 + 2 ) / 3;
+			int	chunkEnd	= pos + encodedLen;
+			int	decoded		= 0;
+
+			while ( decoded < chunkLen ) {
+				// Read 4 encoded chars, each offset by 32
+				int	c1	= encoded.charAt( pos++ ) - 32;
+				int	c2	= encoded.charAt( pos++ ) - 32;
+				int	c3	= ( pos < chunkEnd ) ? encoded.charAt( pos++ ) - 32 : 0;
+				int	c4	= ( pos < chunkEnd ) ? encoded.charAt( pos++ ) - 32 : 0;
+
+				// Validate characters are in range
+				if ( c1 < 0 || c1 > 63 || c2 < 0 || c2 > 63 ) {
+					throw new BoxRuntimeException( "Invalid UUencoded character" );
+				}
+
+				out.write( ( ( c1 << 2 ) | ( c2 >>> 4 ) ) & 0xFF );
+				decoded++;
+
+				if ( decoded < chunkLen ) {
+					if ( c3 < 0 || c3 > 63 ) {
+						throw new BoxRuntimeException( "Invalid UUencoded character" );
+					}
+					out.write( ( ( c2 << 4 ) | ( c3 >>> 2 ) ) & 0xFF );
+					decoded++;
+				}
+
+				if ( decoded < chunkLen ) {
+					if ( c4 < 0 || c4 > 63 ) {
+						throw new BoxRuntimeException( "Invalid UUencoded character" );
+					}
+					out.write( ( ( c3 << 6 ) | c4 ) & 0xFF );
+					decoded++;
+				}
+			}
+		}
+
+		return out.toByteArray();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -91,22 +92,39 @@ public final class LocalizationUtil {
 	private static final String															LOCALE_PATTERN_FORMATTER_PREFIX		= "locale_pattern_formatter_";
 
 	/**
+	 * Pre-built DateTimeFormatter for ISO dates with 24-hour hours and an AM/PM marker
+	 * (e.g. "2024-04-02 21:01:00 PM"). Parses HOUR_OF_DAY (0-23) and AMPM_OF_DAY as
+	 * independent fields - Java's standard "HH a" pattern is rejected because HH and
+	 * 'a' are mutually exclusive in DateTimeFormatter. The corresponding
+	 * {@link CommonFormatter} (see {@link #getCommonFormatters()}) supplies a validator
+	 * that enforces consistency rules (e.g. hour > 12 with AM is rejected).
+	 */
+	private static final DateTimeFormatter												ISO_24_HOUR_MERIDIAN_FORMATTER		= new DateTimeFormatterBuilder()
+	    .parseCaseInsensitive()
+	    .appendPattern( "yyyy-MM-dd " )
+	    .appendValue( ChronoField.HOUR_OF_DAY, 2 )
+	    .appendPattern( ":mm:ss " )
+	    .appendPattern( "a" )
+	    .toFormatter( Locale.US );
+
+	/**
 	 * A wrapper class that combines a regex pattern with its corresponding DateTimeFormatter
 	 * for efficient pattern matching before attempting to parse.
 	 */
 	public static class CommonFormatter {
 
-		private final Pattern				pattern;
-		private final DateTimeFormatter		formatter;
-		private final String				description;
-		private final String				regexPattern;
-		private final String				datePattern;
-		private final TemporalQuery<?>[]	optimizedQueries;
+		private final Pattern										pattern;
+		private final DateTimeFormatter								formatter;
+		private final String										description;
+		private final String										regexPattern;
+		private final String										datePattern;
+		private final TemporalQuery<?>[]							optimizedQueries;
+		private final Function<TemporalAccessor, TemporalAccessor>	validator;
 
-		private static final Pattern		dateMatchPattern		= Pattern.compile( ".*[yMLdDjgEFwWu].*" );
-		private static final Pattern		timeMatchPattern		= Pattern.compile( ".*[HhKkmsSnA].*" );
-		private static final Pattern		timezoneMatchPattern	= Pattern.compile( ".*[zZVvXxOo].*" );
-		private static final Pattern		offsetMatchPattern		= Pattern.compile( ".*[XxZO].*" );
+		private static final Pattern								dateMatchPattern		= Pattern.compile( ".*[yMLdDjgEFwWu].*" );
+		private static final Pattern								timeMatchPattern		= Pattern.compile( ".*[HhKkmsSnA].*" );
+		private static final Pattern								timezoneMatchPattern	= Pattern.compile( ".*[zZVvXxOo].*" );
+		private static final Pattern								offsetMatchPattern		= Pattern.compile( ".*[XxZO].*" );
 
 		public CommonFormatter( String regexPattern, String datePattern, String description ) {
 			this.regexPattern		= regexPattern;
@@ -115,6 +133,7 @@ public final class LocalizationUtil {
 			this.formatter			= LocalizationUtil.getPatternFormatter( datePattern, Locale.US );
 			this.description		= description;
 			this.optimizedQueries	= determineOptimalTemporalQueries( datePattern );
+			this.validator			= null;
 		}
 
 		/**
@@ -127,12 +146,31 @@ public final class LocalizationUtil {
 		 * @param description  a human-readable description of this formatter
 		 */
 		public CommonFormatter( String regexPattern, String datePattern, DateTimeFormatter formatter, String description ) {
+			this( regexPattern, datePattern, formatter, description, null );
+		}
+
+		/**
+		 * Constructor for cases where a pre-built DateTimeFormatter is required
+		 * AND a post-parse validator is needed to enforce domain-specific rules
+		 * (e.g. consistent AM/PM with a 24-hour hour value).
+		 *
+		 * @param regexPattern the regex used to identify matching input strings
+		 * @param datePattern  the date pattern string (used only for query determination)
+		 * @param formatter    the pre-built DateTimeFormatter to use for parsing
+		 * @param description  a human-readable description of this formatter
+		 * @param validator    optional post-parse validator; returns a (possibly adjusted)
+		 *                     TemporalAccessor to use, or {@code null} to signal that this
+		 *                     formatter should be skipped (caller will try the next one).
+		 */
+		public CommonFormatter( String regexPattern, String datePattern, DateTimeFormatter formatter, String description,
+		    Function<TemporalAccessor, TemporalAccessor> validator ) {
 			this.regexPattern		= regexPattern;
 			this.datePattern		= datePattern;
 			this.pattern			= Pattern.compile( regexPattern );
 			this.formatter			= formatter;
 			this.description		= description;
 			this.optimizedQueries	= determineOptimalTemporalQueries( datePattern );
+			this.validator			= validator;
 		}
 
 		public boolean matches( String input ) {
@@ -157,6 +195,23 @@ public final class LocalizationUtil {
 
 		public TemporalQuery<?>[] getOptimizedQueries() {
 			return this.optimizedQueries;
+		}
+
+		/**
+		 * Runs the optional post-parse validator on a parsed {@link TemporalAccessor}.
+		 * <p>
+		 * The default implementation is a no-op (returns the input unchanged). Formatters
+		 * that need to enforce domain-specific rules on the parsed result (e.g. ensuring
+		 * that an AM/PM marker is consistent with a 24-hour hour value) supply a custom
+		 * {@code validator} via the constructor.
+		 *
+		 * @param parsed the TemporalAccessor returned by {@link DateTimeFormatter#parseBest}
+		 *
+		 * @return the (possibly adjusted) TemporalAccessor to use, or {@code null} to signal
+		 *         that this formatter should be skipped (the caller will try the next one).
+		 */
+		public TemporalAccessor validateAndAdjust( TemporalAccessor parsed ) {
+			return this.validator == null ? parsed : this.validator.apply( parsed );
 		}
 
 		/**
@@ -1523,7 +1578,69 @@ public final class LocalizationUtil {
 		    "Month/year format with first-of-month assumption (12/2025 or 12-2025)"
 		) );
 
+		// ISO date with 24-hour hours and AM/PM marker (e.g. "2024-04-02 21:01:00 PM").
+		// Uses the pre-built ISO_24_HOUR_MERIDIAN_FORMATTER, which parses HOUR_OF_DAY (0-23)
+		// and AMPM_OF_DAY as independent fields. Hours 13-23 are matched by the regex; hours
+		// 1-12 are already handled by the 12-hour "yyyy-MM-dd h:mm:ss a" pattern earlier in
+		// the list. A validator enforces consistency: hours > 12 with AM are rejected, and
+		// hours 12 with AM are normalized to midnight (hour 0).
+		formatters.add( new CommonFormatter(
+		    "^\\d{4}-\\d{2}-\\d{2}\\s+(2[0-3]|1[3-9]):\\d{2}:\\d{2}\\s+[APap][Mm]$",
+		    "yyyy-MM-dd HH:mm:ss a",
+		    ISO_24_HOUR_MERIDIAN_FORMATTER,
+		    "ISO date with 24-hour hours (13-23) and AM/PM marker (validated)",
+		    LocalizationUtil::validateIsoWith24HourAndMeridian
+		) );
+
 		return formatters;
+	}
+
+	/**
+	 * Validator for ISO date strings with 24-hour hours and an AM/PM marker.
+	 * <p>
+	 * The parser produces a {@link TemporalAccessor} with both {@link ChronoField#HOUR_OF_DAY}
+	 * (0-23) and {@link ChronoField#AMPM_OF_DAY} (0=AM, 1=PM) populated. Rules enforced:
+	 * <ul>
+	 * <li>Hour 13-23 with AM: <b>reject</b> (return {@code null} to fall through to other formatters).</li>
+	 * <li>Hour 13-23 with PM: accept; rebuild as a {@link LocalDateTime} preserving the hour value.</li>
+	 * <li>Hour 12 with AM: accept and normalize to hour 0 (midnight).</li>
+	 * <li>Hour 12 with PM: accept; hour stays at 12 (noon).</li>
+	 * <li>Hour 0-11 with AM/PM: accept; hour value is preserved as-is (the value already matches the period).</li>
+	 * </ul>
+	 *
+	 * @param parsed the TemporalAccessor produced by the custom ISO 24-hour + meridian formatter
+	 *
+	 * @return a rebuilt {@link LocalDateTime} on success, or {@code null} if the input is rejected
+	 */
+	private static TemporalAccessor validateIsoWith24HourAndMeridian( TemporalAccessor parsed ) {
+		if ( !parsed.isSupported( ChronoField.HOUR_OF_DAY ) || !parsed.isSupported( ChronoField.AMPM_OF_DAY ) ) {
+			return null;
+		}
+		int	hourOfDay	= parsed.get( ChronoField.HOUR_OF_DAY );
+		int	amPm		= parsed.get( ChronoField.AMPM_OF_DAY );
+
+		// Reject hour > 12 with AM (inconsistent) - caller will try the next formatter.
+		if ( hourOfDay > 12 && amPm == 0 ) {
+			return null;
+		}
+
+		// Normalize hour 12 + AM to midnight (hour 0). Hour 12 + PM stays as 12 (noon).
+		// Hours 0-23 with PM are kept as-is; hours 0-12 with AM are kept as-is.
+		int finalHour;
+		if ( hourOfDay == 12 && amPm == 0 ) {
+			finalHour = 0;
+		} else {
+			finalHour = hourOfDay;
+		}
+
+		int	year	= parsed.get( ChronoField.YEAR );
+		int	month	= parsed.get( ChronoField.MONTH_OF_YEAR );
+		int	day		= parsed.get( ChronoField.DAY_OF_MONTH );
+		int	minute	= parsed.get( ChronoField.MINUTE_OF_HOUR );
+		int	second	= parsed.get( ChronoField.SECOND_OF_MINUTE );
+		int	nano	= parsed.isSupported( ChronoField.NANO_OF_SECOND ) ? parsed.get( ChronoField.NANO_OF_SECOND ) : 0;
+
+		return LocalDateTime.of( year, month, day, finalHour, minute, second, nano );
 	}
 
 	/**
@@ -1570,6 +1687,15 @@ public final class LocalizationUtil {
 					    dateTime,
 					    formatter.getOptimizedQueries()
 					);
+
+					// Run the optional post-parse validator. A formatter may return null
+					// (reject) or a different TemporalAccessor (e.g. a normalized LocalDateTime).
+					date = formatter.validateAndAdjust( date );
+					if ( date == null ) {
+						loggingService.getRuntimeLogger().trace(
+						    "Validation rejected date time for pattern [" + formatter.getDescription() + "]: " + dateTime );
+						continue;
+					}
 
 					// Parse timezone if not provided and date does not already contain timezone info
 					if ( timezone == null && ( ! ( date instanceof ZonedDateTime ) && ! ( date instanceof OffsetDateTime ) ) ) {

--- a/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/LocalizationUtil.java
@@ -1026,20 +1026,20 @@ public final class LocalizationUtil {
 				"description", "US date MM/dd/yyyy or MM-dd-yyyy with time and AM/PM no seconds"
 			) );
 
-			// US Short DateTime 24-hour with seconds (e.g., 02/04/2024 21:01:00, 01-31-2026 23:59:59)
+			// US Short DateTime 24-hour with seconds (e.g., 02/04/2024 21:01:00, 01-31-2026 23:59:59, 7/17/2025 00:00:00.000)
 			add( Map.of(
 				"regexPattern",
-				"^\\d{2}[-/]\\d{1,2}[-/]\\d{4}\\s+\\d{2}:\\d{2}:\\d{2}$",
-				"datePattern", "MM<-/>dd<-/>yyyy HH:mm:ss",
-				"description", "US date MM/dd/yyyy or MM-dd-yyyy with 24-hour time with seconds"
+				"^\\d{1,2}[-/]\\d{1,2}[-/]\\d{4}\\s+\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?$",
+				"datePattern", "M<-/>d<-/>yyyy HH:mm:ss[.SSS]",
+				"description", "US date M/d/yyyy or MM-dd-yyyy with 24-hour time with seconds and optional milliseconds"
 			) );
 
-			// US Short DateTime 24-hour no seconds (e.g., 02/04/2024 21:01)
+			// US Short DateTime 24-hour no seconds (e.g., 02/04/2024 21:01, 7/17/2025 00:00)
 			add( Map.of(
 				"regexPattern",
-				"^\\d{2}[-/]\\d{1,2}[-/]\\d{4}\\s+\\d{2}:\\d{2}$",
-				"datePattern", "MM<-/>dd<-/>yyyy HH:mm",
-				"description", "US date MM/dd/yyyy or MM-dd-yyyy with 24-hour time no seconds"
+				"^\\d{1,2}[-/]\\d{1,2}[-/]\\d{4}\\s+\\d{2}:\\d{2}$",
+				"datePattern", "M<-/>d<-/>yyyy HH:mm",
+				"description", "US date M/d/yyyy or MM-dd-yyyy with 24-hour time no seconds"
 			) );
 
 

--- a/src/main/java/ortus/boxlang/runtime/util/ZipUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/ZipUtil.java
@@ -37,6 +37,8 @@ import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.itadaki.bzip2.BZip2InputStream;
+import org.itadaki.bzip2.BZip2OutputStream;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -52,6 +54,9 @@ import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxIOException;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.util.BLCollector;
+import ortus.boxlang.runtime.util.jtar.TarEntry;
+import ortus.boxlang.runtime.util.jtar.TarInputStream;
+import ortus.boxlang.runtime.util.jtar.TarOutputStream;
 
 /**
  * This class provides zip utilities for the BoxLang runtime
@@ -61,7 +66,62 @@ public class ZipUtil {
 	// Create enum of valid compression methods: zip, gzip, tar, etc.
 	public enum COMPRESSION_FORMAT {
 		ZIP,
-		GZIP
+		GZIP,
+		TAR,
+		TGZ,
+		BZIP,
+		TBZ,
+		TBZ2
+	}
+
+	/**
+	 * Resolves an explicit archive format or detects it from a path extension.
+	 *
+	 * @param format The explicit format, or {@code null}
+	 * @param path   The archive path used for extension detection
+	 *
+	 * @return The resolved compression format
+	 *
+	 * @throws BoxRuntimeException If the format is unavailable or unsupported
+	 */
+	public static COMPRESSION_FORMAT detectFormat( String format, String path ) {
+		if ( format != null && !format.isBlank() ) {
+			String normalizedFormat = format.trim().toLowerCase();
+			if ( normalizedFormat.equals( "bz2" ) || normalizedFormat.equals( "bzip2" ) ) {
+				return COMPRESSION_FORMAT.BZIP;
+			}
+			if ( normalizedFormat.equals( "tar.bz" ) ) {
+				return COMPRESSION_FORMAT.TBZ;
+			}
+			if ( normalizedFormat.equals( "tar.gz" ) ) {
+				return COMPRESSION_FORMAT.TGZ;
+			}
+			try {
+				return COMPRESSION_FORMAT.valueOf( normalizedFormat.toUpperCase() );
+			} catch ( IllegalArgumentException e ) {
+				throw new BoxRuntimeException( "Unsupported compression format: [" + format + "]", e );
+			}
+		}
+		String lowerPath = path == null ? "" : path.trim().toLowerCase();
+		if ( lowerPath.endsWith( ".zip" ) ) {
+			return COMPRESSION_FORMAT.ZIP;
+		}
+		if ( lowerPath.endsWith( ".tgz" ) || lowerPath.endsWith( ".tar.gz" ) ) {
+			return COMPRESSION_FORMAT.TGZ;
+		}
+		if ( lowerPath.endsWith( ".tbz" ) || lowerPath.endsWith( ".tbz2" ) || lowerPath.endsWith( ".tar.bz" ) || lowerPath.endsWith( ".tar.bz2" ) ) {
+			return COMPRESSION_FORMAT.TBZ;
+		}
+		if ( lowerPath.endsWith( ".bz2" ) || lowerPath.endsWith( ".bz" ) || lowerPath.endsWith( ".bzip2" ) ) {
+			return COMPRESSION_FORMAT.BZIP;
+		}
+		if ( lowerPath.endsWith( ".gz" ) ) {
+			return COMPRESSION_FORMAT.GZIP;
+		}
+		if ( lowerPath.endsWith( ".tar" ) ) {
+			return COMPRESSION_FORMAT.TAR;
+		}
+		throw new BoxRuntimeException( "Unable to detect compression format from path: [" + path + "]. Specify the format explicitly." );
 	}
 
 	/**
@@ -122,9 +182,234 @@ public class ZipUtil {
 				return compressZip( Array.of( source ), destination, includeBaseFolder, overwrite, prefix, filter, recurse, zipCompressionLevel, context );
 			case GZIP :
 				return compressGzip( source, destination, includeBaseFolder, overwrite, zipCompressionLevel );
+			case TAR :
+				return compressTar( source, destination, includeBaseFolder, overwrite, filter, recurse, context, false );
+			case TGZ :
+				return compressTar( source, destination, includeBaseFolder, overwrite, filter, recurse, context, true );
+			case BZIP :
+				return compressBzip( source, destination, overwrite );
+			case TBZ :
+			case TBZ2 :
+				return compressTarBzip( source, destination, includeBaseFolder, overwrite, filter, recurse, context, format == COMPRESSION_FORMAT.TBZ );
 			default :
 				throw new BoxRuntimeException( "Unsupported compression format: [" + format + "]" );
 		}
+	}
+
+	/**
+	 * Compresses a file or directory into a bzip2-compressed TAR archive.
+	 *
+	 * @param source            The source file or directory
+	 * @param destination       The destination archive path
+	 * @param includeBaseFolder Whether to include the source directory as the archive root
+	 * @param overwrite         Whether to overwrite an existing archive
+	 * @param filter            A file-name filter
+	 * @param recurse           Whether to include nested directories
+	 * @param context           The BoxLang context used by function filters
+	 *
+	 * @return The absolute destination archive path
+	 */
+	private static String compressTarBzip(
+	    String source,
+	    String destination,
+	    Boolean includeBaseFolder,
+	    Boolean overwrite,
+	    Object filter,
+	    Boolean recurse,
+	    IBoxContext context,
+	    Boolean shortExtension ) {
+		Path	sourcePath		= ensurePath( source );
+		Path	destinationPath	= toPathWithExtension( destination, shortExtension ? ".tbz" : ".tbz2" );
+		if ( Files.exists( destinationPath ) && !overwrite ) {
+			throw new BoxRuntimeException( "Destination file already exists: [" + destination + "]" );
+		}
+		try ( BZip2OutputStream bzipOutputStream = new BZip2OutputStream( Files.newOutputStream( destinationPath ) );
+		    TarOutputStream tarOutputStream = new TarOutputStream( bzipOutputStream ) ) {
+			writeTarTree( sourcePath, destinationPath, includeBaseFolder, filter, recurse, context, tarOutputStream );
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error compressing TBZ2 file: [" + destination + "]", e );
+		}
+		return destinationPath.toString();
+	}
+
+	/**
+	 * Compresses a file or directory as a bzip2 stream.
+	 *
+	 * @param source      The source file or directory
+	 * @param destination The destination bzip2 file
+	 * @param overwrite   Whether to overwrite an existing destination
+	 *
+	 * @return The absolute destination path
+	 */
+	private static String compressBzip( String source, String destination, Boolean overwrite ) {
+		Path	sourcePath		= ensurePath( source );
+		Path	destinationPath	= toPathWithExtension( destination, ".bz2" );
+		if ( Files.exists( destinationPath ) && !overwrite ) {
+			throw new BoxRuntimeException( "Destination file already exists: [" + destination + "]" );
+		}
+		try ( BZip2OutputStream bzipOutputStream = new BZip2OutputStream( Files.newOutputStream( destinationPath ) ) ) {
+			Files.copy( sourcePath, bzipOutputStream );
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error compressing BZIP file: [" + destination + "]", e );
+		}
+		return destinationPath.toString();
+	}
+
+	/**
+	 * Writes all files and directories under a source path into a TAR stream.
+	 *
+	 * @param sourcePath        The source path
+	 * @param destinationPath   The archive path, which is skipped when inside the source
+	 * @param includeBaseFolder Whether to include the source directory name
+	 * @param filter            The archive entry filter
+	 * @param recurse           Whether to recurse into child directories
+	 * @param context           The BoxLang context
+	 * @param tarOutputStream   The destination TAR stream
+	 *
+	 * @throws IOException If an entry cannot be written
+	 */
+	private static void writeTarTree(
+	    Path sourcePath,
+	    Path destinationPath,
+	    Boolean includeBaseFolder,
+	    Object filter,
+	    Boolean recurse,
+	    IBoxContext context,
+	    TarOutputStream tarOutputStream ) throws IOException {
+		Path basePath = includeBaseFolder ? sourcePath.getParent() : sourcePath;
+		Files.walkFileTree( sourcePath, new SimpleFileVisitor<>() {
+
+			@Override
+			public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException {
+				if ( file.toAbsolutePath().normalize().equals( destinationPath ) || !matchesArchiveFilter( basePath.relativize( file ), filter, context ) ) {
+					return FileVisitResult.CONTINUE;
+				}
+				writeTarEntry( tarOutputStream, file, basePath.relativize( file ) );
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult preVisitDirectory( Path directory, BasicFileAttributes attrs ) throws IOException {
+				if ( !recurse && !directory.equals( sourcePath ) ) {
+					return FileVisitResult.SKIP_SUBTREE;
+				}
+				if ( !directory.equals( sourcePath ) || includeBaseFolder ) {
+					writeTarEntry( tarOutputStream, directory, basePath.relativize( directory ) );
+				}
+				return FileVisitResult.CONTINUE;
+			}
+		} );
+	}
+
+	/**
+	 * Compresses a file or directory into a raw TAR or gzip-compressed TAR archive.
+	 *
+	 * @param source            The source file or directory
+	 * @param destination       The destination archive path
+	 * @param includeBaseFolder Whether to include the source directory as the archive root
+	 * @param overwrite         Whether to overwrite an existing archive
+	 * @param filter            A file-name filter
+	 * @param recurse           Whether to include nested directories
+	 * @param context           The BoxLang context used by function filters
+	 * @param gzip              Whether to gzip-compress the TAR stream
+	 *
+	 * @return The absolute destination archive path
+	 */
+	private static String compressTar(
+	    String source,
+	    String destination,
+	    Boolean includeBaseFolder,
+	    Boolean overwrite,
+	    Object filter,
+	    Boolean recurse,
+	    IBoxContext context,
+	    Boolean gzip ) {
+		Path	sourcePath		= ensurePath( source );
+		String	extension		= gzip ? ".tgz" : ".tar";
+		Path	destinationPath	= toPathWithExtension( destination, extension );
+		if ( Files.exists( destinationPath ) && !overwrite ) {
+			throw new BoxRuntimeException( "Destination file already exists: [" + destination + "]" );
+		}
+		try {
+			if ( destinationPath.getParent() != null ) {
+				Files.createDirectories( destinationPath.getParent() );
+			}
+			OutputStream	fileOutputStream	= Files.newOutputStream( destinationPath );
+			OutputStream	archiveOutputStream	= gzip ? new GZIPOutputStream( fileOutputStream ) : fileOutputStream;
+			try ( TarOutputStream tarOutputStream = new TarOutputStream( archiveOutputStream ) ) {
+				Path basePath = includeBaseFolder ? sourcePath.getParent() : sourcePath;
+				Files.walkFileTree( sourcePath, new SimpleFileVisitor<>() {
+
+					@Override
+					public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException {
+						if ( file.toAbsolutePath().normalize().equals( destinationPath )
+						    || !matchesArchiveFilter( basePath.relativize( file ), filter, context ) ) {
+							return FileVisitResult.CONTINUE;
+						}
+						writeTarEntry( tarOutputStream, file, basePath.relativize( file ) );
+						return FileVisitResult.CONTINUE;
+					}
+
+					@Override
+					public FileVisitResult preVisitDirectory( Path directory, BasicFileAttributes attrs ) throws IOException {
+						if ( !recurse && !directory.equals( sourcePath ) ) {
+							return FileVisitResult.SKIP_SUBTREE;
+						}
+						if ( !directory.equals( sourcePath ) || includeBaseFolder ) {
+							writeTarEntry( tarOutputStream, directory, basePath.relativize( directory ) );
+						}
+						return FileVisitResult.CONTINUE;
+					}
+				} );
+			}
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error compressing TAR file: [" + destination + "]", e );
+		}
+		return destinationPath.toString();
+	}
+
+	/**
+	 * Writes one file or directory to a TAR output stream.
+	 *
+	 * @param tarOutputStream The TAR output stream
+	 * @param file            The source file or directory
+	 * @param relativePath    The archive-relative entry path
+	 *
+	 * @throws IOException If the entry cannot be written
+	 */
+	private static void writeTarEntry( TarOutputStream tarOutputStream, Path file, Path relativePath ) throws IOException {
+		String entryName = relativePath.toString().replace( '\\', '/' );
+		if ( Files.isDirectory( file ) && !entryName.endsWith( "/" ) ) {
+			entryName += "/";
+		}
+		TarEntry entry = new TarEntry( file.toFile(), entryName );
+		tarOutputStream.putNextEntry( entry );
+		if ( Files.isRegularFile( file ) ) {
+			Files.copy( file, tarOutputStream );
+		}
+	}
+
+	/**
+	 * Determines whether an archive-relative path passes the configured compression filter.
+	 *
+	 * @param relativePath The archive-relative path
+	 * @param filter       A string or BoxLang function filter
+	 * @param context      The BoxLang context used by function filters
+	 *
+	 * @return {@code true} when the path should be included
+	 */
+	private static boolean matchesArchiveFilter( Path relativePath, Object filter, IBoxContext context ) {
+		if ( filter == null ) {
+			return true;
+		}
+		String entryName = relativePath.toString().replace( '\\', '/' );
+		if ( filter instanceof String filterString ) {
+			return FileSystemUtil.fileMatchesPattern( filterString, Path.of( entryName ) );
+		}
+		if ( filter instanceof Function filterFunction ) {
+			return BooleanCaster.cast( context.invokeFunction( filterFunction, new Object[] { entryName } ) );
+		}
+		return true;
 	}
 
 	/**
@@ -403,8 +688,163 @@ public class ZipUtil {
 			case GZIP :
 				extractGZip( source, destination, overwrite );
 				break;
+			case TAR :
+				extractTar( source, destination, overwrite, recurse, filter, entryPaths, false );
+				break;
+			case TGZ :
+				extractTar( source, destination, overwrite, recurse, filter, entryPaths, true );
+				break;
+			case BZIP :
+				extractBzip( source, destination, overwrite );
+				break;
+			case TBZ :
+			case TBZ2 :
+				extractTarBzip( source, destination, overwrite, recurse, filter, entryPaths );
+				break;
 			default :
 				throw new BoxRuntimeException( "Unsupported compression format: [" + format + "]" );
+		}
+	}
+
+	/**
+	 * Extracts a bzip2-compressed TAR archive.
+	 *
+	 * @param source      The source archive path
+	 * @param destination The destination directory
+	 * @param overwrite   Whether to overwrite existing files
+	 * @param recurse     Whether to extract nested entries
+	 * @param filter      A string entry-name filter
+	 * @param entryPaths  Specific entry paths to extract
+	 */
+	private static void extractTarBzip(
+	    String source,
+	    String destination,
+	    Boolean overwrite,
+	    Boolean recurse,
+	    Object filter,
+	    Array entryPaths ) {
+		try ( BZip2InputStream bzipInputStream = new BZip2InputStream( Files.newInputStream( ensurePath( source ) ), false );
+		    TarInputStream tarInputStream = new TarInputStream( bzipInputStream ) ) {
+			Path destinationPath = Paths.get( destination ).normalize().toAbsolutePath();
+			Files.createDirectories( destinationPath );
+			extractTarEntries( tarInputStream, destinationPath, source, destination, overwrite, recurse, filter, entryPaths );
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error extracting TBZ2 file: [" + source + "] to destination: [" + destination + "]", e );
+		}
+	}
+
+	/**
+	 * Extracts a raw bzip2 stream to a destination directory.
+	 *
+	 * @param source      The source bzip2 file
+	 * @param destination The destination directory
+	 * @param overwrite   Whether to overwrite an existing output file
+	 */
+	private static void extractBzip( String source, String destination, Boolean overwrite ) {
+		Path	sourcePath		= ensurePath( source );
+		Path	destinationPath	= Paths.get( destination ).normalize().toAbsolutePath();
+		Path	targetPath		= destinationPath.resolve( sourcePath.getFileName().toString().replaceFirst( "(?i)\\.(bzip2|bz2|bz)$", "" ) );
+		try {
+			Files.createDirectories( destinationPath );
+			if ( Files.exists( targetPath ) && !overwrite ) {
+				throw new BoxRuntimeException( "Destination file already exists: [" + targetPath + "] and overwrite is not allowed." );
+			}
+			try ( BZip2InputStream bzipInputStream = new BZip2InputStream( Files.newInputStream( sourcePath ), false ) ) {
+				Files.copy( bzipInputStream, targetPath, StandardCopyOption.REPLACE_EXISTING );
+			}
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error extracting BZIP file: [" + source + "] to destination: [" + destination + "]", e );
+		}
+	}
+
+	/**
+	 * Extracts a raw TAR or gzip-compressed TAR archive with path traversal protection.
+	 *
+	 * @param source      The source archive path
+	 * @param destination The destination directory
+	 * @param overwrite   Whether to overwrite existing files
+	 * @param recurse     Whether to extract nested entries
+	 * @param filter      A string entry-name filter
+	 * @param entryPaths  Specific entry paths to extract
+	 * @param gzip        Whether the TAR stream is gzip-compressed
+	 */
+	private static void extractTar(
+	    String source,
+	    String destination,
+	    Boolean overwrite,
+	    Boolean recurse,
+	    Object filter,
+	    Array entryPaths,
+	    Boolean gzip ) {
+		Path	sourcePath		= ensurePath( source );
+		Path	destinationPath	= Paths.get( destination ).normalize().toAbsolutePath();
+		try {
+			Files.createDirectories( destinationPath );
+			InputStream	fileInputStream		= Files.newInputStream( sourcePath );
+			InputStream	archiveInputStream	= gzip ? new GZIPInputStream( fileInputStream ) : fileInputStream;
+			try ( TarInputStream tarInputStream = new TarInputStream( archiveInputStream ) ) {
+				extractTarEntries( tarInputStream, destinationPath, source, destination, overwrite, recurse, filter, entryPaths );
+			}
+		} catch ( IOException e ) {
+			throw new BoxRuntimeException( "Error extracting TAR file: [" + source + "] to destination: [" + destination + "]", e );
+		}
+	}
+
+	/**
+	 * Extracts entries from an already decompressed TAR stream.
+	 *
+	 * @param tarInputStream  The TAR input stream
+	 * @param destinationPath The normalized destination directory
+	 * @param source          The source archive path for diagnostics
+	 * @param destination     The destination path for diagnostics
+	 * @param overwrite       Whether to overwrite existing files
+	 * @param recurse         Whether to extract nested entries
+	 * @param filter          The entry filter
+	 * @param entryPaths      Specific entries to extract
+	 *
+	 * @throws IOException If an archive entry cannot be read or written
+	 */
+	private static void extractTarEntries(
+	    TarInputStream tarInputStream,
+	    Path destinationPath,
+	    String source,
+	    String destination,
+	    Boolean overwrite,
+	    Boolean recurse,
+	    Object filter,
+	    Array entryPaths ) throws IOException {
+		TarEntry entry;
+		while ( ( entry = tarInputStream.getNextEntry() ) != null ) {
+			String entryName = entry.getName();
+			if ( entryName == null || entryName.isBlank() || ( !recurse && entryName.contains( "/" ) ) ) {
+				continue;
+			}
+			if ( entry.isLink() ) {
+				logger.warn( "Skipping unsupported TAR link entry [{}]", entryName );
+				continue;
+			}
+			if ( filter != null && filter instanceof String filterString && !FileSystemUtil.fileMatchesPattern( filterString, Path.of( entryName ) ) ) {
+				continue;
+			}
+			if ( entryPaths != null && !entryPaths.isEmpty() && !entryPaths.contains( entryName ) ) {
+				continue;
+			}
+			Path targetPath = destinationPath.resolve( entryName ).normalize();
+			if ( !targetPath.startsWith( destinationPath ) ) {
+				logger.warn( "Tar Slip attack detected for entry [{}], skipping extraction", entryName );
+				continue;
+			}
+			if ( Files.exists( targetPath ) && !overwrite ) {
+				continue;
+			}
+			if ( entry.isDirectory() ) {
+				Files.createDirectories( targetPath );
+			} else {
+				if ( targetPath.getParent() != null ) {
+					Files.createDirectories( targetPath.getParent() );
+				}
+				Files.copy( tarInputStream, targetPath, StandardCopyOption.REPLACE_EXISTING );
+			}
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/util/ZipUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/ZipUtil.java
@@ -14,16 +14,15 @@
  */
 package ortus.boxlang.runtime.util;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.InputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.io.ByteArrayInputStream;
-import java.util.zip.InflaterInputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +33,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -156,7 +156,7 @@ public class ZipUtil {
 	    IBoxContext context ) {
 
 		// Prepare destination paths
-		final Path destinationFile = toPathWithExtension( destination, ".zip" );
+		final Path destinationFile = toPathWithExtension( destination, ".zip" ).toAbsolutePath().normalize();
 
 		// Verify destination does not exist
 		if ( destinationFile.toFile().exists() && !overwrite ) {
@@ -217,6 +217,11 @@ public class ZipUtil {
 
 							@Override
 							public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException {
+								// Skip the destination zip file if it's in the source directory
+								if ( file.toAbsolutePath().normalize().equals( destinationFile ) ) {
+									return FileVisitResult.CONTINUE;
+								}
+
 								Path	targetFile		= basePath.relativize( file.normalize() );  // Normalize the file path
 								String	zipEntryName	= finalPathPrefix + targetFile.toString().replace( "\\", "/" );
 

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/Octal.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/Octal.java
@@ -1,0 +1,104 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/** TAR numeric field encoding. */
+public final class Octal {
+
+	private static final long	OCTAL_MAX		= 8589934591L;
+	private static final byte	LARGE_NUM_MASK	= ( byte ) 0x80;
+
+	private Octal() {
+	}
+
+	/**
+	 * Parses an octal or POSIX base-256 field.
+	 * 
+	 * @param header The encoded TAR header
+	 * @param offset The field offset
+	 * @param length The field length
+	 * 
+	 * @return The decoded numeric value
+	 */
+	public static long parseOctal( byte[] header, int offset, int length ) {
+		if ( length == 12 && ( header[ offset ] & LARGE_NUM_MASK ) != 0 ) {
+			return ByteBuffer.wrap( header, offset + 4, 8 ).order( ByteOrder.BIG_ENDIAN ).getLong();
+		}
+		long	result	= 0;
+		boolean	padding	= true;
+		for ( int i = offset; i < offset + length; i++ ) {
+			byte value = header[ i ];
+			if ( value == 0 )
+				break;
+			if ( ( value == ' ' || value == '0' ) && padding )
+				continue;
+			if ( value == ' ' )
+				break;
+			padding	= false;
+			result	= ( result << 3 ) + value - '0';
+		}
+		return result;
+	}
+
+	/**
+	 * Writes an octal or POSIX base-256 field.
+	 * 
+	 * @param value  The numeric value
+	 * @param buffer The destination header buffer
+	 * @param offset The field offset
+	 * @param length The field length
+	 * 
+	 * @return The offset after the field
+	 */
+	public static int getOctalBytes( long value, byte[] buffer, int offset, int length ) {
+		if ( value > OCTAL_MAX && length == 12 ) {
+			buffer[ offset ] = LARGE_NUM_MASK;
+			ByteBuffer.wrap( buffer, offset + 4, 8 ).order( ByteOrder.BIG_ENDIAN ).putLong( value );
+			return offset + length;
+		}
+		int index = length - 1;
+		buffer[ offset + index-- ] = 0;
+		for ( long current = value; index >= 0; index-- ) {
+			buffer[ offset + index ]	= ( byte ) ( '0' + ( current & 7 ) );
+			current						>>= 3;
+		}
+		return offset + length;
+	}
+
+	/**
+	 * Writes a TAR checksum field.
+	 * 
+	 * @param value  The checksum value
+	 * @param buffer The destination header buffer
+	 * @param offset The field offset
+	 * @param length The field length
+	 * 
+	 * @return The offset after the field
+	 */
+	public static int getCheckSumOctalBytes( long value, byte[] buffer, int offset, int length ) {
+		getOctalBytes( value, buffer, offset, length - 1 );
+		buffer[ offset + length - 1 ] = ' ';
+		return offset + length;
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/PermissionUtils.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/PermissionUtils.java
@@ -1,0 +1,72 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Map;
+import java.util.Set;
+
+/** Resolves portable TAR permission modes from source files. */
+public final class PermissionUtils {
+
+	private static final Map<PosixFilePermission, Integer> POSIX_MODES = Map.of(
+	    PosixFilePermission.OWNER_READ, 0400,
+	    PosixFilePermission.OWNER_WRITE, 0200,
+	    PosixFilePermission.OWNER_EXECUTE, 0100,
+	    PosixFilePermission.GROUP_READ, 0040,
+	    PosixFilePermission.GROUP_WRITE, 0020,
+	    PosixFilePermission.GROUP_EXECUTE, 0010,
+	    PosixFilePermission.OTHERS_READ, 0004,
+	    PosixFilePermission.OTHERS_WRITE, 0002,
+	    PosixFilePermission.OTHERS_EXECUTE, 0001
+	);
+
+	private PermissionUtils() {
+	}
+
+	/**
+	 * Returns the source mode, preserving POSIX permissions when available and using a safe fallback otherwise.
+	 *
+	 * @param file The source file
+	 *
+	 * @return The TAR permission mode
+	 */
+	public static int permissions( File file ) {
+		if ( Files.getFileAttributeView( file.toPath(), java.nio.file.attribute.PosixFileAttributeView.class ) != null ) {
+			try {
+				Set<PosixFilePermission> permissions = Files.getPosixFilePermissions( file.toPath() );
+				return permissions.stream().mapToInt( permission -> POSIX_MODES.get( permission ) ).sum();
+			} catch ( Exception ignored ) {
+				// Fall through to the portable Java File fallback.
+			}
+		}
+		int mode = file.isDirectory() ? 0700 : 0600;
+		if ( file.canRead() )
+			mode |= file.isDirectory() ? 0100 : 0400;
+		if ( file.canWrite() )
+			mode |= file.isDirectory() ? 0100 : 0200;
+		if ( file.canExecute() )
+			mode |= 0111;
+		return mode;
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarConstants.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarConstants.java
@@ -1,0 +1,32 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+/** TAR stream block sizes. */
+public final class TarConstants {
+
+	public static final int	EOF_BLOCK		= 1024;
+	public static final int	DATA_BLOCK		= 512;
+	public static final int	HEADER_BLOCK	= 512;
+
+	private TarConstants() {
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarEntry.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarEntry.java
@@ -1,0 +1,189 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.io.File;
+import java.util.Date;
+
+/** TAR archive entry. */
+public class TarEntry {
+
+	protected File		file;
+	protected TarHeader	header;
+
+	/**
+	 * Creates an entry from a file and archive name.
+	 * 
+	 * @param file      The source file
+	 * @param entryName The archive entry name
+	 */
+	public TarEntry( File file, String entryName ) {
+		this.file = file;
+		this.extractTarHeader( entryName );
+	}
+
+	/**
+	 * Creates an entry from a TAR header buffer.
+	 * 
+	 * @param headerBuffer The encoded header
+	 */
+	public TarEntry( byte[] headerBuffer ) {
+		this.header = new TarHeader();
+		this.parseTarHeader( headerBuffer );
+	}
+
+	/**
+	 * Creates an entry from an existing header.
+	 * 
+	 * @param header The TAR header
+	 */
+	public TarEntry( TarHeader header ) {
+		this.header = header;
+	}
+
+	/** @return The logical archive entry name. */
+	public String getName() {
+		return header.namePrefix.length() == 0 ? header.name.toString() : header.namePrefix + "/" + header.name;
+	}
+
+	/**
+	 * Replaces the logical entry name after processing an extended TAR header.
+	 *
+	 * @param name The logical entry name
+	 */
+	public void setName( String name ) {
+		header.namePrefix	= new StringBuilder();
+		header.name			= new StringBuilder( name );
+	}
+
+	/**
+	 * Returns the TAR type flag.
+	 *
+	 * @return The TAR type flag
+	 */
+	public byte getTypeFlag() {
+		return header.typeflag;
+	}
+
+	/**
+	 * Returns the underlying TAR header.
+	 *
+	 * @return The TAR header
+	 */
+	public TarHeader getHeader() {
+		return header;
+	}
+
+	/** @return The source file, if present. */
+	public File getFile() {
+		return file;
+	}
+
+	/** @return The entry size in bytes. */
+	public long getSize() {
+		return header.size;
+	}
+
+	/** @param size The entry size in bytes. */
+	public void setSize( long size ) {
+		header.size = size;
+	}
+
+	/** @return Whether this entry is a directory. */
+	public boolean isDirectory() {
+		return header.typeflag == TarHeader.LF_DIR || header.name.toString().endsWith( "/" );
+	}
+
+	/** @return Whether this entry is a symbolic or hard link. */
+	public boolean isLink() {
+		return header.typeflag == TarHeader.LF_LINK || header.typeflag == TarHeader.LF_SYMLINK;
+	}
+
+	/** @param entryName The archive entry name. */
+	public void extractTarHeader( String entryName ) {
+		header = TarHeader.createHeader( entryName, file.length(), file.lastModified() / 1000, file.isDirectory(), PermissionUtils.permissions( file ) );
+	}
+
+	/** @param output The destination header buffer. */
+	public void writeEntryHeader( byte[] output ) {
+		int offset = 0;
+		offset	= TarHeader.getStringBytes( header.name, output, offset, TarHeader.NAMELEN );
+		offset	= Octal.getOctalBytes( header.mode, output, offset, TarHeader.MODELEN );
+		offset	= Octal.getOctalBytes( header.userId, output, offset, TarHeader.UIDLEN );
+		offset	= Octal.getOctalBytes( header.groupId, output, offset, TarHeader.GIDLEN );
+		offset	= Octal.getOctalBytes( header.size, output, offset, TarHeader.SIZELEN );
+		offset	= Octal.getOctalBytes( header.modTime, output, offset, TarHeader.MODTIMELEN );
+		int checksumOffset = offset;
+		for ( int i = 0; i < TarHeader.CHKSUMLEN; i++ )
+			output[ offset++ ] = ' ';
+		output[ offset++ ]	= header.typeflag;
+		offset				= TarHeader.getStringBytes( header.linkName, output, offset, TarHeader.NAMELEN );
+		offset				= TarHeader.getStringBytes( header.magic, output, offset, TarHeader.USTAR_MAGICLEN );
+		offset				= TarHeader.getStringBytes( header.userName, output, offset, TarHeader.USTAR_USER_NAMELEN );
+		offset				= TarHeader.getStringBytes( header.groupName, output, offset, TarHeader.USTAR_GROUP_NAMELEN );
+		offset				= Octal.getOctalBytes( header.devMajor, output, offset, TarHeader.USTAR_DEVLEN );
+		offset				= Octal.getOctalBytes( header.devMinor, output, offset, TarHeader.USTAR_DEVLEN );
+		TarHeader.getStringBytes( header.namePrefix, output, offset, TarHeader.USTAR_FILENAME_PREFIX );
+		long checksum = 0;
+		for ( byte value : output )
+			checksum += value & 0xFF;
+		Octal.getCheckSumOctalBytes( checksum, output, checksumOffset, TarHeader.CHKSUMLEN );
+	}
+
+	/** @param input The encoded header buffer. */
+	public void parseTarHeader( byte[] input ) {
+		int offset = 0;
+		header.name			= TarHeader.parseString( input, offset, TarHeader.NAMELEN );
+		offset				+= TarHeader.NAMELEN;
+		header.mode			= ( int ) Octal.parseOctal( input, offset, TarHeader.MODELEN );
+		offset				+= TarHeader.MODELEN;
+		header.userId		= ( int ) Octal.parseOctal( input, offset, TarHeader.UIDLEN );
+		offset				+= TarHeader.UIDLEN;
+		header.groupId		= ( int ) Octal.parseOctal( input, offset, TarHeader.GIDLEN );
+		offset				+= TarHeader.GIDLEN;
+		header.size			= Octal.parseOctal( input, offset, TarHeader.SIZELEN );
+		offset				+= TarHeader.SIZELEN;
+		header.modTime		= Octal.parseOctal( input, offset, TarHeader.MODTIMELEN );
+		offset				+= TarHeader.MODTIMELEN;
+		header.checkSum		= ( int ) Octal.parseOctal( input, offset, TarHeader.CHKSUMLEN );
+		offset				+= TarHeader.CHKSUMLEN;
+		header.typeflag		= input[ offset++ ];
+		header.linkName		= TarHeader.parseString( input, offset, TarHeader.NAMELEN );
+		offset				+= TarHeader.NAMELEN;
+		offset				+= TarHeader.USTAR_MAGICLEN + TarHeader.USTAR_USER_NAMELEN + TarHeader.USTAR_GROUP_NAMELEN + TarHeader.USTAR_DEVLEN * 2;
+		header.namePrefix	= TarHeader.parseString( input, offset, TarHeader.USTAR_FILENAME_PREFIX );
+	}
+
+	@Override
+	public boolean equals( Object object ) {
+		return object instanceof TarEntry && getName().equals( ( ( TarEntry ) object ).getName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getName().hashCode();
+	}
+
+	/** @return The entry modification time. */
+	public Date getModTime() {
+		return new Date( header.modTime * 1000 );
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarHeader.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarHeader.java
@@ -1,0 +1,101 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+/** TAR header representation. */
+public class TarHeader {
+
+	public static final int		NAMELEN			= 100, MODELEN = 8, UIDLEN = 8, GIDLEN = 8, SIZELEN = 12, MODTIMELEN = 12, CHKSUMLEN = 8;
+	public static final byte	LF_NORMAL		= '0', LF_LINK = '1', LF_SYMLINK = '2', LF_DIR = '5', LF_GNU_LONGNAME = 'L', LF_PAX_EXTENDED = 'x',
+	    LF_PAX_GLOBAL = 'g';
+	public static final String	USTAR_MAGIC		= "ustar  ";
+	public static final int		USTAR_MAGICLEN	= 8, USTAR_USER_NAMELEN = 32, USTAR_GROUP_NAMELEN = 32, USTAR_DEVLEN = 8, USTAR_FILENAME_PREFIX = 155;
+	public StringBuilder		name			= new StringBuilder(), linkName = new StringBuilder(), magic = new StringBuilder( USTAR_MAGIC );
+	public StringBuilder		userName		= new StringBuilder(), groupName = new StringBuilder(), namePrefix = new StringBuilder();
+	public int					mode, userId, groupId, checkSum, devMajor, devMinor;
+	public long					size, modTime;
+	public byte					typeflag;
+
+	/**
+	 * Parses a TAR string field.
+	 * 
+	 * @param header The encoded header
+	 * @param offset The field offset
+	 * @param length The field length
+	 * 
+	 * @return The decoded string
+	 */
+	public static StringBuilder parseString( byte[] header, int offset, int length ) {
+		int end = offset;
+		while ( end < offset + length && header[ end ] != 0 )
+			end++;
+		return new StringBuilder( new String( header, offset, end - offset, StandardCharsets.UTF_8 ) );
+	}
+
+	/**
+	 * Writes a TAR string field.
+	 * 
+	 * @param value  The value to write
+	 * @param buffer The destination buffer
+	 * @param offset The field offset
+	 * @param length The field length
+	 * 
+	 * @return The offset after the field
+	 */
+	public static int getStringBytes( StringBuilder value, byte[] buffer, int offset, int length ) {
+		byte[]	bytes	= value.toString().getBytes( StandardCharsets.UTF_8 );
+		int		count	= Math.min( bytes.length, length );
+		System.arraycopy( bytes, 0, buffer, offset, count );
+		for ( int i = count; i < length; i++ )
+			buffer[ offset + i ] = 0;
+		return offset + length;
+	}
+
+	/**
+	 * Creates a TAR header for a file or directory.
+	 * 
+	 * @param entryName   The archive entry name
+	 * @param size        The entry size
+	 * @param modTime     The modification time in seconds
+	 * @param directory   Whether the entry is a directory
+	 * @param permissions The TAR permission mode
+	 * 
+	 * @return The initialized TAR header
+	 */
+	public static TarHeader createHeader( String entryName, long size, long modTime, boolean directory, int permissions ) {
+		TarHeader	header	= new TarHeader();
+		String		name	= TarUtils.trim( entryName.replace( File.separatorChar, '/' ), '/' );
+		int			split	= name.length() > 100 ? name.lastIndexOf( '/' ) : -1;
+		if ( split > 0 ) {
+			header.namePrefix	= new StringBuilder( name.substring( 0, split ) );
+			name				= name.substring( split + 1 );
+		}
+		header.name		= new StringBuilder( name );
+		header.mode		= permissions;
+		header.typeflag	= directory ? LF_DIR : LF_NORMAL;
+		header.size		= directory ? 0 : size;
+		header.modTime	= modTime;
+		return header;
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarInputStream.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarInputStream.java
@@ -1,0 +1,248 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/** TAR input stream. */
+public class TarInputStream extends FilterInputStream {
+
+	private TarEntry	currentEntry;
+	private long		currentFileSize;
+	private long		bytesRead;
+	private boolean		defaultSkip;
+	private String		pendingName;
+
+	/** Creates a TAR input stream. */
+	public TarInputStream( InputStream input ) {
+		super( input );
+	}
+
+	/**
+	 * Reads one byte from the current TAR entry.
+	 *
+	 * @return The byte read, or {@code -1} at the end of the entry
+	 * 
+	 * @throws IOException If the underlying stream cannot be read
+	 */
+	@Override
+	public int read() throws IOException {
+		byte[] buffer = new byte[ 1 ];
+		return read( buffer, 0, 1 ) < 0 ? -1 : buffer[ 0 ] & 0xFF;
+	}
+
+	/**
+	 * Reads bytes from the current TAR entry, bounded by its declared size.
+	 *
+	 * @param buffer The destination buffer
+	 * @param offset The destination offset
+	 * @param length The maximum number of bytes to read
+	 * 
+	 * @return The number of bytes read, or {@code -1} at the end of the entry
+	 * 
+	 * @throws IOException If the underlying stream cannot be read
+	 */
+	@Override
+	public int read( byte[] buffer, int offset, int length ) throws IOException {
+		if ( currentEntry != null ) {
+			long remaining = currentEntry.getSize() - currentFileSize;
+			if ( remaining <= 0 )
+				return -1;
+			length = ( int ) Math.min( length, remaining );
+		}
+		int read = super.read( buffer, offset, length );
+		if ( read > 0 ) {
+			currentFileSize	+= currentEntry == null ? 0 : read;
+			bytesRead		+= read;
+		}
+		return read;
+	}
+
+	/**
+	 * Returns the next TAR entry, processing GNU long-name and PAX path records.
+	 *
+	 * @return The next entry, or {@code null} at the end of the archive
+	 * 
+	 * @throws IOException If the archive is malformed or cannot be read
+	 */
+	public TarEntry getNextEntry() throws IOException {
+		while ( true ) {
+			closeCurrentEntry();
+			byte[]	header	= new byte[ TarConstants.HEADER_BLOCK ];
+			int		offset	= 0;
+			while ( offset < header.length ) {
+				int read = super.read( header, offset, header.length - offset );
+				if ( read < 0 )
+					break;
+				offset		+= read;
+				bytesRead	+= read;
+			}
+			boolean empty = true;
+			for ( byte value : header ) {
+				if ( value != 0 ) {
+					empty = false;
+					break;
+				}
+			}
+			if ( empty )
+				return null;
+			currentEntry = new TarEntry( header );
+			if ( currentEntry.getTypeFlag() == TarHeader.LF_GNU_LONGNAME || currentEntry.getTypeFlag() == TarHeader.LF_PAX_EXTENDED
+			    || currentEntry.getTypeFlag() == TarHeader.LF_PAX_GLOBAL ) {
+				byte[] data = readCurrentEntryData();
+				if ( currentEntry.getTypeFlag() == TarHeader.LF_GNU_LONGNAME ) {
+					String	longName	= new String( data, StandardCharsets.UTF_8 );
+					int		terminator	= longName.indexOf( '\u0000' );
+					pendingName = terminator < 0 ? longName : longName.substring( 0, terminator );
+				} else if ( currentEntry.getTypeFlag() == TarHeader.LF_PAX_EXTENDED || currentEntry.getTypeFlag() == TarHeader.LF_PAX_GLOBAL ) {
+					String paxPath = parsePaxPath( new String( data, StandardCharsets.UTF_8 ) );
+					if ( paxPath != null )
+						pendingName = paxPath;
+				}
+				continue;
+			}
+			if ( pendingName != null ) {
+				currentEntry.setName( pendingName );
+				pendingName = null;
+			}
+			return currentEntry;
+		}
+	}
+
+	/**
+	 * Reads the complete current extended-header payload.
+	 *
+	 * @return The extended-header bytes
+	 * 
+	 * @throws IOException If the payload is truncated
+	 */
+	private byte[] readCurrentEntryData() throws IOException {
+		byte[]	data	= new byte[ ( int ) currentEntry.getSize() ];
+		int		offset	= 0;
+		while ( offset < data.length ) {
+			int read = read( data, offset, data.length - offset );
+			if ( read < 0 )
+				throw new IOException( "Unexpected end of TAR extended header" );
+			offset += read;
+		}
+		return data;
+	}
+
+	/**
+	 * Parses a length-prefixed PAX payload for its path attribute.
+	 *
+	 * @param data The decoded PAX payload
+	 * 
+	 * @return The PAX path, or {@code null} when absent or malformed
+	 */
+	private String parsePaxPath( String data ) {
+		int offset = 0;
+		while ( offset < data.length() ) {
+			int separator = data.indexOf( ' ', offset );
+			if ( separator < 0 )
+				break;
+			int recordLength;
+			try {
+				recordLength = Integer.parseInt( data.substring( offset, separator ) );
+			} catch ( NumberFormatException e ) {
+				break;
+			}
+			if ( recordLength <= 0 || offset + recordLength > data.length() )
+				break;
+			String record = data.substring( separator + 1, offset + recordLength );
+			if ( record.startsWith( "path=" ) )
+				return record.substring( 5 ).replaceFirst( "\\n$", "" );
+			offset += recordLength;
+		}
+		return null;
+	}
+
+	/**
+	 * Finishes the current entry and consumes its data padding.
+	 *
+	 * @throws IOException If the entry is truncated
+	 */
+	private void closeCurrentEntry() throws IOException {
+		if ( currentEntry == null )
+			return;
+		long remaining = currentEntry.getSize() - currentFileSize;
+		while ( remaining > 0 ) {
+			long skipped = skip( remaining );
+			if ( skipped <= 0 )
+				throw new IOException( "Possible tar file corruption" );
+			remaining -= skipped;
+		}
+		currentEntry	= null;
+		currentFileSize	= 0;
+		long padding = ( TarConstants.DATA_BLOCK - bytesRead % TarConstants.DATA_BLOCK ) % TarConstants.DATA_BLOCK;
+		if ( padding > 0 )
+			skip( padding );
+	}
+
+	/**
+	 * Skips bytes in the current entry or underlying TAR stream.
+	 *
+	 * @param count The number of bytes to skip
+	 * 
+	 * @return The number of bytes skipped
+	 * 
+	 * @throws IOException If the underlying stream cannot be skipped
+	 */
+	@Override
+	public long skip( long count ) throws IOException {
+		if ( defaultSkip ) {
+			long skipped = super.skip( count );
+			bytesRead += skipped;
+			return skipped;
+		}
+		long	left	= count;
+		byte[]	buffer	= new byte[ 2048 ];
+		while ( left > 0 ) {
+			int read = read( buffer, 0, ( int ) Math.min( left, buffer.length ) );
+			if ( read < 0 )
+				break;
+			left -= read;
+		}
+		return count - left;
+	}
+
+	/**
+	 * Returns the number of bytes consumed from the underlying TAR stream.
+	 *
+	 * @return The current stream offset in bytes
+	 */
+	public long getCurrentOffset() {
+		return bytesRead;
+	}
+
+	/** Enables the underlying stream skip behavior. */
+	public void setDefaultSkip( boolean value ) {
+		defaultSkip = value;
+	}
+
+	/** Returns whether underlying skip behavior is enabled. */
+	public boolean isDefaultSkip() {
+		return defaultSkip;
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarOutputStream.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarOutputStream.java
@@ -1,0 +1,138 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/** TAR output stream. */
+public class TarOutputStream extends OutputStream {
+
+	private final OutputStream	output;
+	private long				bytesWritten;
+	private long				currentFileSize;
+	private TarEntry			currentEntry;
+
+	/** Creates a TAR output stream. */
+	public TarOutputStream( OutputStream output ) {
+		this.output = output;
+	}
+
+	/**
+	 * Writes the next entry header and selects it as the current entry.
+	 *
+	 * @param entry The entry to write
+	 * 
+	 * @throws IOException If the previous entry is incomplete or the header cannot be written
+	 */
+	public void putNextEntry( TarEntry entry ) throws IOException {
+		closeCurrentEntry();
+		byte[] entryName = entry.getName().getBytes( StandardCharsets.UTF_8 );
+		if ( entryName.length > TarHeader.NAMELEN + TarHeader.USTAR_FILENAME_PREFIX || entry.getName()
+		    .substring( Math.max( 0, entry.getName().lastIndexOf( '/' ) + 1 ) ).getBytes( StandardCharsets.UTF_8 ).length > TarHeader.NAMELEN ) {
+			writeLongNameEntry( entryName );
+		}
+		writeEntryHeader( entry );
+	}
+
+	/** Writes one normal TAR entry header and selects it as current. */
+	private void writeEntryHeader( TarEntry entry ) throws IOException {
+		byte[] header = new byte[ TarConstants.HEADER_BLOCK ];
+		entry.writeEntryHeader( header );
+		write( header );
+		currentEntry = entry;
+	}
+
+	/** Writes a GNU long-name metadata entry. */
+	private void writeLongNameEntry( byte[] entryName ) throws IOException {
+		TarHeader longNameHeader = TarHeader.createHeader( "././@LongLink", entryName.length + 1L, 0, false, 0644 );
+		longNameHeader.typeflag = TarHeader.LF_GNU_LONGNAME;
+		TarEntry longNameEntry = new TarEntry( longNameHeader );
+		writeEntryHeader( longNameEntry );
+		write( entryName );
+		write( 0 );
+		closeCurrentEntry();
+	}
+
+	/**
+	 * Writes one byte to the underlying TAR stream.
+	 *
+	 * @param value The byte value
+	 * 
+	 * @throws IOException If the underlying stream cannot be written
+	 */
+	@Override
+	public void write( int value ) throws IOException {
+		output.write( value );
+		bytesWritten++;
+		if ( currentEntry != null )
+			currentFileSize++;
+	}
+
+	/**
+	 * Writes bytes to the current TAR entry.
+	 *
+	 * @param buffer The source buffer
+	 * @param offset The source offset
+	 * @param length The number of bytes to write
+	 * 
+	 * @throws IOException If the entry size is exceeded or the stream cannot be written
+	 */
+	@Override
+	public void write( byte[] buffer, int offset, int length ) throws IOException {
+		if ( currentEntry != null && currentFileSize + length > currentEntry.getSize() )
+			throw new IOException( "TAR entry exceeds declared size" );
+		output.write( buffer, offset, length );
+		bytesWritten += length;
+		if ( currentEntry != null )
+			currentFileSize += length;
+	}
+
+	/**
+	 * Completes the current entry and writes record padding.
+	 *
+	 * @throws IOException If the current entry is incomplete
+	 */
+	private void closeCurrentEntry() throws IOException {
+		if ( currentEntry == null )
+			return;
+		if ( currentFileSize < currentEntry.getSize() )
+			throw new IOException( "TAR entry was not fully written" );
+		currentEntry	= null;
+		currentFileSize	= 0;
+		int padding = ( int ) ( ( TarConstants.DATA_BLOCK - bytesWritten % TarConstants.DATA_BLOCK ) % TarConstants.DATA_BLOCK );
+		if ( padding > 0 )
+			write( new byte[ padding ] );
+	}
+
+	/**
+	 * Writes the TAR end markers and closes the underlying stream.
+	 *
+	 * @throws IOException If the stream cannot be closed
+	 */
+	@Override
+	public void close() throws IOException {
+		closeCurrentEntry();
+		output.write( new byte[ TarConstants.EOF_BLOCK ] );
+		output.close();
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/util/jtar/TarUtils.java
+++ b/src/main/java/ortus/boxlang/runtime/util/jtar/TarUtils.java
@@ -1,0 +1,46 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Vendored and adapted from https://github.com/xiaoxindada/jtar.
+ * Original JTar copyright 2012 Kamran Zafar; Apache License 2.0.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+/** TAR utility methods. */
+public final class TarUtils {
+
+	private TarUtils() {
+	}
+
+	/**
+	 * Trims a character from both ends of a string.
+	 * 
+	 * @param value     The source value
+	 * @param character The character to remove
+	 * 
+	 * @return The trimmed value
+	 */
+	public static String trim( String value, char character ) {
+		int	start	= 0;
+		int	end		= value.length();
+		while ( start < end && value.charAt( start ) == character )
+			start++;
+		while ( end > start && value.charAt( end - 1 ) == character )
+			end--;
+		return value.substring( start, end );
+	}
+}

--- a/src/main/java/ortus/boxlang/runtime/validation/Validator.java
+++ b/src/main/java/ortus/boxlang/runtime/validation/Validator.java
@@ -29,6 +29,7 @@ import ortus.boxlang.runtime.validation.dynamic.MaxLength;
 import ortus.boxlang.runtime.validation.dynamic.Min;
 import ortus.boxlang.runtime.validation.dynamic.MinLength;
 import ortus.boxlang.runtime.validation.dynamic.Requires;
+import ortus.boxlang.runtime.validation.dynamic.RequiresOneOf;
 import ortus.boxlang.runtime.validation.dynamic.TypeOneOf;
 import ortus.boxlang.runtime.validation.dynamic.ValueOneOf;
 import ortus.boxlang.runtime.validation.dynamic.ValueRequires;
@@ -117,6 +118,17 @@ public interface Validator {
 	 */
 	public static Validator requires( Key... recordNames ) {
 		return new Requires( Set.of( recordNames ) );
+	}
+
+	/**
+	 * Builder method to create a RequiresOneOf validator
+	 *
+	 * @param recordNames The names of the records where at least one is required if this record is present
+	 *
+	 * @return The RequiresOneOf validator
+	 */
+	public static Validator requiresOneOf( Key... recordNames ) {
+		return new RequiresOneOf( Set.of( recordNames ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/validation/dynamic/RequiresOneOf.java
+++ b/src/main/java/ortus/boxlang/runtime/validation/dynamic/RequiresOneOf.java
@@ -1,0 +1,56 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.validation.dynamic;
+
+import java.util.Set;
+
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
+import ortus.boxlang.runtime.validation.Validatable;
+import ortus.boxlang.runtime.validation.Validator;
+
+/**
+ * If this record is present, ensure that the required records are also present
+ */
+public class RequiresOneOf implements Validator {
+
+	private Set<Key> recordNames;
+
+	public RequiresOneOf( Set<Key> recordNames ) {
+		this.recordNames = recordNames;
+	}
+
+	public void validate( IBoxContext context, Key caller, Validatable record, IStruct records ) {
+		if ( records.containsKey( record.name() ) ) {
+			boolean foundOne = false;
+			for ( Key required : recordNames ) {
+				if ( records.containsKey( required ) ) {
+					foundOne = true;
+					break;
+				}
+			}
+			if ( !foundOne ) {
+				String missingRecordsString = String.join( ", ", recordNames.stream().map( Key::getName ).toList() );
+				throw new BoxValidationException( caller, record, "requires at least one of the following records to be present: " + missingRecordsString );
+			}
+		}
+	}
+
+}

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -6949,4 +6949,27 @@ public class CoreLangTest {
 		    context, BoxSourceType.CFSCRIPT );
 		assertThat( variables.get( result ) ).isEqualTo( "brad" );
 	}
+
+	@Test
+	public void testNullLiterals() {
+		instance.executeSource(
+		    """
+		    assert null == null : "Expected true"
+		    assert null EQ null : "Expected true"
+		    assert null === null : "Expected true"
+		    assert null IS null : "Expected true"
+
+		    foo = null;
+		    assert foo == null;
+		    assert foo EQ null;
+		    assert foo === null;
+		    assert foo IS null;
+		    foo = "brafd";
+		    assert foo != null;
+		    assert foo NEQ null;
+		    assert foo !== null;
+		                         """,
+		    context );
+	}
+
 }

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -6889,4 +6889,50 @@ public class CoreLangTest {
 		    TimeUnit.NANOSECONDS.toMillis( bridgeElapsed ) );
 	}
 
+	@Test
+	public void testAssertInSwitch() {
+		instance.executeSource(
+		    """
+		      switch ( "sdf" ) {
+		    case "sdf" :
+		    	assert true;
+		        }
+		             """,
+		    context );
+	}
+
+	@Test
+	public void testRethrowInSwitch() {
+		BoxRuntimeException e = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    try {
+		    	1/0;
+		    } catch( e ) {
+		         switch ( "sdf" ) {
+		         	default:
+		         	rethrow;
+		           }
+		    }
+		                """,
+		    context ) );
+		assertThat( e.getMessage() ).contains( "zero" );
+	}
+
+	@Test
+	public void testRethrowInSwitchCF() {
+		BoxRuntimeException e = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    try {
+		    	1/0;
+		    } catch( e ) {
+		         switch ( "sdf" ) {
+		         	default:
+		         	rethrow;
+		        }
+		    }
+		                """,
+		    context, BoxSourceType.CFSCRIPT ) );
+		assertThat( e.getMessage() ).contains( "zero" );
+	}
+
 }

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -6935,4 +6935,18 @@ public class CoreLangTest {
 		assertThat( e.getMessage() ).contains( "zero" );
 	}
 
+	@Test
+	public void testCanSetExtendedInfo() {
+		instance.executeSource(
+		    """
+		    try {
+		    	1/0
+		    } catch(e){
+		    	e.extendedInfo = "brad"
+		    	result = e.extendedInfo
+		    }
+		                  """,
+		    context, BoxSourceType.CFSCRIPT );
+		assertThat( variables.get( result ) ).isEqualTo( "brad" );
+	}
 }

--- a/src/test/java/TestCases/phase1/CoreLangTest.java
+++ b/src/test/java/TestCases/phase1/CoreLangTest.java
@@ -6972,4 +6972,29 @@ public class CoreLangTest {
 		    context );
 	}
 
+	@Test
+	public void testOverrideDefaultMethodInProxy() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			request.onOpenInvoked = false;
+
+			class MyListener {
+				public void function onOpen( WebSocket webSocket ) {
+					request.onOpenInvoked = true;
+				}
+			}
+			listener = createDynamicProxy(
+				new MyListener(),
+				[ "java.net.http.WebSocket$Listener" ]
+			);
+
+			listener.onOpen( javaCast( "null", "" ) );
+			variables.result = request.onOpenInvoked;
+		                               """,
+		    context );
+		// @formatter:on
+		assertThat( variables.get( result ) ).isEqualTo( true );
+	}
+
 }

--- a/src/test/java/TestCases/phase1/OperatorsTest.java
+++ b/src/test/java/TestCases/phase1/OperatorsTest.java
@@ -108,7 +108,7 @@ public class OperatorsTest {
 		result = ( Number ) instance.executeStatement( "'5'+'2'", context );
 		assertThat( result.doubleValue() ).isEqualTo( 7 );
 
-		Number	leftDate	= NumberCaster.cast( true, "1/2/2026" );
+		Number	leftDate	= NumberCaster.cast( true, true, "1/2/2026" );
 		Number	dateResult	= ( Number ) instance.executeStatement( "'1/2/2026'+5", context );
 		assertThat( dateResult.doubleValue() ).isWithin( 0.0000001D ).of( leftDate.doubleValue() + 5D );
 	}
@@ -159,8 +159,8 @@ public class OperatorsTest {
 		Number result = ( Number ) instance.executeStatement( "10/5", context );
 		assertThat( result.doubleValue() ).isEqualTo( 2 );
 
-		Number	leftDate	= NumberCaster.cast( true, "1/2/2026" );
-		Number	rightDate	= NumberCaster.cast( true, "1/1/2026" );
+		Number	leftDate	= NumberCaster.cast( true, true, "1/2/2026" );
+		Number	rightDate	= NumberCaster.cast( true, true, "1/1/2026" );
 		Number	dateResult	= ( Number ) instance.executeStatement( "'1/2/2026'/'1/1/2026'", context );
 		assertThat( dateResult.doubleValue() ).isWithin( 0.0000001D ).of( leftDate.doubleValue() / rightDate.doubleValue() );
 	}
@@ -178,8 +178,8 @@ public class OperatorsTest {
 		Number result = ( Number ) instance.executeStatement( "10*5", context );
 		assertThat( result.doubleValue() ).isEqualTo( 50 );
 
-		Number	leftDate	= NumberCaster.cast( true, "1/2/2026" );
-		Number	rightDate	= NumberCaster.cast( true, "1/1/2026" );
+		Number	leftDate	= NumberCaster.cast( true, true, "1/2/2026" );
+		Number	rightDate	= NumberCaster.cast( true, true, "1/1/2026" );
 		Number	dateResult	= ( Number ) instance.executeStatement( "'1/2/2026'*'1/1/2026'", context );
 		assertThat( dateResult.doubleValue() ).isWithin( 0.0000001D ).of( leftDate.doubleValue() * rightDate.doubleValue() );
 	}

--- a/src/test/java/TestCases/phase2/ClosureFunctionTest.java
+++ b/src/test/java/TestCases/phase2/ClosureFunctionTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.BaseBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.Referencer;
@@ -745,4 +746,35 @@ public class ClosureFunctionTest {
 
 	}
 
+	@DisplayName( "test lexical binding" )
+	@Test
+	public void testLexicalBinding() {
+
+		BaseBoxContext.nullIsUndefined = true;
+		try {
+			instance.executeSource(
+			    """
+			    function foo() {
+			    	var x = 42;
+
+			    	return () => {
+			    		// here, bar has non-lexical access to `x`
+			    		return bar()
+			    	}
+			    }
+
+			    function bar() {
+			    	return (x) => x ?: "undefined" // can climb into caller's captures
+			    }
+
+			    // lucee: 42, boxlang: 42
+			    result = foo()()();
+			        """,
+			    context );
+		} finally {
+			BaseBoxContext.nullIsUndefined = false;
+		}
+		assertThat( variables.get( result ) ).isEqualTo( "undefined" );
+
+	}
 }

--- a/src/test/java/TestCases/phase2/QueryTest.java
+++ b/src/test/java/TestCases/phase2/QueryTest.java
@@ -380,4 +380,24 @@ public class QueryTest {
 		assertThat( singleColMeta.getAsString( Key.type ) ).isEqualTo( "string" );
 	}
 
+	@Test
+	public void testCompatFindColumn() {
+
+		instance.executeSource(
+		    """
+		    myQuery = queryNew("id,name,role", "double,VarChar,VarChar");
+		    idPos = myQuery.findColumn( "id" )
+		    namePos =  myQuery.findColumn( "name" )
+		    rolePos = myQuery.findColumn( "role" )
+		    invalidPos = myQuery.findColumn( "invalid" )
+
+		                         """,
+		    context, BoxSourceType.BOXSCRIPT );
+		assertThat( variables.get( Key.of( "idPos" ) ) ).isEqualTo( 1 );
+		assertThat( variables.get( Key.of( "namePos" ) ) ).isEqualTo( 2 );
+		assertThat( variables.get( Key.of( "rolePos" ) ) ).isEqualTo( 3 );
+		assertThat( variables.get( Key.of( "invalidPos" ) ) ).isEqualTo( 0 );
+
+	}
+
 }

--- a/src/test/java/TestCases/phase3/ApplicationTest.java
+++ b/src/test/java/TestCases/phase3/ApplicationTest.java
@@ -19,8 +19,11 @@ package TestCases.phase3;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.AfterEach;
@@ -268,6 +271,133 @@ public class ApplicationTest {
 
 		ApplicationBoxContext	appContext	= context.getParentOfType( ApplicationBoxContext.class );
 		Application				app			= appContext.getApplication();
+		assertThat( app.getClassLoaderCount() ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "Reload java settings jar when reloadOnChange is enabled" )
+	@Test
+	public void testJavaSettingsReloadOnChange() throws Exception {
+		Path	sourceJar		= Path.of( "src/test/resources/libs/helloworld.jar" ).toAbsolutePath();
+		Path	tempDirectory	= Files.createTempDirectory( "boxlang-java-settings-" );
+		Path	targetJar		= tempDirectory.resolve( "helloworld.jar" );
+		Files.copy( sourceJar, targetJar, StandardCopyOption.REPLACE_EXISTING );
+
+		try {
+			String jarPath = targetJar.toString().replace( "\\", "/" );
+			instance.executeSource(
+			    "bx:application name=\"reloadOnChangeApp\" javaSettings={ loadPaths=[\"" + jarPath + "\"], reloadOnChange=true };",
+			    context );
+
+			RequestBoxContext	requestContext		= context.getRequestContext();
+			ClassLoader			firstClassLoader	= requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+			Application			app					= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+
+			Files.copy( sourceJar, targetJar, StandardCopyOption.REPLACE_EXISTING );
+			Files.setLastModifiedTime( targetJar, java.nio.file.attribute.FileTime.from( Instant.now().plusSeconds( 2 ) ) );
+
+			instance.executeSource(
+			    "bx:application name=\"reloadOnChangeApp\" javaSettings={ loadPaths=[\"" + jarPath + "\"], reloadOnChange=true };",
+			    context );
+
+			ClassLoader secondClassLoader = requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+			assertThat( secondClassLoader ).isNotSameInstanceAs( firstClassLoader );
+			assertThat( app.getClassLoaderCount() ).isEqualTo( 1 );
+			assertThat( app.getClassLoaders().containsValue( firstClassLoader ) ).isFalse();
+		} finally {
+			Files.deleteIfExists( targetJar );
+			Files.deleteIfExists( tempDirectory );
+		}
+	}
+
+	@DisplayName( "Do not reload java settings jar when reloadOnChange is disabled" )
+	@Test
+	public void testJavaSettingsNoReloadOnChange() throws Exception {
+		Path	sourceJar		= Path.of( "src/test/resources/libs/helloworld.jar" ).toAbsolutePath();
+		Path	tempDirectory	= Files.createTempDirectory( "boxlang-java-settings-" );
+		Path	targetJar		= tempDirectory.resolve( "helloworld.jar" );
+		Files.copy( sourceJar, targetJar, StandardCopyOption.REPLACE_EXISTING );
+
+		try {
+			String jarPath = targetJar.toString().replace( "\\", "/" );
+			instance.executeSource(
+			    "bx:application name=\"noReloadOnChangeApp\" javaSettings={ loadPaths=[\"" + jarPath + "\"], reloadOnChange=false };",
+			    context );
+
+			RequestBoxContext	requestContext		= context.getRequestContext();
+			ClassLoader			firstClassLoader	= requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+			Application			app					= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+
+			Files.copy( sourceJar, targetJar, StandardCopyOption.REPLACE_EXISTING );
+			Files.setLastModifiedTime( targetJar, java.nio.file.attribute.FileTime.from( Instant.now().plusSeconds( 2 ) ) );
+
+			instance.executeSource(
+			    "bx:application name=\"noReloadOnChangeApp\" javaSettings={ loadPaths=[\"" + jarPath + "\"], reloadOnChange=false };",
+			    context );
+
+			ClassLoader secondClassLoader = requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+			assertThat( secondClassLoader ).isSameInstanceAs( firstClassLoader );
+			assertThat( app.getClassLoaderCount() ).isEqualTo( 1 );
+		} finally {
+			Files.deleteIfExists( targetJar );
+			Files.deleteIfExists( tempDirectory );
+		}
+	}
+
+	@DisplayName( "Add a java settings jar during an application update" )
+	@Test
+	public void testJavaSettingsAddJar() throws Exception {
+		Path	helloWorldJar	= Path.of( "src/test/resources/libs/helloworld.jar" ).toAbsolutePath();
+		Path	caffeineJar		= Path.of( "src/test/resources/libs/caffeine-3.1.8.jar" ).toAbsolutePath();
+		String	helloWorldPath	= helloWorldJar.toString().replace( "\\", "/" );
+		String	caffeinePath	= caffeineJar.toString().replace( "\\", "/" );
+
+		instance.executeSource(
+		    "bx:application name=\"addJarApp\" javaSettings={ loadPaths=[\"" + helloWorldPath + "\"], reloadOnChange=false };",
+		    context );
+
+		RequestBoxContext	requestContext		= context.getRequestContext();
+		ClassLoader			firstClassLoader	= requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+		Application			app					= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+
+		instance.executeSource(
+		    """
+		    bx:application name="addJarApp" javaSettings={
+		    	loadPaths=["%s", "%s"],
+		    	reloadOnChange=false
+		    };
+		    import com.github.benmanes.caffeine.cache.Caffeine;
+		    result = Caffeine.newBuilder();
+		    """.formatted( helloWorldPath, caffeinePath ),
+		    context );
+
+		ClassLoader secondClassLoader = requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+		assertThat( secondClassLoader ).isNotSameInstanceAs( firstClassLoader );
+		assertThat( variables.get( result ) ).isNotNull();
+		assertThat( app.getClassLoaderCount() ).isEqualTo( 2 );
+	}
+
+	@DisplayName( "Reuse the classloader when java settings paths are reordered" )
+	@Test
+	public void testJavaSettingsPathOrderDoesNotCreateDuplicateClassLoader() {
+		String	helloWorldPath	= Path.of( "src/test/resources/libs/helloworld.jar" ).toAbsolutePath().toString().replace( "\\", "/" );
+		String	caffeinePath	= Path.of( "src/test/resources/libs/caffeine-3.1.8.jar" ).toAbsolutePath().toString().replace( "\\", "/" );
+
+		instance.executeSource(
+		    "bx:application name=\"orderedJavaSettingsApp\" javaSettings={ loadPaths=[\"" + helloWorldPath + "\", \"" + caffeinePath
+		        + "\"], reloadOnChange=false };",
+		    context );
+
+		RequestBoxContext	requestContext		= context.getRequestContext();
+		ClassLoader			firstClassLoader	= requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+		Application			app					= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+
+		instance.executeSource(
+		    "bx:application name=\"orderedJavaSettingsApp\" javaSettings={ loadPaths=[\"" + caffeinePath + "\", \"" + helloWorldPath
+		        + "\"], reloadOnChange=false };",
+		    context );
+
+		ClassLoader secondClassLoader = requestContext.getApplicationListener().getRequestClassLoader( requestContext );
+		assertThat( secondClassLoader ).isSameInstanceAs( firstClassLoader );
 		assertThat( app.getClassLoaderCount() ).isEqualTo( 1 );
 	}
 

--- a/src/test/java/TestCases/phase3/ClassTest.java
+++ b/src/test/java/TestCases/phase3/ClassTest.java
@@ -479,7 +479,7 @@ public class ClassTest {
 		assertThat( meta.get( Key.of( "functions" ) ) instanceof Array ).isTrue();
 		assertThat( meta.getAsArray( Key.of( "functions" ) ).size() ).isEqualTo( 5 );
 		assertThat( meta.get( Key.of( "extends" ) ) ).isNull();
-		assertThat( meta.get( Key.of( "output" ) ) ).isEqualTo( false );
+		assertThat( meta.get( Key.of( "output" ) ) ).isEqualTo( true );
 		assertThat( meta.get( Key.of( "persisent" ) ) ).isEqualTo( false );
 		assertThat( meta.get( Key.of( "accessors" ) ) ).isEqualTo( true );
 	}
@@ -512,7 +512,7 @@ public class ClassTest {
 		assertThat( meta.get( Key.of( "functions" ) ) instanceof Array ).isTrue();
 		assertThat( meta.getAsArray( Key.of( "functions" ) ).size() ).isEqualTo( 5 );
 		assertThat( meta.get( Key.of( "extends" ) ) ).isNull();
-		assertThat( meta.get( Key.of( "output" ) ) ).isEqualTo( false );
+		assertThat( meta.get( Key.of( "output" ) ) ).isEqualTo( true );
 		assertThat( meta.get( Key.of( "persisent" ) ) ).isEqualTo( false );
 		assertThat( meta.get( Key.of( "accessors" ) ) ).isEqualTo( true );
 	}
@@ -637,7 +637,7 @@ public class ClassTest {
 		assertThat( meta.getAsString( Key.of( "path" ) ) ).contains( "MyClass.bx" );
 		// assertThat( meta.get( Key.of( "hashcode" ) ) ).isEqualTo( cfc.hashCode() );
 		assertThat( meta.get( Key.of( "properties" ) ) instanceof Array ).isTrue();
-		assertThat( meta.getAsBoolean( Key.of( "output" ) ) ).isFalse();
+		assertThat( meta.getAsBoolean( Key.of( "output" ) ) ).isTrue();
 		Array properties = meta.getAsArray( Key.of( "properties" ) );
 		assertThat( properties.size() ).isEqualTo( 1 );
 		assertThat( properties.get( 0 ) instanceof IStruct ).isTrue();
@@ -2008,23 +2008,6 @@ public class ClassTest {
 
 		// The second run should be less than 1.5% of the first run
 		assertThat( DoubleCaster.cast( secondRunTime / firstRunTime ) ).isLessThan( .015 );
-	}
-
-	@Test
-	public void testOuputInApplication() {
-		instance.executeSource(
-		    """
-		    bx:savecontent variable="result" {
-		       	new src.test.java.TestCases.phase3.Application().run()
-		    }
-
-		    bx:savecontent variable="result2" {
-		       	new src.test.java.TestCases.phase3.NotApplication().run()
-		    }
-		         """,
-		    context );
-		assertThat( variables.get( "result" ) ).isEqualTo( "Hello BradHello World" );
-		assertThat( variables.get( "result2" ) ).isEqualTo( "" );
 	}
 
 	@Test

--- a/src/test/java/TestCases/phase3/ClassTest.java
+++ b/src/test/java/TestCases/phase3/ClassTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.compiler.JavaMethodResolver;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.BaseBoxContext;
 import ortus.boxlang.runtime.context.ConfigOverrideBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
@@ -2502,6 +2503,40 @@ public class ClassTest {
 		    context );
 		assertThat( variables.getAsString( Key.of( "result" ) ) ).isEqualTo( "baseTemplateFallback/includes/cfc/MyClass.cfc" );
 		assertThat( variables.getAsString( Key.of( "result2" ) ) ).isEqualTo( "baseTemplateFallback/cfc/MyClass2.cfc" );
+
+	}
+
+	@Test
+	public void testIncludeAClass() {
+		boolean originalAllowIncludeClassFiles = BaseBoxContext.allowIncludeClassFiles;
+		BaseBoxContext.allowIncludeClassFiles = true;
+		try {
+			instance.executeSource(
+			    """
+			       include "/src/test/java/TestCases/phase3/IncludeMe.bx";
+			    fooResult = foo();
+			    barResult = bar();
+			          """,
+			    context );
+		} finally {
+			BaseBoxContext.allowIncludeClassFiles = originalAllowIncludeClassFiles;
+		}
+		assertThat( variables.get( Key.of( "pseudoRan" ) ) ).isEqualTo( true );
+		assertThat( variables.get( Key.of( "out" ) ) ).isEqualTo( System.out );
+		assertThat( variables.getAsString( Key.of( "fooResult" ) ) ).isEqualTo( "foo" );
+		assertThat( variables.getAsString( Key.of( "barResult" ) ) ).isEqualTo( "bar" );
+
+		BaseBoxContext.allowIncludeClassFiles = false;
+		try {
+			Throwable t = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+			    """
+			    include "/src/test/java/TestCases/phase3/IncludeMe.bx";
+			       """,
+			    context ) );
+			assertThat( t.getMessage() ).contains( "cannot be included" );
+		} finally {
+			BaseBoxContext.allowIncludeClassFiles = originalAllowIncludeClassFiles;
+		}
 
 	}
 

--- a/src/test/java/TestCases/phase3/ClassTest.java
+++ b/src/test/java/TestCases/phase3/ClassTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.compiler.JavaMethodResolver;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.ConfigOverrideBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.DoubleCaster;
@@ -54,6 +55,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.ExceptionUtil;
 import ortus.boxlang.runtime.types.meta.ClassMeta;
 import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.util.Mapping;
 
 public class ClassTest {
 
@@ -2504,6 +2506,29 @@ public class ClassTest {
 		           """,
 		    context );
 		assertThat( variables.get( "result" ) ).isEqualTo( 5 );
+	}
+
+	@Test
+	public void testClassLookupRelativeToBaseTemplateFallback() {
+		context		= getContext( "src/test/java/TestCases/phase3/", "baseTemplateFallback/index.cfm" );
+		variables	= context.getScopeNearby( VariablesScope.name );
+		instance.executeSource(
+		    """
+		       include "/baseTemplateFallback/index.cfm";
+		    println(variables)
+		          """,
+		    context );
+		assertThat( variables.getAsString( Key.of( "result" ) ) ).isEqualTo( "baseTemplateFallback/includes/cfc/MyClass.cfc" );
+		assertThat( variables.getAsString( Key.of( "result2" ) ) ).isEqualTo( "baseTemplateFallback/cfc/MyClass2.cfc" );
+
+	}
+
+	// Used for tests that need to spoof a base template path
+	private IBoxContext getContext( String rootPath, String template ) {
+		return new ScriptingRequestBoxContext( new ConfigOverrideBoxContext( instance.getRuntimeContext(), config -> {
+			config.getAsStruct( Key.mappings ).put( "/", Mapping.ofExternal( "/", new java.io.File( rootPath ).getAbsolutePath() ) );
+			return config;
+		} ), false ).loadApplicationDescriptor( FileSystemUtil.createFileUri( template ) );
 	}
 
 }

--- a/src/test/java/TestCases/phase3/ClassTest.java
+++ b/src/test/java/TestCases/phase3/ClassTest.java
@@ -2514,9 +2514,8 @@ public class ClassTest {
 		variables	= context.getScopeNearby( VariablesScope.name );
 		instance.executeSource(
 		    """
-		       include "/baseTemplateFallback/index.cfm";
-		    println(variables)
-		          """,
+		    include "/baseTemplateFallback/index.cfm";
+		       """,
 		    context );
 		assertThat( variables.getAsString( Key.of( "result" ) ) ).isEqualTo( "baseTemplateFallback/includes/cfc/MyClass.cfc" );
 		assertThat( variables.getAsString( Key.of( "result2" ) ) ).isEqualTo( "baseTemplateFallback/cfc/MyClass2.cfc" );

--- a/src/test/java/TestCases/phase3/IncludeMe.bx
+++ b/src/test/java/TestCases/phase3/IncludeMe.bx
@@ -1,0 +1,17 @@
+import java.lang.System;
+
+class {
+    // test the imports
+    out = System.out;
+
+    pseudoRan = true
+    
+    function foo() {
+        return "foo";
+    }
+
+    function bar() {
+        return "bar";
+    }
+
+ }

--- a/src/test/java/TestCases/phase3/baseTemplateFallback/cfc/MyClass.cfc
+++ b/src/test/java/TestCases/phase3/baseTemplateFallback/cfc/MyClass.cfc
@@ -1,0 +1,3 @@
+component {
+	this.foo = "baseTemplateFallback/cfc/MyClass.cfc";
+}

--- a/src/test/java/TestCases/phase3/baseTemplateFallback/cfc/MyClass2.cfc
+++ b/src/test/java/TestCases/phase3/baseTemplateFallback/cfc/MyClass2.cfc
@@ -1,0 +1,3 @@
+component {
+	this.foo = "baseTemplateFallback/cfc/MyClass2.cfc";
+}

--- a/src/test/java/TestCases/phase3/baseTemplateFallback/includes/cfc/MyClass.cfc
+++ b/src/test/java/TestCases/phase3/baseTemplateFallback/includes/cfc/MyClass.cfc
@@ -1,0 +1,3 @@
+component {
+	this.foo = "baseTemplateFallback/includes/cfc/MyClass.cfc";
+}

--- a/src/test/java/TestCases/phase3/baseTemplateFallback/includes/index.cfm
+++ b/src/test/java/TestCases/phase3/baseTemplateFallback/includes/index.cfm
@@ -1,0 +1,2 @@
+<cfset result = new cfc.MyClass().foo>
+<cfset result2 = new cfc.MyClass2().foo>

--- a/src/test/java/TestCases/phase3/baseTemplateFallback/index.cfm
+++ b/src/test/java/TestCases/phase3/baseTemplateFallback/index.cfm
@@ -1,0 +1,1 @@
+<cfinclude template="includes/index.cfm">

--- a/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
+++ b/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
@@ -568,6 +568,24 @@ public class CFTranspilerTest {
 		assertThat( variables.getAsString( result ) ).isEqualTo( "1,2,3,4,5,6" );
 	}
 
+	@DisplayName( "Can append a number in a string list with a custom delimiter" )
+	@Test
+	public void testAppendNumberWithCustomDelimiter() {
+		instance.executeSource(
+		    """
+		        result = "///Users//luis//".listAppend( "//foo///bar////baz///", "/"  )
+		    """,
+		    context, BoxSourceType.CFSCRIPT );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "///Users//luis/////foo///bar////baz///" );
+
+		instance.executeSource(
+		    """
+		        result = listAppend( "///Users//luis//", "//foo///bar////baz///", "/"  )
+		    """,
+		    context, BoxSourceType.CFSCRIPT );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "///Users//luis/////foo///bar////baz///" );
+	}
+
 	@DisplayName( "Can replace once with one in replaceNoCase" )
 	@Test
 	public void testReplaceNoCaseOnce() {

--- a/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
+++ b/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
@@ -724,4 +724,19 @@ public class CFTranspilerTest {
 		assertThat( variables.get( result ) ).isEqualTo( "098f6bcd4621d373cade4e832627b4f6" );
 	}
 
+	@Test
+	public void testLoopWithStructInsteadOfCollection() {
+		instance.executeSource(
+		    """
+		    <cfset brad = "wood">
+		    <cfset result = "">
+		    <cfloop struct="#variables#" item="key">
+		    	<cfset result &= key />
+		    </cfloop>
+		             """, context, BoxSourceType.CFTEMPLATE );
+
+		assertThat( variables.getAsString( result ) ).contains( "brad" );
+		assertThat( variables.getAsString( result ) ).contains( "result" );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/compiler/QoQParseTest.java
+++ b/src/test/java/ortus/boxlang/compiler/QoQParseTest.java
@@ -678,6 +678,23 @@ public class QoQParseTest {
 	}
 
 	@Test
+	public void testParameterizedNullValue() {
+		instance.executeSource(
+		    """
+		        q = queryNew( "id", "integer", [[1]] );
+		        q = QueryExecute("
+		        				select id from q where id IN (?)
+		       ",
+		    [{value:[], list=true}],
+		    { dbType : "query" } );
+
+		    result = q.recordcount
+		                      			                          """,
+		    context, BoxSourceType.CFSCRIPT );
+		assertThat( variables.getAsInteger( result ) ).isEqualTo( 0 );
+	}
+
+	@Test
 	@Disabled
 	public void testsdf() {
 		instance.executeSource(

--- a/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
+++ b/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
@@ -476,4 +476,30 @@ class ScheduledTaskTest {
 		assertThat( variables.get( result ) ).isEqualTo( "what" );
 
 	}
+
+	@DisplayName( "call( DynamicObject, String ) registers without infinite recursion and executes the named method" )
+	@Test
+	public void testCallDynamicObjectWithMethodName() {
+		DynamicObject	dyno		= DynamicObject.of( new CallableTestTarget() );
+
+		ScheduledTask	registered	= task.call( dyno, "run" );
+		assertThat( registered ).isSameInstanceAs( task );
+
+		task.run( true );
+
+		@SuppressWarnings( "unchecked" )
+		java.util.Optional<Object> lastResult = ( java.util.Optional<Object> ) task.getStats().get( "lastResult" );
+		assertThat( lastResult.get() ).isEqualTo( "ran" );
+	}
+
+	/**
+	 * A named, public class so JVM reflection can resolve its public methods —
+	 * anonymous test-local classes are not public and fail reflective lookup.
+	 */
+	public static class CallableTestTarget {
+
+		public String run() {
+			return "ran";
+		}
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/array/ArraySortTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/array/ArraySortTest.java
@@ -323,22 +323,24 @@ public class ArraySortTest {
 	@DisplayName( "It should work on native arrays" )
 	@Test
 	public void testNativeArray() {
+		// @formatter:off
 		instance.executeSource(
 		    """
-		         threadList = createObject("java", "java.lang.Thread")
-		         	.getAllStackTraces().keySet().toArray();
+			// Get Java array
+			threadList = ["B","C","A"].toArray();
 
-		    result = threadList.toList();
+			result = threadList.toList();
 
-		         // Sort the list
-		         arraySort( threadList, (a, b)  => {
-		         	return a.compareTo(b);
-		         });
+			// Sort the list
+			arraySort( threadList, (a, b)  => {
+				return a.compareTo(b);
+			});
 
-		      result2 = threadList.toList();
+			result2 = threadList.toList();
 
-		      """,
+		         """,
 		    context );
+		// @formatter:on
 		assertThat( variables.getAsString( result ) ).isNotEqualTo( variables.getAsString( Key.of( "result2" ) ) );
 
 	}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BinaryDecodeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BinaryDecodeTest.java
@@ -37,6 +37,7 @@ import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.util.EncryptionUtil;
 
 public class BinaryDecodeTest {
 
@@ -91,9 +92,9 @@ public class BinaryDecodeTest {
 
 		assertTrue( variables.get( result ) instanceof byte[] );
 
-		String mimeString = Base64.getMimeEncoder().encodeToString( myString.getBytes() );
+		String uuEncoded = EncryptionUtil.uuEncode( myString.getBytes() );
 
-		variables.put( Key.of( "binaryString" ), mimeString );
+		variables.put( Key.of( "binaryString" ), uuEncoded );
 		instance.executeSource(
 		    """
 		    result = BinaryDecode( binaryString, "uu" );
@@ -101,6 +102,7 @@ public class BinaryDecodeTest {
 		    context );
 
 		assertTrue( variables.get( result ) instanceof byte[] );
+		assertEquals( myString, new String( ( byte[] ) variables.get( result ) ) );
 
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BinaryEncodeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BinaryEncodeTest.java
@@ -37,6 +37,7 @@ import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.util.EncryptionUtil;
 
 public class BinaryEncodeTest {
 
@@ -97,17 +98,16 @@ public class BinaryEncodeTest {
 
 		assertThat( variables.getAsString( result ) ).isEqualTo( base64String );
 
-		byte[]	mimeBytes	= Base64.getMimeEncoder().encode( myString.getBytes() );
-		String	mimeString	= Base64.getMimeEncoder().encodeToString( mimeBytes );
-
-		variables.put( Key.of( "binaryData" ), mimeBytes );
+		// Test UU encoding with raw bytes
+		String uuExpected = EncryptionUtil.uuEncode( myString.getBytes() );
+		variables.put( Key.of( "binaryData" ), myString.getBytes() );
 		instance.executeSource(
 		    """
 		    result = BinaryEncode( binaryData, "uu" );
 		    """,
 		    context );
 
-		assertThat( variables.getAsString( result ) ).isEqualTo( mimeString );
+		assertThat( variables.getAsString( result ) ).isEqualTo( uuExpected );
 
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitAndTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitAndTest.java
@@ -59,27 +59,34 @@ public class BitAndTest {
 	@Test
 	public void testBitwiseAndWithPositiveIntegers() {
 		instance.executeSource( "result = bitAnd(5, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 1 );
+		assertThat( variables.get( result ) ).isEqualTo( 1L );
 	}
 
 	@DisplayName( "Bitwise AND operation with negative integers" )
 	@Test
 	public void testBitwiseAndWithNegativeIntegers() {
 		instance.executeSource( "result = bitAnd(-5, -3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( -7 );
+		assertThat( variables.get( result ) ).isEqualTo( -7L );
 	}
 
 	@DisplayName( "Bitwise AND operation with zero" )
 	@Test
 	public void testBitwiseAndWithZero() {
 		instance.executeSource( "result = bitAnd(0, 10);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 0 );
+		assertThat( variables.get( result ) ).isEqualTo( 0L );
 	}
 
 	@DisplayName( "Bitwise AND operation with large integers" )
 	@Test
 	public void testBitwiseAndWithLargeIntegers() {
 		instance.executeSource( "result = bitAnd(123456789, 987654321);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 39471121 );
+		assertThat( variables.get( result ) ).isEqualTo( 39471121L );
+	}
+
+	@DisplayName( "Bitwise AND operation with long-range values" )
+	@Test
+	public void testBitwiseAndWithLongRangeValues() {
+		instance.executeSource( "result = bitAnd(2190225219, 3);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 3L );
 	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskClearTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskClearTest.java
@@ -61,28 +61,35 @@ public class BitMaskClearTest {
 	@Test
 	public void testBitwiseMaskClearWithPositiveIntegers() {
 		instance.executeSource( "result = bitMaskClear(15, 1, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 1 );
+		assertThat( variables.get( result ) ).isEqualTo( 1L );
 	}
 
 	@DisplayName( "Bitwise Mask Clear operation with negative integers" )
 	@Test
 	public void testBitwiseMaskClearWithNegativeIntegers() {
 		instance.executeSource( "result = bitMaskClear(-5, 1, 2);", context );
-		assertThat( variables.get( result ) ).isEqualTo( -7 );
+		assertThat( variables.get( result ) ).isEqualTo( -7L );
 	}
 
 	@DisplayName( "Bitwise Mask Clear operation with zero" )
 	@Test
 	public void testBitwiseMaskClearWithZero() {
 		instance.executeSource( "result = bitMaskClear(0, 2, 4);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 0 );
+		assertThat( variables.get( result ) ).isEqualTo( 0L );
 	}
 
 	@DisplayName( "Bitwise Mask Clear operation with large integers" )
 	@Test
 	public void testBitwiseMaskClearWithLargeIntegers() {
 		instance.executeSource( "result = bitMaskClear(123456789, 4, 10);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 123453445 );
+		assertThat( variables.get( result ) ).isEqualTo( 123453445L );
+	}
+
+	@DisplayName( "Bitwise Mask Clear operation with long-range values" )
+	@Test
+	public void testBitwiseMaskClearWithLongRangeValues() {
+		instance.executeSource( "result = bitMaskClear(2190225219, 4, 10);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 2190213123L );
 	}
 
 	@DisplayName( "Bitwise Mask Clear operation with invalid length" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskReadTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskReadTest.java
@@ -61,28 +61,35 @@ public class BitMaskReadTest {
 	@Test
 	public void testBitwiseMaskReadWithPositiveIntegers() {
 		instance.executeSource( "result = bitMaskRead(15, 1, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 7 );
+		assertThat( variables.get( result ) ).isEqualTo( 7L );
 	}
 
 	@DisplayName( "Bitwise Mask Read operation with negative integers" )
 	@Test
 	public void testBitwiseMaskReadWithNegativeIntegers() {
 		instance.executeSource( "result = bitMaskRead(-5, 1, 2);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 1 );
+		assertThat( variables.get( result ) ).isEqualTo( 1L );
 	}
 
 	@DisplayName( "Bitwise Mask Read operation with zero" )
 	@Test
 	public void testBitwiseMaskReadWithZero() {
 		instance.executeSource( "result = bitMaskRead(0, 2, 4);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 0 );
+		assertThat( variables.get( result ) ).isEqualTo( 0L );
 	}
 
 	@DisplayName( "Bitwise Mask Read operation with large integers" )
 	@Test
 	public void testBitwiseMaskReadWithLargeIntegers() {
 		instance.executeSource( "result = bitMaskRead(123456789, 4, 10);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 209 );
+		assertThat( variables.get( result ) ).isEqualTo( 209L );
+	}
+
+	@DisplayName( "Bitwise Mask Read operation with long-range values" )
+	@Test
+	public void testBitwiseMaskReadWithLongRangeValues() {
+		instance.executeSource( "result = bitMaskRead(2190225219, 4, 10);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 756L );
 	}
 
 	@DisplayName( "Bitwise Mask Read operation with invalid length" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskSetTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitMaskSetTest.java
@@ -61,28 +61,35 @@ public class BitMaskSetTest {
 	@Test
 	public void testBitwiseMaskSetWithPositiveIntegers() {
 		instance.executeSource( "result = bitMaskSet(5, 3, 2, 4);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 13 );
+		assertThat( variables.get( result ) ).isEqualTo( 13L );
 	}
 
 	@DisplayName( "Bitwise Mask Set operation with negative integers" )
 	@Test
 	public void testBitwiseMaskSetWithNegativeIntegers() {
 		instance.executeSource( "result = bitMaskSet(-5, -3, 1, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( -5 );
+		assertThat( variables.get( result ) ).isEqualTo( -5L );
 	}
 
 	@DisplayName( "Bitwise Mask Set operation with zero" )
 	@Test
 	public void testBitwiseMaskSetWithZero() {
 		instance.executeSource( "result = bitMaskSet(0, 10, 2, 4);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 40 );
+		assertThat( variables.get( result ) ).isEqualTo( 40L );
 	}
 
 	@DisplayName( "Bitwise Mask Set operation with large integers" )
 	@Test
 	public void testBitwiseMaskSetWithLargeIntegers() {
 		instance.executeSource( "result = bitMaskSet(123456789, 987654321, 5, 10);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 123442741 );
+		assertThat( variables.get( result ) ).isEqualTo( 123442741L );
+	}
+
+	@DisplayName( "Bitwise Mask Set operation with long-range values" )
+	@Test
+	public void testBitwiseMaskSetWithLongRangeValues() {
+		instance.executeSource( "result = bitMaskSet(2190225219, 1023, 4, 10);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 2190229491L );
 	}
 
 	@DisplayName( "Bitwise Mask Set operation with invalid length" )

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitNotTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitNotTest.java
@@ -59,13 +59,20 @@ public class BitNotTest {
 	@Test
 	public void testBitwiseNotWithPositiveIntegers() {
 		instance.executeSource( "result = bitNot(5);", context );
-		assertThat( variables.get( result ) ).isEqualTo( -6 );
+		assertThat( variables.get( result ) ).isEqualTo( -6L );
 	}
 
 	@DisplayName( "Bitwise NOT operation with negative integers" )
 	@Test
 	public void testBitwiseNotWithNegativeIntegers() {
 		instance.executeSource( "result = bitNot(-5);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 4 );
+		assertThat( variables.get( result ) ).isEqualTo( 4L );
+	}
+
+	@DisplayName( "Bitwise NOT operation with long-range values" )
+	@Test
+	public void testBitwiseNotWithLongRangeValues() {
+		instance.executeSource( "result = bitNot(2190225219);", context );
+		assertThat( variables.get( result ) ).isEqualTo( -2190225220L );
 	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitOrTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitOrTest.java
@@ -42,27 +42,34 @@ public class BitOrTest {
 	@Test
 	public void testBitwiseOrWithPositiveIntegers() {
 		instance.executeSource( "result = bitOr(5, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 7 );
+		assertThat( variables.get( result ) ).isEqualTo( 7L );
 	}
 
 	@DisplayName( "Bitwise OR operation with negative integers" )
 	@Test
 	public void testBitwiseOrWithNegativeIntegers() {
 		instance.executeSource( "result = bitOr(-5, -3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( -1 );
+		assertThat( variables.get( result ) ).isEqualTo( -1L );
 	}
 
 	@DisplayName( "Bitwise OR operation with zero" )
 	@Test
 	public void testBitwiseOrWithZero() {
 		instance.executeSource( "result = bitOr(0, 10);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 10 );
+		assertThat( variables.get( result ) ).isEqualTo( 10L );
 	}
 
 	@DisplayName( "Bitwise OR operation with large integers" )
 	@Test
 	public void testBitwiseOrWithLargeIntegers() {
 		instance.executeSource( "result = bitOr(123456789, 987654321);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 1071639989 );
+		assertThat( variables.get( result ) ).isEqualTo( 1071639989L );
+	}
+
+	@DisplayName( "Bitwise OR operation with long-range values" )
+	@Test
+	public void testBitwiseOrWithLongRangeValues() {
+		instance.executeSource( "result = bitOr(2190225218, 1);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 2190225219L );
 	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitXorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/binary/BitXorTest.java
@@ -59,13 +59,28 @@ public class BitXorTest {
 	@Test
 	public void testBitwiseXorWithPositiveIntegers() {
 		instance.executeSource( "result = bitXor(5, 3);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 6 );
+		assertThat( variables.get( result ) ).isEqualTo( 6L );
 	}
 
 	@DisplayName( "Bitwise XOR operation with negative integers" )
 	@Test
 	public void testBitwiseXorWithNegativeIntegers() {
 		instance.executeSource( "result = bitXor(-5, -4);", context );
-		assertThat( variables.get( result ) ).isEqualTo( 7 );
+		assertThat( variables.get( result ) ).isEqualTo( 7L );
 	}
+
+	@DisplayName( "Bitwise XOR operation with large numbers" )
+	@Test
+	public void testBitwiseXorWithLargeNumbers() {
+		instance.executeSource( "result = bitXor(1, 2190225219);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 2190225218L );
+	}
+
+	@DisplayName( "Bitwise XOR operation with long-range values" )
+	@Test
+	public void testBitwiseXorWithLongRangeValues() {
+		instance.executeSource( "result = bitXor(1, 4294967296);", context );
+		assertThat( variables.get( result ) ).isEqualTo( 4294967297L );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListAppendTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListAppendTest.java
@@ -155,9 +155,41 @@ public class ListAppendTest {
 		    result = "brad,jon".listAppend( null )
 		      """,
 		    context );
-		// even with ignore empty elements defaulting to true, we still get the trailing slash because that flag is only enforced
-		// when parsing the incoming list, not when generating the final list. Not sure what is correct, but this behavior does match CFML
-		assertThat( variables.getAsString( result ) ).isEqualTo( "brad,jon," );
+		// With includeEmptyFields defaulting to false, empty tokens are filtered from BOTH the
+		// incoming list AND the value being appended. Appending null (which coerces to "") yields
+		// no tokens to add, so the result is unchanged.
+		assertThat( variables.getAsString( result ) ).isEqualTo( "brad,jon" );
+	}
+
+	@DisplayName( "Can append a number in a string list" )
+	@Test
+	public void testAppendIgnoringEmptyEverywhere() {
+		instance.executeSource(
+		    """
+		        result = listAppend( "///Users//luis//", "//foo///bar////baz///", "/", false  )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "Users/luis/foo/bar/baz" );
+	}
+
+	@DisplayName( "Matches Lucee: empties filtered from both list and value when includeEmptyFields=false" )
+	@Test
+	public void testAppendLuceeCompatEmptyHandling() {
+		// includeEmptyFields=false: empties filtered from BOTH the list and the value
+		instance.executeSource(
+		    """
+		    result = listAppend( "a,,b,", ",x,,y,", ",", false )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "a,b,x,y" );
+
+		// includeEmptyFields=true: all empties preserved in both list and value
+		instance.executeSource(
+		    """
+		    result = listAppend( "a,,b,", ",x,,y,", ",", true )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "a,,b,,,x,,y," );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListPrependTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/list/ListPrependTest.java
@@ -142,4 +142,24 @@ public class ListPrependTest {
 		assertThat( variables.getAsString( result ) ).isEqualTo( "0-and-1-and-2-and-3-and-4-and-5" );
 	}
 
+	@DisplayName( "Matches Lucee: empties filtered from both list and value when includeEmptyFields=false" )
+	@Test
+	public void testPrependLuceeCompatEmptyHandling() {
+		// includeEmptyFields=false: empties filtered from BOTH the list and the value
+		instance.executeSource(
+		    """
+		    result = listPrepend( "a,,b,", ",x,,y,", ",", false )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( "x,y,a,b" );
+
+		// includeEmptyFields=true: all empties preserved in both list and value
+		instance.executeSource(
+		    """
+		    result = listPrepend( "a,,b,", ",x,,y,", ",", true )
+		    """,
+		    context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( ",x,,y,,a,,b," );
+	}
+
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseNTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/math/FormatBaseNTest.java
@@ -126,4 +126,19 @@ public class FormatBaseNTest {
 		        context )
 		);
 	}
+
+	@DisplayName( "It supports unsigned 32-bit long values" )
+	@Test
+	public void testItSupportsUnsigned32BitLongValues() {
+
+		variables.put( Key.of( "largeLongValue" ), LongCaster.cast( 3367874497L ) );
+
+		instance.executeSource(
+		    """
+		    result = largeLongValue.formatBaseN(16);
+		    """,
+		    context );
+
+		assertThat( variables.get( result ) ).isEqualTo( "c8bdafc1" );
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/query/QueryFilterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/query/QueryFilterTest.java
@@ -33,6 +33,7 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.Query;
+import ortus.boxlang.runtime.types.Struct;
 
 public class QueryFilterTest {
 
@@ -265,6 +266,21 @@ public class QueryFilterTest {
 		assertThat( nameValues.get( 2 ) ).isEqualTo( "Charlie" );
 		assertThat( nameValues.get( 3 ) ).isEqualTo( "Delta" );
 
+	}
+
+	@Test
+	public void testTrustsTypeData() {
+		instance.executeStatement( "myQry = QueryNew( 'col', 'integer' )", context );
+		// Passing null context will bypass type validation
+		variables.getAsQuery( Key.of( "myQry" ) ).addRow( Struct.of( "col", "" ), null );
+		instance.executeSource(
+		    """
+		    // Doesn't error
+		       filtered = myQry.filter((d) => true);
+		          	   """,
+		    context );
+		assertThat( variables.getAsQuery( Key.of( "myQry" ) ).size() ).isEqualTo( 1 );
+		assertThat( variables.getAsQuery( Key.of( "myQry" ) ).getRow( 0 )[ 0 ] ).isEqualTo( "" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/query/QuerySetCellTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/query/QuerySetCellTest.java
@@ -243,9 +243,13 @@ public class QuerySetCellTest {
 			);
 			// @formatter:on
 
-			Query query = variables.getAsQuery( result );
-			assertThat( query.getCell( Key.of( "name" ), 0 ) ).isEqualTo( "" );
-			assertThat( query.getCell( Key.of( "createdDate" ), 0 ) ).isEqualTo( null );
+			Query		query	= variables.getAsQuery( result );
+			// We need to avoid query.getCell() for the sake of the test since it will convert nulls back to empty strings
+			Object[]	row		= query.getData().get( 0 );
+			// name
+			assertThat( row[ 0 ] ).isEqualTo( "" );
+			// createdDate
+			assertThat( row[ 1 ] ).isEqualTo( null );
 		} finally {
 			Query.queryNullToEmpty = false;
 		}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/set/SetBIFsTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/set/SetBIFsTest.java
@@ -337,6 +337,20 @@ public class SetBIFsTest {
 		assertThat( variables.get( result ) ).isEqualTo( 3 );
 	}
 
+	@DisplayName( "Struct.keySet() works on non-string keys" )
+	@Test
+	public void testStructKeySetNonStringKeys() {
+		instance.executeSource(
+		    """
+		       threadClass = createObject( "java", "java.lang.Thread" );
+		    for( mthread in threadClass.getAllStackTraces().keySet() ) {
+		    	mthread.isAlive();
+		    }
+		       """,
+		    context );
+		// Does not error
+	}
+
 	@DisplayName( "Struct.keySet() inherits case-insensitivity from default struct" )
 	@Test
 	public void testStructKeySetCaseInsensitive() {

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/BoxRegisterInterceptorTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/BoxRegisterInterceptorTest.java
@@ -52,7 +52,9 @@ public class BoxRegisterInterceptorTest {
 
 	@AfterAll
 	public static void teardown() {
-		instance.getInterceptorService().clearInterceptionStates();
+		// Only remove the states that tests in this class registered on
+		instance.getInterceptorService().removeState( Key.of( "preFunctionInvoke" ) );
+		instance.getInterceptorService().removeState( Key.of( "afterCacheElementRemoved" ) );
 	}
 
 	@BeforeEach

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/CreateObjectTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/CreateObjectTest.java
@@ -38,6 +38,7 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.exceptions.BoxValidationException;
 import ortus.boxlang.runtime.types.exceptions.ClassNotFoundBoxLangException;
 
 public class CreateObjectTest {
@@ -303,6 +304,29 @@ public class CreateObjectTest {
 			instance.executeSource(
 			    """
 			    result = createObject( "webservice", "/nonexistent/file.wsdl" )
+			    """,
+			    context );
+		} );
+	}
+
+	@DisplayName( "Test custom CL" )
+	@Test
+	void testCustomClassLoader() {
+		instance.executeSource(
+		    """
+		       import ortus.boxlang.runtime.interop.DynamicObject;
+		       // Simulate a custom class loader created in BL
+		          parentLoader = DynamicObject.of( GetBoxContext().getRequestContext().getRequestClassLoader() );
+
+		    result = createObject( type="java", className="java.lang.String", classLoader=parentLoader ).init("brad")
+		               """,
+		    context );
+		assertThat( variables.get( Key.of( "result" ) ) ).isEqualTo( "brad" );
+
+		assertThrows( BoxValidationException.class, () -> {
+			instance.executeSource(
+			    """
+			    result = createObject( type="java", className="java.lang.String", classLoader="notaclassloader" ).init("brad")
 			    """,
 			    context );
 		} );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/ModuleReloadTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/ModuleReloadTest.java
@@ -23,6 +23,7 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +59,7 @@ public class ModuleReloadTest {
 
 	@DisplayName( "It can reload all modules" )
 	@Test
+	@Disabled( "This causes concurrency errors elsewhere in the test suite" )
 	public void testReload() {
 		// @formatter:off
 		instance.executeSource(

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/WriteLogTest.java
@@ -22,8 +22,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.PrintStream;
-import java.nio.file.Paths;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang3.Strings;
@@ -37,7 +37,6 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
-import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -68,7 +67,7 @@ public class WriteLogTest {
 	@AfterAll
 	public static void teardown() {
 		System.setOut( originalOut );
-		LoggingService.getInstance().shutdownAppenders();
+		// LoggingService.getInstance().shutdownAppenders();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			try {
 				FileSystemUtil.deleteFile( logFilePath );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/zip/CompressTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/zip/CompressTest.java
@@ -2,8 +2,11 @@ package ortus.boxlang.runtime.bifs.global.zip;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.itadaki.bzip2.BZip2InputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +22,8 @@ import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.runtime.util.ZipUtil;
+import ortus.boxlang.runtime.util.jtar.TarEntry;
+import ortus.boxlang.runtime.util.jtar.TarInputStream;
 
 public class CompressTest {
 
@@ -94,6 +99,82 @@ public class CompressTest {
 		System.out.println( list.toList() );
 		assertThat( list.toList() ).doesNotContain( "resources/" );
 		assertThat( list.toList().size() ).isGreaterThan( 3 );
+	}
+
+	@Test
+	public void testCompressTar() throws Exception {
+		String	source		= "src/test/resources/chuck_norris.jpg";
+		String	destination	= "src/test/resources/tmp/compress_tests/test.tar";
+		variables.put( Key.source, source );
+		variables.put( Key.destination, destination );
+
+		instance.executeSource( "compress( format='tar', source=source, destination=destination );", context );
+
+		try ( TarInputStream tarInputStream = new TarInputStream( Files.newInputStream( Path.of( destination ) ) ) ) {
+			TarEntry entry = tarInputStream.getNextEntry();
+			assertThat( entry ).isNotNull();
+			assertThat( entry.getName() ).isEqualTo( "chuck_norris.jpg" );
+		}
+	}
+
+	@Test
+	public void testCompressTgz() {
+		String	source		= "src/test/resources/chuck_norris.jpg";
+		String	destination	= "src/test/resources/tmp/compress_tests/test.tgz";
+		variables.put( Key.source, source );
+		variables.put( Key.destination, destination );
+
+		instance.executeSource( "compress( format='tgz', source=source, destination=destination );", context );
+
+		assertThat( Files.exists( Path.of( destination ) ) ).isTrue();
+	}
+
+	@Test
+	public void testCompressDetectsFormatFromDestination() {
+		String	source		= "src/test/resources/chuck_norris.jpg";
+		String	destination	= "src/test/resources/tmp/compress_tests/detected.tar";
+		variables.put( Key.source, source );
+		variables.put( Key.destination, destination );
+
+		instance.executeSource( "compress( source=source, destination=destination );", context );
+
+		assertThat( Files.exists( Path.of( destination ) ) ).isTrue();
+	}
+
+	@Test
+	public void testCompressBzip() throws Exception {
+		String	source		= "src/test/resources/chuck_norris.jpg";
+		String	destination	= "src/test/resources/tmp/compress_tests/test.bz2";
+		variables.put( Key.source, source );
+		variables.put( Key.destination, destination );
+
+		instance.executeSource( "compress( format='bzip2', source=source, destination=destination );", context );
+
+		try ( BZip2InputStream input = new BZip2InputStream( Files.newInputStream( Path.of( destination ) ), false );
+		    ByteArrayOutputStream output = new ByteArrayOutputStream() ) {
+			input.transferTo( output );
+			assertThat( output.toByteArray() ).isEqualTo( Files.readAllBytes( Path.of( source ) ) );
+		}
+	}
+
+	@Test
+	public void testCompressTbzAndTarBzAliases() throws Exception {
+		String source = "src/test/resources/chuck_norris.jpg";
+		for ( String format : new String[] { "tbz", "tbz2", "tar.bz" } ) {
+			String destination = "src/test/resources/tmp/compress_tests/test-" + format
+			    + ( format.equals( "tbz2" ) ? ".tbz2" : ".tbz" );
+			variables.put( Key.source, source );
+			variables.put( Key.destination, destination );
+
+			instance.executeSource( "compress( format='" + format + "', source=source, destination=destination );", context );
+
+			try ( BZip2InputStream bzipInput = new BZip2InputStream( Files.newInputStream( Path.of( destination ) ), false );
+			    TarInputStream tarInput = new TarInputStream( bzipInput ) ) {
+				TarEntry entry = tarInput.getNextEntry();
+				assertThat( entry ).isNotNull();
+				assertThat( entry.getName() ).isEqualTo( "chuck_norris.jpg" );
+			}
+		}
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/zip/ExtractTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/zip/ExtractTest.java
@@ -1,0 +1,179 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.zip;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.itadaki.bzip2.BZip2OutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.util.jtar.TarEntry;
+import ortus.boxlang.runtime.util.jtar.TarOutputStream;
+
+public class ExtractTest {
+
+	private Path workingDirectory;
+
+	@AfterEach
+	public void cleanup() throws Exception {
+		if ( workingDirectory != null ) {
+			try ( var paths = Files.walk( workingDirectory ) ) {
+				paths.sorted( ( left, right ) -> right.compareTo( left ) ).forEach( path -> {
+					try {
+						Files.deleteIfExists( path );
+					} catch ( Exception e ) {
+						throw new RuntimeException( e );
+					}
+				} );
+			}
+		}
+	}
+
+	@Test
+	public void testExtractTar() throws Exception {
+		workingDirectory = Files.createTempDirectory( "boxlang-extract-tar" );
+		Path	sourceFile	= workingDirectory.resolve( "archive.tar" );
+		Path	destination	= workingDirectory.resolve( "destination" );
+		Path	entryFile	= Files.createTempFile( workingDirectory, "entry", ".txt" );
+		byte[]	content		= "tar content".getBytes( StandardCharsets.UTF_8 );
+		Files.write( entryFile, content );
+
+		try ( TarOutputStream tarOutputStream = new TarOutputStream( new BufferedOutputStream( new FileOutputStream( sourceFile.toFile() ) ) ) ) {
+			TarEntry entry = new TarEntry( entryFile.toFile(), "folder/example.txt" );
+			tarOutputStream.putNextEntry( entry );
+			try ( InputStream inputStream = Files.newInputStream( entryFile ) ) {
+				inputStream.transferTo( tarOutputStream );
+			}
+		}
+
+		BoxRuntime	instance	= BoxRuntime.getInstance( true );
+		IBoxContext	context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.source, sourceFile.toString() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.destination, destination.toString() );
+
+		instance.executeSource( "extract( source=source, destination=destination );", context );
+
+		assertThat( Files.readString( destination.resolve( "folder/example.txt" ) ) ).isEqualTo( "tar content" );
+	}
+
+	@Test
+	public void testExtractTgz() throws Exception {
+		workingDirectory = Files.createTempDirectory( "boxlang-extract-tgz" );
+		Path	sourceFile	= workingDirectory.resolve( "archive.tgz" );
+		Path	destination	= workingDirectory.resolve( "destination" );
+		Path	entryFile	= Files.createTempFile( workingDirectory, "entry", ".txt" );
+		Files.writeString( entryFile, "tgz content" );
+
+		try ( GZIPOutputStream gzipOutputStream = new GZIPOutputStream( Files.newOutputStream( sourceFile ) );
+		    TarOutputStream tarOutputStream = new TarOutputStream( gzipOutputStream ) ) {
+			TarEntry entry = new TarEntry( entryFile.toFile(), "folder/example.txt" );
+			tarOutputStream.putNextEntry( entry );
+			try ( InputStream inputStream = Files.newInputStream( entryFile ) ) {
+				inputStream.transferTo( tarOutputStream );
+			}
+		}
+
+		BoxRuntime	instance	= BoxRuntime.getInstance( true );
+		IBoxContext	context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.source, sourceFile.toString() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.destination, destination.toString() );
+
+		instance.executeSource( "extract( source=source, destination=destination );", context );
+
+		assertThat( Files.readString( destination.resolve( "folder/example.txt" ) ) ).isEqualTo( "tgz content" );
+	}
+
+	@Test
+	public void testExtractRequiresDetectableFormat() throws Exception {
+		workingDirectory = Files.createTempDirectory( "boxlang-extract-unknown" );
+		Path	sourceFile	= workingDirectory.resolve( "archive.data" );
+		Path	destination	= workingDirectory.resolve( "destination" );
+		Files.writeString( sourceFile, "not an archive" );
+
+		BoxRuntime	instance	= BoxRuntime.getInstance( true );
+		IBoxContext	context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.source, sourceFile.toString() );
+		context.getScopeNearby( VariablesScope.name ).put( Key.destination, destination.toString() );
+
+		org.junit.jupiter.api.Assertions.assertThrows(
+		    RuntimeException.class,
+		    () -> instance.executeSource( "extract( source=source, destination=destination );", context )
+		);
+	}
+
+	@Test
+	public void testExtractBzipAndBzip2Aliases() throws Exception {
+		workingDirectory = Files.createTempDirectory( "boxlang-extract-bzip" );
+		Path	sourceFile	= workingDirectory.resolve( "content.bz2" );
+		Path	destination	= workingDirectory.resolve( "destination" );
+		Files.writeString( workingDirectory.resolve( "content" ), "bzip content" );
+		try ( BZip2OutputStream output = new BZip2OutputStream( Files.newOutputStream( sourceFile ) ) ) {
+			output.write( "bzip content".getBytes( StandardCharsets.UTF_8 ) );
+		}
+
+		BoxRuntime instance = BoxRuntime.getInstance( true );
+		for ( String format : new String[] { "bzip", "bzip2" } ) {
+			IBoxContext context = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+			context.getScopeNearby( VariablesScope.name ).put( Key.source, sourceFile.toString() );
+			context.getScopeNearby( VariablesScope.name ).put( Key.destination, destination.toString() );
+			instance.executeSource( "extract( format='" + format + "', source=source, destination=destination, overwrite=true );", context );
+			assertThat( Files.readString( destination.resolve( "content" ) ) ).isEqualTo( "bzip content" );
+		}
+	}
+
+	@Test
+	public void testExtractTbzAliases() throws Exception {
+		workingDirectory = Files.createTempDirectory( "boxlang-extract-tbz" );
+		Path entryFile = workingDirectory.resolve( "entry.txt" );
+		Files.writeString( entryFile, "tbz content" );
+		Path	sourceFile	= workingDirectory.resolve( "archive.tbz2" );
+		Path	destination	= workingDirectory.resolve( "destination" );
+
+		try ( BZip2OutputStream bzipOutput = new BZip2OutputStream( Files.newOutputStream( sourceFile ) );
+		    TarOutputStream tarOutput = new TarOutputStream( bzipOutput ) ) {
+			TarEntry entry = new TarEntry( entryFile.toFile(), "folder/example.txt" );
+			tarOutput.putNextEntry( entry );
+			try ( InputStream input = Files.newInputStream( entryFile ) ) {
+				input.transferTo( tarOutput );
+			}
+		}
+
+		BoxRuntime instance = BoxRuntime.getInstance( true );
+		for ( String format : new String[] { "tbz", "tbz2", "tar.bz" } ) {
+			IBoxContext context = new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+			context.getScopeNearby( VariablesScope.name ).put( Key.source, sourceFile.toString() );
+			context.getScopeNearby( VariablesScope.name ).put( Key.destination, destination.toString() );
+			instance.executeSource( "extract( format='" + format + "', source=source, destination=destination, overwrite=true );", context );
+			assertThat( Files.readString( destination.resolve( "folder/example.txt" ) ) ).isEqualTo( "tbz content" );
+		}
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleClassFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleClassFixture.bx
@@ -1,0 +1,34 @@
+class {
+
+	this.callOrder			= [];
+	this.shouldThrow		= false;
+	this.lastResult			= "";
+	this.lastErrorMessage	= "";
+
+	function before() {
+		this.callOrder.append( "before" );
+	}
+
+	function run() {
+		this.callOrder.append( "run" );
+		if ( this.shouldThrow ) {
+			throw( message = "boom" );
+		}
+		return "ran-ok";
+	}
+
+	function onSuccess( result ) {
+		this.callOrder.append( "onSuccess" );
+		this.lastResult = result;
+	}
+
+	function onError( exception ) {
+		this.callOrder.append( "onError" );
+		this.lastErrorMessage = exception.message;
+	}
+
+	function after( result ) {
+		this.callOrder.append( "after" );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleCustomMethodFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleCustomMethodFixture.bx
@@ -1,0 +1,9 @@
+class {
+
+	this.executed = false;
+
+	function purge() {
+		this.executed = true;
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleMinimalClassFixture.bx
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleMinimalClassFixture.bx
@@ -1,0 +1,9 @@
+class {
+
+	this.runCount = 0;
+
+	function run() {
+		this.runCount++;
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/async/ScheduleTest.java
@@ -33,15 +33,19 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.tasks.BaseScheduler;
+import ortus.boxlang.runtime.async.tasks.ScheduledTask;
 import ortus.boxlang.runtime.async.tasks.TaskRecord;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.interop.DynamicObject;
+import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.services.SchedulerService;
 import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class ScheduleTest {
@@ -709,5 +713,174 @@ public class ScheduleTest {
 
 		// No scheduler is created when there is nothing to load
 		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+	}
+
+	// --------------------------------------------------------------------------
+	// Class-based task tests
+	// --------------------------------------------------------------------------
+
+	private static final String	CLASS_FIXTURE			= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleClassFixture";
+	private static final String	MINIMAL_CLASS_FIXTURE	= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleMinimalClassFixture";
+	private static final String	CUSTOM_METHOD_FIXTURE	= "src.test.java.ortus.boxlang.runtime.components.async.ScheduleCustomMethodFixture";
+
+	private IClassRunnable getClassInstance( String taskName ) {
+		BaseScheduler	scheduler	= ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		TaskRecord		record		= scheduler.getTaskRecord( taskName );
+		DynamicObject	dyno		= ( DynamicObject ) record.task.getTask();
+		return ( IClassRunnable ) dyno.getTargetInstance();
+	}
+
+	/**
+	 * Register a class-based task directly via {@link Schedule#registerClassTask} without ever
+	 * calling {@code ScheduledTask.start()} — this keeps run-order assertions deterministic by
+	 * avoiding any race with the real scheduled executor's own immediate first fire (which
+	 * would otherwise run concurrently with a manual {@code run(true)} call in these tests).
+	 */
+	private ScheduledTask registerClassTaskDirect( String taskName, String className, String method ) {
+		BaseScheduler	scheduler	= Schedule.getOrCreateScheduler( context, Schedule.DEFAULT_SCHEDULER_NAME );
+		IStruct			taskDef		= Struct.of( Key._CLASS, className, Key.method, method );
+		return Schedule.registerClassTask( scheduler, taskName, "", context, taskDef );
+	}
+
+	@DisplayName( "It can create a task with a class instead of a url" )
+	@Test
+	public void testCreateWithClass() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="classTask" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		BaseScheduler scheduler = ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		assertThat( scheduler.hasTask( "classTask" ) ).isTrue();
+	}
+
+	@DisplayName( "update throws when both url and class are provided" )
+	@Test
+	public void testCreateThrowsWhenBothUrlAndClass() {
+		assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="myTask" url="http://localhost/test" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		) );
+	}
+
+	@DisplayName( "update throws when neither url nor class are provided" )
+	@Test
+	public void testCreateThrowsWhenNeitherUrlNorClass() {
+		assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="myTask" interval="120">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		) );
+	}
+
+	@DisplayName( "running a class task fires before/run/after/onSuccess in order" )
+	@Test
+	public void testClassTaskLifecycleOrderOnSuccess() {
+		ScheduledTask task = registerClassTaskDirect( "classTask", CLASS_FIXTURE, "run" );
+		task.run( true );
+
+		IClassRunnable	fixtureInstance	= getClassInstance( "classTask" );
+		Array			callOrder		= ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+
+		// ScheduledTask.run() fires afterTask before onTaskSuccess on the success path
+		assertThat( callOrder.toArray() ).asList().containsExactly( "before", "run", "after", "onSuccess" ).inOrder();
+		assertThat( fixtureInstance.getThisScope().getAsString( Key.of( "lastResult" ) ) ).isEqualTo( "ran-ok" );
+	}
+
+	@DisplayName( "running a class task that throws fires before/run/onError/after and records the failure" )
+	@Test
+	public void testClassTaskLifecycleOrderOnError() {
+		ScheduledTask	task			= registerClassTaskDirect( "classTask", CLASS_FIXTURE, "run" );
+		IClassRunnable	fixtureInstance	= getClassInstance( "classTask" );
+		fixtureInstance.getThisScope().put( Key.of( "shouldThrow" ), true );
+
+		task.run( true );
+
+		Array callOrder = ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().containsExactly( "before", "run", "onError", "after" ).inOrder();
+		assertThat( fixtureInstance.getThisScope().getAsString( Key.of( "lastErrorMessage" ) ) ).isEqualTo( "boom" );
+		assertThat( ( ( java.util.concurrent.atomic.AtomicInteger ) task.getStats().get( "totalFailures" ) ).get() ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "a class task with no lifecycle methods runs fine — they are optional" )
+	@Test
+	public void testClassTaskWithoutLifecycleMethods() {
+		ScheduledTask task = registerClassTaskDirect( "minimalTask", MINIMAL_CLASS_FIXTURE, "run" );
+		task.run( true );
+
+		IClassRunnable fixtureInstance = getClassInstance( "minimalTask" );
+		assertThat( fixtureInstance.getThisScope().getAsInteger( Key.of( "runCount" ) ) ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "a class task honors a custom method attribute instead of run()" )
+	@Test
+	public void testClassTaskCustomMethod() {
+		ScheduledTask task = registerClassTaskDirect( "customMethodTask", CUSTOM_METHOD_FIXTURE, "purge" );
+		task.run( true );
+
+		IClassRunnable fixtureInstance = getClassInstance( "customMethodTask" );
+		assertThat( fixtureInstance.getThisScope().getAsBoolean( Key.of( "executed" ) ) ).isTrue();
+	}
+
+	@DisplayName( "a class task's onError() composes with onException=\"pause\" instead of being overwritten" )
+	@Test
+	public void testClassTaskOnErrorComposesWithOnExceptionPause() {
+		BaseScheduler	scheduler	= Schedule.getOrCreateScheduler( context, Schedule.DEFAULT_SCHEDULER_NAME );
+		IStruct			taskDef		= Struct.of( Key._CLASS, CLASS_FIXTURE, Key.method, "run", Key.onException, "pause" );
+		ScheduledTask	task		= Schedule.registerClassTask( scheduler, "classTask", "", context, taskDef );
+		Schedule.applyTaskConfiguration( task, null, taskDef, instance.getRuntimeContext() );
+
+		IClassRunnable fixtureInstance = getClassInstance( "classTask" );
+		fixtureInstance.getThisScope().put( Key.of( "shouldThrow" ), true );
+
+		task.run( true );
+
+		// The class's own onError() still fired ...
+		Array callOrder = ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().contains( "onError" );
+		// ... and the onException="pause" behavior also fired, disabling the task
+		assertThat( task.isDisabled() ).isTrue();
+	}
+
+	@DisplayName( "a class-based task survives a persistence reload" )
+	@Test
+	public void testClassTaskSurvivesReload() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="update" task="classReloadTask" class="%s" interval="120">
+		    """.formatted( CLASS_FIXTURE ),
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		// Remove the in-memory scheduler to simulate a fresh state
+		svc.removeScheduler( SCHEDULER_KEY, true, 5 );
+		assertThat( svc.hasScheduler( SCHEDULER_KEY ) ).isFalse();
+
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <bx:schedule action="reload">
+		    <bx:schedule action="pause" task="classReloadTask">
+		    <bx:schedule action="run" task="classReloadTask">
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE
+		);
+		// @formatter:on
+
+		BaseScheduler scheduler = ( BaseScheduler ) svc.getScheduler( SCHEDULER_KEY );
+		assertThat( scheduler.hasTask( "classReloadTask" ) ).isTrue();
+
+		IClassRunnable	fixtureInstance	= getClassInstance( "classReloadTask" );
+		Array			callOrder		= ( Array ) fixtureInstance.getThisScope().get( Key.of( "callOrder" ) );
+		assertThat( callOrder.toArray() ).asList().contains( "run" );
 	}
 }

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -869,6 +869,30 @@ public class HTTPTest {
 		assertThat( httpResult.getAsString( Key.errorDetail ) ).contains( "URISyntaxException" );
 	}
 
+	@DisplayName( "It ignores Java restricted request headers" )
+	@Test
+	public void testIgnoresRestrictedHeaders( WireMockRuntimeInfo wmRuntimeInfo ) {
+		stubFor( post( "/restricted-headers" )
+		    .willReturn( ok().withBody( "ok" ) ) );
+
+		instance.executeSource( String.format( """
+		                                       	bx:http method="POST" url="%s" {
+		                                       		bx:httpparam type="header" name="Connection" value="keep-alive";
+		                                       		bx:httpparam type="header" name="Host" value="example.com";
+		                                       		bx:httpparam type="header" name="Content-Length" value="123";
+		                                       		bx:httpparam type="header" name="Expect" value="100-continue";
+		                                       		bx:httpparam type="header" name="Upgrade" value="h2c";
+		                                       		bx:httpparam type="formfield" name="foo" value="bar";
+		                                       	}
+		                                       	result = bxhttp;
+		                                       """, wmRuntimeInfo.getHttpBaseUrl() + "/restricted-headers" ), context );
+
+		IStruct httpResult = variables.getAsStruct( result );
+		assertThat( httpResult.getAsInteger( Key.statusCode ) ).isEqualTo( 200 );
+		assertThat( httpResult.getAsString( Key.errorDetail ) ).isEqualTo( "" );
+		assertThat( httpResult.getAsString( Key.fileContent ) ).isEqualTo( "ok" );
+	}
+
 	@DisplayName( "It can handle timeouts" )
 	@Test
 	public void testTimeout( WireMockRuntimeInfo wmRuntimeInfo ) {

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -834,6 +834,40 @@ public class HTTPTest {
 		    .isEqualTo( "Unknown host: does-not-exist.also-does-not-exist: Name or service not known." );
 	}
 
+	@DisplayName( "It can handle malformed URLs with a complete result struct" )
+	@Test
+	public void testMalformedURLHasCompleteResult() {
+		// @formatter:off
+		instance.executeSource( """
+			bx:http method="GET" url="http://exa mple.com";
+			result = bxhttp;
+		""", context );
+		// @formatter:on
+
+		IStruct httpResult = variables.getAsStruct( result );
+
+		Assertions.assertTrue( httpResult.containsKey( Key.statusCode ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.status_code ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.statusText ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.status_text ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.fileContent ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.errorDetail ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.header ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.responseHeader ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.charset ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.mimetype ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.text ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.cookies ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.executionTime ) );
+		Assertions.assertTrue( httpResult.containsKey( Key.request ) );
+
+		assertThat( httpResult.getAsInteger( Key.statusCode ) ).isEqualTo( 500 );
+		assertThat( httpResult.getAsString( Key.fileContent ) ).isEqualTo( "" );
+		assertThat( httpResult.getAsString( Key.header ) ).isEqualTo( "" );
+		assertThat( httpResult.getAsString( Key.mimetype ) ).isEqualTo( "" );
+		assertThat( httpResult.getAsString( Key.errorDetail ) ).contains( "URISyntaxException" );
+	}
+
 	@DisplayName( "It can handle timeouts" )
 	@Test
 	public void testTimeout( WireMockRuntimeInfo wmRuntimeInfo ) {

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -840,6 +840,7 @@ public class HTTPTest {
 		// @formatter:off
 		instance.executeSource( """
 			bx:http method="GET" url="http://exa mple.com";
+			
 			result = bxhttp;
 		""", context );
 		// @formatter:on

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -2133,9 +2133,9 @@ public class HTTPTest {
 	@DisplayName( "onHTTPResponse interceptor fires on network-level errors with null response" )
 	@Test
 	public void testOnHTTPResponseInterceptorFiredOnNetworkError( WireMockRuntimeInfo wmRuntimeInfo ) {
-		// Stub a slow endpoint that will trigger a timeout
+		// Stub a slow endpoint that will trigger a timeout (delay just over the 1s request timeout)
 		stubFor( get( urlEqualTo( "/interceptor-timeout" ) )
-		    .willReturn( ok( "slow" ).withFixedDelay( 5000 ) ) );
+		    .willReturn( ok( "slow" ).withFixedDelay( 1500 ) ) );
 
 		String			baseURL					= wmRuntimeInfo.getHttpBaseUrl();
 
@@ -2187,8 +2187,7 @@ public class HTTPTest {
 		// response must be null on the error path (no raw HttpResponse was received)
 		assertThat( responseWasNull.get() ).isTrue();
 
-		// The result struct should carry a non-200 status code indicating an error
-		assertThat( capturedStatusCode.get() ).isGreaterThan( 0 );
+		// The result struct should carry an error status code (408 for timeout)
 		assertThat( capturedStatusCode.get() ).isAtLeast( 400 );
 
 		// The result struct should carry an errorDetail message

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -70,10 +70,14 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -2124,6 +2128,71 @@ public class HTTPTest {
 		assertThat( resultStruct.containsKey( Key.statusCode ) ).isTrue();
 		assertThat( resultStruct.containsKey( Key.fileContent ) ).isTrue();
 		assertThat( resultStruct.getAsInteger( Key.statusCode ) ).isEqualTo( 200 );
+	}
+
+	@DisplayName( "onHTTPResponse interceptor fires on network-level errors with null response" )
+	@Test
+	public void testOnHTTPResponseInterceptorFiredOnNetworkError( WireMockRuntimeInfo wmRuntimeInfo ) {
+		// Stub a slow endpoint that will trigger a timeout
+		stubFor( get( urlEqualTo( "/interceptor-timeout" ) )
+		    .willReturn( ok( "slow" ).withFixedDelay( 5000 ) ) );
+
+		String			baseURL					= wmRuntimeInfo.getHttpBaseUrl();
+
+		// Counters / captured values set by the interceptor
+		AtomicBoolean	interceptorCalled		= new AtomicBoolean( false );
+		AtomicBoolean	responseWasNull			= new AtomicBoolean( false );
+		AtomicInteger	capturedStatusCode		= new AtomicInteger( 0 );
+		AtomicBoolean	resultHadErrorDetail	= new AtomicBoolean( false );
+
+		// Register an interceptor for ON_HTTP_RESPONSE
+		instance.getInterceptorService().register(
+		    data -> {
+			    interceptorCalled.set( true );
+			    // On the error path the raw response object is null
+			    responseWasNull.set( data.get( Key.of( "response" ) ) == null );
+			    IStruct res = ( IStruct ) data.get( Key.of( "result" ) );
+			    if ( res != null ) {
+				    Object sc = res.get( Key.statusCode );
+				    if ( sc instanceof Number n ) {
+					    capturedStatusCode.set( n.intValue() );
+				    }
+				    Object ed = res.get( Key.errorDetail );
+				    resultHadErrorDetail.set( ed != null && !ed.toString().isEmpty() );
+			    }
+			    return false;
+		    },
+		    BoxEvent.ON_HTTP_RESPONSE.key() );
+
+		try {
+			// Trigger a timeout – this will hit the ExecutionException/HttpTimeoutException
+			// catch branch inside BoxHttpRequest.invoke()
+			instance.executeSource(
+			    String.format(
+			        """
+			        	bx:http result="result" url="%s" timeout="1";
+			        """,
+			        baseURL + "/interceptor-timeout"
+			    ),
+			    context
+			);
+		} finally {
+			// Always clean up the interceptor state to avoid polluting other tests
+			instance.getInterceptorService().clearInterceptionStates();
+		}
+
+		// The interceptor must have been called even though the request failed
+		assertThat( interceptorCalled.get() ).isTrue();
+
+		// response must be null on the error path (no raw HttpResponse was received)
+		assertThat( responseWasNull.get() ).isTrue();
+
+		// The result struct should carry a non-200 status code indicating an error
+		assertThat( capturedStatusCode.get() ).isGreaterThan( 0 );
+		assertThat( capturedStatusCode.get() ).isAtLeast( 400 );
+
+		// The result struct should carry an errorDetail message
+		assertThat( resultHadErrorDetail.get() ).isTrue();
 	}
 
 	private X509Certificate generateSelfSignedCertificate( KeyPair keyPair ) throws Exception {

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -50,6 +50,8 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -69,9 +71,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
@@ -2174,8 +2173,8 @@ public class HTTPTest {
 			    context
 			);
 		} finally {
-			// Always clean up the interceptor state to avoid polluting other tests
-			instance.getInterceptorService().clearInterceptionStates();
+			// Only remove the state we registered on
+			instance.getInterceptorService().removeState( BoxEvent.ON_HTTP_ERROR.key() );
 		}
 
 		// The interceptor must have been called even though the request failed

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -35,9 +35,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URI;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.math.BigInteger;
+import java.util.List;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -843,7 +846,7 @@ public class HTTPTest {
 		// @formatter:off
 		instance.executeSource( """
 			bx:http method="GET" url="http://exa mple.com";
-			
+
 			result = bxhttp;
 		""", context );
 		// @formatter:on
@@ -1723,6 +1726,10 @@ public class HTTPTest {
 
 		// HTTP error (500) is a successful request, just error status
 		assertThat( stats.getAsLong( Key.of( "successfulRequests" ) ) ).isGreaterThan( 0L );
+		assertThat( ( List<?> ) stats.get( Key.of( "observedHosts" ) ) ).contains( URI.create( baseURL ).getHost() );
+		assertThat( ( List<?> ) stats.get( Key.of( "observedHosts" ) ) ).contains( "invalid-host-that-does-not-exist-12345.com" );
+		assertThat( ( List<?> ) stats.get( Key.of( "observedRequestTimeoutSeconds" ) ) ).contains( 0 );
+		assertThat( ( List<?> ) stats.get( Key.of( "observedRequestTimeoutSeconds" ) ) ).contains( 1 );
 	}
 
 	@DisplayName( "Can track min and max execution times across multiple requests" )

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -40,6 +40,7 @@ import java.net.URI;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.nio.file.Path;
 import java.security.KeyPair;
@@ -1039,9 +1040,10 @@ public class HTTPTest {
 	@DisplayName( "It can process a basic authentication request" )
 	@Test
 	public void testBasicAuth( WireMockRuntimeInfo wmRuntimeInfo ) {
-		String	username			= "admin";
-		String	password			= "password";
-		String	base64Credentials	= Base64.getEncoder().encodeToString( ( username + ":" + password ).getBytes() );
+		String	username			= "admín";
+		String	password			= "pässword";
+		String	base64Credentials	= Base64.getEncoder()
+		    .encodeToString( ( username + ":" + password ).getBytes( StandardCharsets.UTF_8 ) );
 		stubFor(
 		    get( "/posts/1" )
 		        .withHeader( "Authorization", equalTo( "Basic " + base64Credentials ) )
@@ -1442,6 +1444,39 @@ public class HTTPTest {
 		assertThat( chunkTracker.getAsInteger( Key.of( "count" ) ) ).isGreaterThan( 0 );
 	}
 
+	@DisplayName( "It truncates retained streaming content without truncating callbacks" )
+	@Test
+	public void testStreamingRetainedContentLimit( WireMockRuntimeInfo wmRuntimeInfo ) {
+		String testContent = "First line\nSecond line\nThird line";
+		stubFor( get( "/test-streaming-limit" )
+		    .willReturn( ok( testContent ) ) );
+
+		// @formatter:off
+		instance.executeSource(
+		    String.format(
+		        """
+					callbackContent = "";
+					onChunkFn = ( chunkNumber, content ) => callbackContent &= content;
+					client = getBoxRuntime().getHttpService().getOrBuildClient(
+						"HTTP/2", false, 938, null, null, null, null, null, null
+					);
+					result = client.newRequest( "%s", getBoxContext() )
+						.maxStreamingContentLength( 12 )
+						.onChunk( onChunkFn )
+						.send();
+				""",
+		        wmRuntimeInfo.getHttpBaseUrl() + "/test-streaming-limit"
+		    ),
+		    context
+		);
+		// @formatter:on
+
+		IStruct httpResult = variables.getAsStruct( result );
+		assertThat( httpResult.getAsString( Key.fileContent ) ).hasLength( 12 );
+		assertThat( httpResult.getAsBoolean( Key.of( "streamContentTruncated" ) ) ).isTrue();
+		assertThat( variables.getAsString( Key.of( "callbackContent" ) ) ).contains( "Third line" );
+	}
+
 	@DisplayName( "It handles streaming with onComplete callback" )
 	@Test
 	public void testStreamingWithOnComplete( WireMockRuntimeInfo wmRuntimeInfo ) {
@@ -1606,7 +1641,7 @@ public class HTTPTest {
 					client = getBoxRuntime().getHttpService().getOrBuildClient(
 						"HTTP/2",
 						false,
-						null,
+						937,
 						null,
 						null,
 						null,
@@ -1728,8 +1763,6 @@ public class HTTPTest {
 		assertThat( stats.getAsLong( Key.of( "successfulRequests" ) ) ).isGreaterThan( 0L );
 		assertThat( ( List<?> ) stats.get( Key.of( "observedHosts" ) ) ).contains( URI.create( baseURL ).getHost() );
 		assertThat( ( List<?> ) stats.get( Key.of( "observedHosts" ) ) ).contains( "invalid-host-that-does-not-exist-12345.com" );
-		assertThat( ( List<?> ) stats.get( Key.of( "observedRequestTimeoutSeconds" ) ) ).contains( 0 );
-		assertThat( ( List<?> ) stats.get( Key.of( "observedRequestTimeoutSeconds" ) ) ).contains( 1 );
 	}
 
 	@DisplayName( "Can track min and max execution times across multiple requests" )

--- a/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/net/HTTPTest.java
@@ -2130,9 +2130,9 @@ public class HTTPTest {
 		assertThat( resultStruct.getAsInteger( Key.statusCode ) ).isEqualTo( 200 );
 	}
 
-	@DisplayName( "onHTTPResponse interceptor fires on network-level errors with null response" )
+	@DisplayName( "onHTTPError interceptor fires on network-level errors" )
 	@Test
-	public void testOnHTTPResponseInterceptorFiredOnNetworkError( WireMockRuntimeInfo wmRuntimeInfo ) {
+	public void testOnHTTPErrorInterceptorFiredOnNetworkError( WireMockRuntimeInfo wmRuntimeInfo ) {
 		// Stub a slow endpoint that will trigger a timeout (delay just over the 1s request timeout)
 		stubFor( get( urlEqualTo( "/interceptor-timeout" ) )
 		    .willReturn( ok( "slow" ).withFixedDelay( 1500 ) ) );
@@ -2141,16 +2141,13 @@ public class HTTPTest {
 
 		// Counters / captured values set by the interceptor
 		AtomicBoolean	interceptorCalled		= new AtomicBoolean( false );
-		AtomicBoolean	responseWasNull			= new AtomicBoolean( false );
 		AtomicInteger	capturedStatusCode		= new AtomicInteger( 0 );
 		AtomicBoolean	resultHadErrorDetail	= new AtomicBoolean( false );
 
-		// Register an interceptor for ON_HTTP_RESPONSE
+		// Register an interceptor for ON_HTTP_ERROR
 		instance.getInterceptorService().register(
 		    data -> {
 			    interceptorCalled.set( true );
-			    // On the error path the raw response object is null
-			    responseWasNull.set( data.get( Key.of( "response" ) ) == null );
 			    IStruct res = ( IStruct ) data.get( Key.of( "result" ) );
 			    if ( res != null ) {
 				    Object sc = res.get( Key.statusCode );
@@ -2162,7 +2159,7 @@ public class HTTPTest {
 			    }
 			    return false;
 		    },
-		    BoxEvent.ON_HTTP_RESPONSE.key() );
+		    BoxEvent.ON_HTTP_ERROR.key() );
 
 		try {
 			// Trigger a timeout – this will hit the ExecutionException/HttpTimeoutException
@@ -2183,9 +2180,6 @@ public class HTTPTest {
 
 		// The interceptor must have been called even though the request failed
 		assertThat( interceptorCalled.get() ).isTrue();
-
-		// response must be null on the error path (no raw HttpResponse was received)
-		assertThat( responseWasNull.get() ).isTrue();
 
 		// The result struct should carry an error status code (408 for timeout)
 		assertThat( capturedStatusCode.get() ).isAtLeast( 400 );

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -112,16 +112,20 @@ public class LogTest {
 	private static String getLogFileContent( String expectedText ) {
 		long	deadline	= System.nanoTime() + TimeUnit.SECONDS.toNanos( 2 );
 		String	content		= "";
-
+		System.out.println( "logFilePath: " + logFilePath );
 		while ( System.nanoTime() < deadline ) {
+			System.out.println( "Checking log file content..." );
 			if ( FileSystemUtil.exists( logFilePath ) ) {
+				System.out.println( "Log file exists." );
 				content = StringCaster.cast( FileSystemUtil.read( logFilePath ) );
+				System.out.println( "Log file content: " + content );
 				if ( content.contains( expectedText ) ) {
 					return content;
 				}
 			}
 			LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 25 ) );
 		}
+		System.out.println( "Failed to find expected text in log file within the deadline." );
 
 		return content;
 	}

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -39,7 +39,6 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
-import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -67,8 +66,8 @@ public class LogTest {
 
 	@AfterAll
 	public static void tearDown() {
-		LoggingService.getInstance().shutdownAppenders();
-		deleteLogFile();
+		// LoggingService.getInstance().shutdownAppenders();
+		// deleteLogFile();
 	}
 
 	@BeforeEach

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -47,20 +47,20 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 @Execution( ExecutionMode.SAME_THREAD )
 public class LogTest {
 
-	static BoxRuntime				instance;
-	static String					logsDirectory;
-	IBoxContext						context;
-	IScope							variables;
-	static Key						result		= new Key( "result" );
-	static String					logFilePath;
-	static String					logFileName;
+	static BoxRuntime	instance;
+	static String		logsDirectory;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+	static String		logFilePath;
+	static String		logFileName;
 
 	@BeforeAll
 	public static void setUp() {
 		instance		= BoxRuntime.getInstance( true );
 		logsDirectory	= instance.getConfiguration().logging.logsDirectory;
-		logFileName	= "bxlog.log";
-		logFilePath	= Paths.get( logsDirectory, "/" + logFileName ).normalize().toString();
+		logFileName		= "bxlog.log";
+		logFilePath		= Paths.get( logsDirectory, "/" + logFileName ).normalize().toString();
 		deleteLogFile();
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -21,11 +21,10 @@ package ortus.boxlang.runtime.components.system;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +37,7 @@ import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
@@ -54,33 +54,26 @@ public class LogTest {
 	static Key						result		= new Key( "result" );
 	static String					logFilePath;
 	static String					logFileName;
-	static ByteArrayOutputStream	outContent;
-	static PrintStream				originalOut	= System.out;
 
 	@BeforeAll
 	public static void setUp() {
 		instance		= BoxRuntime.getInstance( true );
 		logsDirectory	= instance.getConfiguration().logging.logsDirectory;
-		outContent		= new ByteArrayOutputStream();
-		System.setOut( new PrintStream( outContent ) );
 		logFileName	= "bxlog.log";
 		logFilePath	= Paths.get( logsDirectory, "/" + logFileName ).normalize().toString();
+		deleteLogFile();
 	}
 
 	@AfterAll
 	public static void tearDown() {
-		System.setOut( originalOut );
 		LoggingService.getInstance().shutdownAppenders();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
+		deleteLogFile();
 	}
 
 	@BeforeEach
 	public void setupEach() {
 		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
 		variables	= context.getScopeNearby( VariablesScope.name );
-		outContent.reset();
 	}
 
 	@DisplayName( "It tests the BIF Log with Script parsing" )
@@ -91,7 +84,7 @@ public class LogTest {
 		    bx:log text="Hello Logger!" file="bxlog";
 		    """,
 		    context, BoxSourceType.BOXSCRIPT );
-		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello Logger!" );
+		assertThat( getLogFileContent( "Hello Logger!" ) ).contains( "Hello Logger!" );
 	}
 
 	@DisplayName( "It tests the BIF Log with CFML parsing" )
@@ -102,7 +95,7 @@ public class LogTest {
 		    <cflog text="Hello CF!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
-		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello CF!" );
+		assertThat( getLogFileContent( "Hello CF!" ) ).contains( "Hello CF!" );
 	}
 
 	@DisplayName( "It tests the BIF Log with BoxLang parsing" )
@@ -113,7 +106,30 @@ public class LogTest {
 		    <bx:log text="Hello BX!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
-		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello BX!" );
+		assertThat( getLogFileContent( "Hello BX!" ) ).contains( "Hello BX!" );
+	}
+
+	private static String getLogFileContent( String expectedText ) {
+		long	deadline	= System.nanoTime() + TimeUnit.SECONDS.toNanos( 2 );
+		String	content		= "";
+
+		while ( System.nanoTime() < deadline ) {
+			if ( FileSystemUtil.exists( logFilePath ) ) {
+				content = StringCaster.cast( FileSystemUtil.read( logFilePath ) );
+				if ( content.contains( expectedText ) ) {
+					return content;
+				}
+			}
+			LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 25 ) );
+		}
+
+		return content;
+	}
+
+	private static void deleteLogFile() {
+		if ( FileSystemUtil.exists( logFilePath ) ) {
+			FileSystemUtil.deleteFile( logFilePath );
+		}
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -21,6 +21,7 @@ package ortus.boxlang.runtime.components.system;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -126,6 +127,14 @@ public class LogTest {
 			LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 25 ) );
 		}
 		System.out.println( "Failed to find expected text in log file within the deadline." );
+		// list out all the files found in the dictory we've been looking for the log file in
+		File logsDir = new File( logsDirectory );
+		if ( logsDir.exists() && logsDir.isDirectory() ) {
+			System.out.println( "Files in logs directory:" );
+			for ( File file : logsDir.listFiles() ) {
+				System.out.println( " - " + file.getName() );
+			}
+		}
 
 		return content;
 	}

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -21,7 +21,6 @@ package ortus.boxlang.runtime.components.system;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.io.File;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -112,29 +111,15 @@ public class LogTest {
 	private static String getLogFileContent( String expectedText ) {
 		long	deadline	= System.nanoTime() + TimeUnit.SECONDS.toNanos( 2 );
 		String	content		= "";
-		System.out.println( "logFilePath: " + logFilePath );
 		while ( System.nanoTime() < deadline ) {
-			System.out.println( "Checking log file content..." );
 			if ( FileSystemUtil.exists( logFilePath ) ) {
-				System.out.println( "Log file exists." );
 				content = StringCaster.cast( FileSystemUtil.read( logFilePath ) );
-				System.out.println( "Log file content: " + content );
 				if ( content.contains( expectedText ) ) {
 					return content;
 				}
 			}
 			LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 25 ) );
 		}
-		System.out.println( "Failed to find expected text in log file within the deadline." );
-		// list out all the files found in the dictory we've been looking for the log file in
-		File logsDir = new File( logsDirectory );
-		if ( logsDir.exists() && logsDir.isDirectory() ) {
-			System.out.println( "Files in logs directory:" );
-			for ( File file : logsDir.listFiles() ) {
-				System.out.println( " - " + file.getName() );
-			}
-		}
-
 		return content;
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -21,12 +21,8 @@ package ortus.boxlang.runtime.components.system;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.PrintStream;
 import java.nio.file.Paths;
-import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +33,7 @@ import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
@@ -45,29 +42,25 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 
 public class LogTest {
 
-	static BoxRuntime				instance;
-	static String					logsDirectory;
-	IBoxContext						context;
-	IScope							variables;
-	static Key						result		= new Key( "result" );
-	static String					logFilePath;
-	static String					logFileName;
-	static ByteArrayOutputStream	outContent;
-	static PrintStream				originalOut	= System.out;
+	static BoxRuntime	instance;
+	static String		logsDirectory;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result		= new Key( "result" );
+	static String		logFilePath;
+	static String		logFileName;
 
 	@BeforeAll
 	public static void setUp() {
 		instance		= BoxRuntime.getInstance( true );
 		logsDirectory	= instance.getConfiguration().logging.logsDirectory;
-		outContent		= new ByteArrayOutputStream();
-		System.setOut( new PrintStream( outContent ) );
-		logFileName	= "bxlog.log";
-		logFilePath	= Paths.get( logsDirectory, "/" + logFileName ).normalize().toString();
+		logFileName		= "bxlog.log";
+		// NOTE: No leading "/" on the second argument — otherwise Java treats it as an absolute path
+		logFilePath		= Paths.get( logsDirectory, logFileName ).normalize().toString();
 	}
 
 	@AfterAll
 	public static void tearDown() {
-		System.setOut( originalOut );
 		LoggingService.getInstance().shutdownAppenders();
 		if ( FileSystemUtil.exists( logFilePath ) ) {
 			FileSystemUtil.deleteFile( logFilePath );
@@ -78,7 +71,6 @@ public class LogTest {
 	public void setupEach() {
 		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
 		variables	= context.getScopeNearby( VariablesScope.name );
-		outContent.reset();
 	}
 
 	@DisplayName( "It tests the BIF Log with Script parsing" )
@@ -89,7 +81,12 @@ public class LogTest {
 		    bx:log text="Hello Logger!" file="bxlog";
 		    """,
 		    context, BoxSourceType.BOXSCRIPT );
-		assertTrue( Strings.CS.contains( outContent.toString( StandardCharsets.UTF_8 ), "Hello Logger!" ) );
+
+		String logContent = readLogFile();
+		assertTrue(
+		    logContent.contains( "Hello Logger!" ),
+		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
+		);
 	}
 
 	@DisplayName( "It tests the BIF Log with CFML parsing" )
@@ -100,7 +97,12 @@ public class LogTest {
 		    <cflog text="Hello Logger!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
-		assertTrue( Strings.CS.contains( outContent.toString( StandardCharsets.UTF_8 ), "Hello Logger!" ) );
+
+		String logContent = readLogFile();
+		assertTrue(
+		    logContent.contains( "Hello Logger!" ),
+		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
+		);
 	}
 
 	@DisplayName( "It tests the BIF Log with BoxLang parsing" )
@@ -111,7 +113,25 @@ public class LogTest {
 		    <bx:log text="Hello Logger!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
-		assertTrue( Strings.CS.contains( outContent.toString( StandardCharsets.UTF_8 ), "Hello Logger!" ) );
+
+		String logContent = readLogFile();
+		assertTrue(
+		    logContent.contains( "Hello Logger!" ),
+		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
+		);
+	}
+
+	/**
+	 * Reads the log file content for assertion. If the file does not exist,
+	 * returns a diagnostic string including the expected path.
+	 *
+	 * @return The log file content or a diagnostic message if not found.
+	 */
+	private String readLogFile() {
+		if ( !FileSystemUtil.exists( logFilePath ) ) {
+			return "(log file not found at: " + logFilePath + ")";
+		}
+		return StringCaster.cast( FileSystemUtil.read( logFilePath ) );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -23,23 +23,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
-import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 
+@Execution( ExecutionMode.SAME_THREAD )
 public class LogTest {
 
 	static BoxRuntime	instance;
@@ -57,14 +58,6 @@ public class LogTest {
 		logFileName		= "bxlog.log";
 		// NOTE: No leading "/" on the second argument — otherwise Java treats it as an absolute path
 		logFilePath		= Paths.get( logsDirectory, logFileName ).normalize().toString();
-	}
-
-	@AfterAll
-	public static void tearDown() {
-		LoggingService.getInstance().shutdownAppenders();
-		if ( FileSystemUtil.exists( logFilePath ) ) {
-			FileSystemUtil.deleteFile( logFilePath );
-		}
 	}
 
 	@BeforeEach
@@ -94,14 +87,14 @@ public class LogTest {
 	public void testComponentCF() {
 		instance.executeSource(
 		    """
-		    <cflog text="Hello Logger!" file="bxlog.log" />
+		    <cflog text="Hello CF!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
 
 		String logContent = readLogFile();
 		assertTrue(
-		    logContent.contains( "Hello Logger!" ),
-		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
+		    logContent.contains( "Hello CF!" ),
+		    "Log file should contain 'Hello CF!' but was: [" + logContent + "]"
 		);
 	}
 
@@ -110,14 +103,14 @@ public class LogTest {
 	public void testComponentBX() {
 		instance.executeSource(
 		    """
-		    <bx:log text="Hello Logger!" file="bxlog.log" />
+		    <bx:log text="Hello BX!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
 
 		String logContent = readLogFile();
 		assertTrue(
-		    logContent.contains( "Hello Logger!" ),
-		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
+		    logContent.contains( "Hello BX!" ),
+		    "Log file should contain 'Hello BX!' but was: [" + logContent + "]"
 		);
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -46,7 +46,7 @@ public class LogTest {
 	static String		logsDirectory;
 	IBoxContext			context;
 	IScope				variables;
-	static Key			result		= new Key( "result" );
+	static Key			result	= new Key( "result" );
 	static String		logFilePath;
 	static String		logFileName;
 

--- a/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LogTest.java
@@ -19,10 +19,14 @@
 
 package ortus.boxlang.runtime.components.system;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +38,7 @@ import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
-import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -43,27 +47,40 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 @Execution( ExecutionMode.SAME_THREAD )
 public class LogTest {
 
-	static BoxRuntime	instance;
-	static String		logsDirectory;
-	IBoxContext			context;
-	IScope				variables;
-	static Key			result	= new Key( "result" );
-	static String		logFilePath;
-	static String		logFileName;
+	static BoxRuntime				instance;
+	static String					logsDirectory;
+	IBoxContext						context;
+	IScope							variables;
+	static Key						result		= new Key( "result" );
+	static String					logFilePath;
+	static String					logFileName;
+	static ByteArrayOutputStream	outContent;
+	static PrintStream				originalOut	= System.out;
 
 	@BeforeAll
 	public static void setUp() {
 		instance		= BoxRuntime.getInstance( true );
 		logsDirectory	= instance.getConfiguration().logging.logsDirectory;
-		logFileName		= "bxlog.log";
-		// NOTE: No leading "/" on the second argument — otherwise Java treats it as an absolute path
-		logFilePath		= Paths.get( logsDirectory, logFileName ).normalize().toString();
+		outContent		= new ByteArrayOutputStream();
+		System.setOut( new PrintStream( outContent ) );
+		logFileName	= "bxlog.log";
+		logFilePath	= Paths.get( logsDirectory, "/" + logFileName ).normalize().toString();
+	}
+
+	@AfterAll
+	public static void tearDown() {
+		System.setOut( originalOut );
+		LoggingService.getInstance().shutdownAppenders();
+		if ( FileSystemUtil.exists( logFilePath ) ) {
+			FileSystemUtil.deleteFile( logFilePath );
+		}
 	}
 
 	@BeforeEach
 	public void setupEach() {
 		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
 		variables	= context.getScopeNearby( VariablesScope.name );
+		outContent.reset();
 	}
 
 	@DisplayName( "It tests the BIF Log with Script parsing" )
@@ -74,12 +91,7 @@ public class LogTest {
 		    bx:log text="Hello Logger!" file="bxlog";
 		    """,
 		    context, BoxSourceType.BOXSCRIPT );
-
-		String logContent = readLogFile();
-		assertTrue(
-		    logContent.contains( "Hello Logger!" ),
-		    "Log file should contain 'Hello Logger!' but was: [" + logContent + "]"
-		);
+		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello Logger!" );
 	}
 
 	@DisplayName( "It tests the BIF Log with CFML parsing" )
@@ -90,12 +102,7 @@ public class LogTest {
 		    <cflog text="Hello CF!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.CFTEMPLATE );
-
-		String logContent = readLogFile();
-		assertTrue(
-		    logContent.contains( "Hello CF!" ),
-		    "Log file should contain 'Hello CF!' but was: [" + logContent + "]"
-		);
+		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello CF!" );
 	}
 
 	@DisplayName( "It tests the BIF Log with BoxLang parsing" )
@@ -106,25 +113,7 @@ public class LogTest {
 		    <bx:log text="Hello BX!" file="bxlog.log" />
 		    """,
 		    context, BoxSourceType.BOXTEMPLATE );
-
-		String logContent = readLogFile();
-		assertTrue(
-		    logContent.contains( "Hello BX!" ),
-		    "Log file should contain 'Hello BX!' but was: [" + logContent + "]"
-		);
-	}
-
-	/**
-	 * Reads the log file content for assertion. If the file does not exist,
-	 * returns a diagnostic string including the expected path.
-	 *
-	 * @return The log file content or a diagnostic message if not found.
-	 */
-	private String readLogFile() {
-		if ( !FileSystemUtil.exists( logFilePath ) ) {
-			return "(log file not found at: " + logFilePath + ")";
-		}
-		return StringCaster.cast( FileSystemUtil.read( logFilePath ) );
+		assertThat( outContent.toString( StandardCharsets.UTF_8 ) ).contains( "Hello BX!" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
@@ -1117,6 +1117,25 @@ public class LoopTest {
 	}
 
 	@Test
+	public void testLoopFileCharactersWithoutItem() throws Exception {
+		Path file = Files.createTempFile( "boxlang-loop", ".txt" );
+		try {
+			Files.writeString( file, "abcdef" );
+			instance.executeSource(
+			    """
+			    result = [];
+			    bx:loop file="%s" index="chunk" characters="2" {
+			    	result.append( chunk );
+			    }
+			    """.formatted( file ),
+			    context );
+			assertThat( variables.getAsArray( Key.of( "result" ) ) ).containsExactly( "ab", "cd", "ef" ).inOrder();
+		} finally {
+			Files.deleteIfExists( file );
+		}
+	}
+
+	@Test
 	public void testUnscopeOutputAfterGroup() {
 		instance.executeSource(
 		    """

--- a/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/LoopTest.java
@@ -20,6 +20,9 @@ package ortus.boxlang.runtime.components.system;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -1073,6 +1076,44 @@ public class LoopTest {
 		    context );
 		assertThat( variables.getAsArray( Key.of( "result" ) ) ).contains( "foo" );
 		assertThat( variables.getAsArray( Key.of( "result" ) ) ).contains( "baz" );
+	}
+
+	@Test
+	public void testLoopFileLines() throws Exception {
+		Path file = Files.createTempFile( "boxlang-loop", ".txt" );
+		try {
+			Files.writeString( file, "one\ntwo\nthree" );
+			instance.executeSource(
+			    """
+			    result = [];
+			    bx:loop file="%s" item="line" index="row" {
+			    	result.append( row & ":" & line );
+			    }
+			    """.formatted( file ),
+			    context );
+			assertThat( variables.getAsArray( Key.of( "result" ) ) ).containsExactly( "1:one", "2:two", "3:three" ).inOrder();
+		} finally {
+			Files.deleteIfExists( file );
+		}
+	}
+
+	@Test
+	public void testLoopFileCharactersWithoutIndex() throws Exception {
+		Path file = Files.createTempFile( "boxlang-loop", ".txt" );
+		try {
+			Files.writeString( file, "abcdef" );
+			instance.executeSource(
+			    """
+			    result = [];
+			    bx:loop file="%s" item="chunk" characters="2" {
+			    	result.append( chunk );
+			    }
+			    """.formatted( file ),
+			    context );
+			assertThat( variables.getAsArray( Key.of( "result" ) ) ).containsExactly( "ab", "cd", "ef" ).inOrder();
+		} finally {
+			Files.deleteIfExists( file );
+		}
 	}
 
 	@Test

--- a/src/test/java/ortus/boxlang/runtime/components/zip/ZipTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/zip/ZipTest.java
@@ -154,4 +154,50 @@ public class ZipTest {
 		assertThat( list.size() ).isEqualTo( 1 );
 		assertThat( list.get( 0 ) ).isEqualTo( "binary_chuck.jpg" );
 	}
+
+	@DisplayName( "It prevents zip file from including itself when zipping its parent directory" )
+	@Test
+	public void testZipInPlaceDoesNotIncludeItself() {
+		String	fixtureDir		= "src/test/resources/tmp/zip_tests/zip-in-place-fixture";
+		String	sampleTextPath	= fixtureDir + "/sample-one.txt";
+		String	sampleCsvPath	= fixtureDir + "/sample-two.csv";
+		String	archivePath		= fixtureDir + "/in_place_test.zip";
+
+		variables.put( Key.of( "fixtureDir" ), fixtureDir );
+		variables.put( Key.of( "sampleTextPath" ), sampleTextPath );
+		variables.put( Key.of( "sampleCsvPath" ), sampleCsvPath );
+		variables.put( Key.of( "archivePath" ), archivePath );
+
+		// @formatter:off
+		instance.executeSource(
+			"""
+				// Clean up fixture directory if it exists
+				if ( directoryExists( fixtureDir ) ) {
+					directoryDelete( fixtureDir, true );
+				}
+				directoryCreate( fixtureDir, true );
+
+				// Create sample files
+				fileWrite( sampleTextPath, "Sample text file for zip test" );
+				fileWrite( sampleCsvPath, "id,name\\n1,alpha\\n2,beta" );
+
+				// Zip the fixture directory, placing the zip inside that same directory
+				bx:zip source="#fixtureDir#" file="#archivePath#" recurse="false" overwrite="true" {}
+			""",
+		    context
+		);
+		// @formatter:on
+
+		// List the contents of the zip file using ZipUtil
+		Array zipContents = ZipUtil.listEntriesFlat( archivePath, "", true, null );
+		System.out.println( "Contents of zip file: " + zipContents.toList() );
+
+		// Verify that the zip file itself is NOT included in the archive
+		// This is the red test - it should fail until we fix the zip component
+		assertThat( zipContents.toList() ).doesNotContain( "in_place_test.zip" );
+
+		// Verify that the sample files ARE included
+		assertThat( zipContents.toList() ).contains( "sample-one.txt" );
+		assertThat( zipContents.toList() ).contains( "sample-two.csv" );
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCasterTest.java
@@ -427,6 +427,55 @@ public class DateTimeCasterTest {
 	}
 
 	@Test
+	@DisplayName( "Test ISO date with 24-hour hours and AM/PM marker (validated)" )
+	public void testParseISOWith24HourAndMeridian() {
+		// Hour 21 with PM: accept (hour stays as 21:01:00)
+		String		dateString1	= "2024-04-02 21:01:00 PM";
+		DateTime	result1		= DateTimeCaster.cast( dateString1 );
+		assertThat( result1 ).isNotNull();
+		assertThat( result1.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 21:01:00" );
+
+		// Hour 9 with AM: handled by the existing 12-hour pattern (h:mm:ss a).
+		// Confirms hour 1-12 + AM/PM still works.
+		String		dateString2	= "2024-04-02 09:30:00 AM";
+		DateTime	result2		= DateTimeCaster.cast( dateString2 );
+		assertThat( result2 ).isNotNull();
+		assertThat( result2.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 09:30:00" );
+
+		// Hour 9 with PM: handled by the existing 12-hour pattern (h:mm:ss a) -> 21:30:00.
+		String		dateString3	= "2024-04-02 09:30:00 PM";
+		DateTime	result3		= DateTimeCaster.cast( dateString3 );
+		assertThat( result3 ).isNotNull();
+		assertThat( result3.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 21:30:00" );
+
+		// Hour 12 with PM: existing 12-hour pattern handles; hour stays as 12 (noon).
+		String		dateString4	= "2024-04-02 12:00:00 PM";
+		DateTime	result4		= DateTimeCaster.cast( dateString4 );
+		assertThat( result4 ).isNotNull();
+		assertThat( result4.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 12:00:00" );
+
+		// Hour 12 with AM: existing 12-hour pattern normalizes to midnight (hour 0).
+		String		dateString5	= "2024-04-02 12:00:00 AM";
+		DateTime	result5		= DateTimeCaster.cast( dateString5 );
+		assertThat( result5 ).isNotNull();
+		assertThat( result5.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 00:00:00" );
+
+		// Hour 23 with PM: new pattern accepts; hour stays as 23.
+		String		dateString6	= "2024-04-02 23:59:59 PM";
+		DateTime	result6		= DateTimeCaster.cast( dateString6 );
+		assertThat( result6 ).isNotNull();
+		assertThat( result6.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2024-04-02 23:59:59" );
+
+		// Hour 13 with AM: REJECT (inconsistent).
+		String dateString7 = "2024-04-02 13:00:00 AM";
+		assertThat( DateTimeCaster.attempt( dateString7 ).wasSuccessful() ).isFalse();
+
+		// Hour 21 with AM: REJECT (inconsistent).
+		String dateString8 = "2024-04-02 21:00:00 AM";
+		assertThat( DateTimeCaster.attempt( dateString8 ).wasSuccessful() ).isFalse();
+	}
+
+	@Test
 	@DisplayName( "Test casting ODBC Date format {d yyyy-mm-dd} to DateTime" )
 	public void testCastODBCDateFormat() {
 		String		dateString	= "{d 2024-04-02}";

--- a/src/test/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCasterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/dynamic/casters/DateTimeCasterTest.java
@@ -614,4 +614,22 @@ public class DateTimeCasterTest {
 		assertThat( result ).isNotNull();
 		assertThat( result.format( "dd.MM.yyyy" ) ).isEqualTo( "13.03.2024" );
 	}
+
+	@Test
+	@DisplayName( "Test US format with single-digit month, 24-hour time and milliseconds" )
+	public void testUSSingleDigitMonthWithMillis() {
+		String		dateString	= "7/17/2025 00:00:00.000";
+		DateTime	result		= DateTimeCaster.cast( dateString );
+		assertThat( result ).isNotNull();
+		assertThat( result.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2025-07-17 00:00:00" );
+	}
+
+	@Test
+	@DisplayName( "Test US format with single-digit month, 24-hour time without milliseconds" )
+	public void testUSSingleDigitMonthNoMillis() {
+		String		dateString	= "7/17/2025 00:00:00";
+		DateTime	result		= DateTimeCaster.cast( dateString );
+		assertThat( result ).isNotNull();
+		assertThat( result.format( "yyyy-MM-dd HH:mm:ss" ) ).isEqualTo( "2025-07-17 00:00:00" );
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/MSSQLDriverTest.java
@@ -25,7 +25,6 @@ import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Query;
 import ortus.boxlang.runtime.types.Struct;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.types.exceptions.DatabaseException;
 
 @EnabledIf( "tools.JDBCTestUtils#hasMSSQLModule" )
@@ -370,6 +369,60 @@ public class MSSQLDriverTest extends AbstractDriverTest {
 		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
 	}
 
+	@DisplayName( "It can call stored proc with some missing proc result resultSet attributes" )
+	@Test
+	public void testCallStoredProcWithMissingProcResultAttributes() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="MSSQLdatasource" result="variables.result" returncode="true">
+		        <bx:procparam name="in1" value="123" type="in" sqltype="integer" />
+		        <bx:procparam name="in2" value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam name="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
+		        <bx:procparam name="out1" type="out" sqltype="nvarchar" variable="out1" />
+		        <bx:procresult name="resultSet1" />
+		        <bx:procresult name="resultSet2" resultSet=2 />
+		    </bx:storedproc>
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE );
+		assertThat( variables.get( "resultSet1" ) ).isInstanceOf( Query.class );
+		Query rs1 = variables.getAsQuery( Key.of( "resultSet1" ) );
+		assertThat( rs1.size() ).isEqualTo( 2 );
+		assertThat( rs1.getRowAsStruct( 0 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "foo" );
+		assertThat( rs1.getRowAsStruct( 1 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "bar" );
+
+		assertThat( variables.get( "resultSet2" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "resultSet2" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+	}
+
+	@DisplayName( "It can call stored proc with some missing proc result resultSet attributes 2" )
+	@Test
+	public void testCallStoredProcWithMissingProcResultAttributes2() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="MSSQLdatasource" result="variables.result" returncode="true">
+		        <bx:procparam name="in1" value="123" type="in" sqltype="integer" />
+		        <bx:procparam name="in2" value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam name="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
+		        <bx:procparam name="out1" type="out" sqltype="nvarchar" variable="out1" />
+		        <bx:procresult name="resultSet1" resultSet=1 />
+		        <bx:procresult name="resultSet2" />
+		    </bx:storedproc>
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE );
+		assertThat( variables.get( "resultSet1" ) ).isInstanceOf( Query.class );
+		Query rs1 = variables.getAsQuery( Key.of( "resultSet1" ) );
+		assertThat( rs1.size() ).isEqualTo( 2 );
+		assertThat( rs1.getRowAsStruct( 0 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "foo" );
+		assertThat( rs1.getRowAsStruct( 1 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "bar" );
+
+		assertThat( variables.get( "resultSet2" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "resultSet2" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+	}
+
 	@DisplayName( "It can call stored proc with cf_sql_ prefix" )
 	@Test
 	public void testCallStoredProcWithCfSqlPrefix() {
@@ -701,24 +754,6 @@ public class MSSQLDriverTest extends AbstractDriverTest {
 
 		assertThat( resultStruct.get( "statusCode" ) ).isEqualTo( 42 );
 		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
-	}
-
-	@DisplayName( "It can't call stored proc mixing positional and indexed proc results" )
-	@Test
-	public void testCallStoredProcErrorOnMixedResults() {
-		Throwable t = assertThrows( BoxRuntimeException.class, () -> instance.executeSource(
-		    """
-		    <bx:storedproc procedure="testProcedure" datasource="MSSQLdatasource">
-		        <bx:procparam name="in1" value="123" type="in" sqltype="integer" />
-		        <bx:procparam name="in2" value="hello" type="in" sqltype="nvarchar" />
-		        <bx:procparam name="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
-		        <bx:procparam name="out1" type="out" sqltype="nvarchar" variable="out1" />
-		        <bx:procresult name="resultSet1" resultSet=1 />
-		        <bx:procresult name="resultSet2" />
-		    </bx:storedproc>
-		    """,
-		    context, BoxSourceType.BOXTEMPLATE ) );
-		assertThat( t.getMessage() ).contains( "Cannot mix" );
 	}
 
 	@DisplayName( "It can call stored proc with selects after insert" )

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
@@ -370,6 +370,62 @@ public class OracleDriverTest extends AbstractDriverTest {
 		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
 	}
 
+	@DisplayName( "It can call stored proc and map only the second result set (named)" )
+	@Test
+	public void testCallStoredProcSecondResultSetOnly() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="OracleDatasource" result="variables.result" debug=false>
+		        <bx:procparam dbvarname="in1" value="123" type="in" sqltype="integer" />
+		        <bx:procparam dbvarname="in2" value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam dbvarname="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
+		        <bx:procparam dbvarname="out1" type="out" sqltype="nvarchar" variable="out1" />
+		        <bx:procresult name="secondOnlyResult" resultSet=2 />
+		    </bx:storedproc>
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( variables.get( "inout1" ) ).isEqualTo( 223 );
+		assertThat( variables.get( "out1" ) ).isEqualTo( "foo-123-hello" );
+
+		assertThat( variables.get( "secondOnlyResult" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "secondOnlyResult" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+		IStruct resultStruct = variables.getAsStruct( result );
+		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
+	}
+
+	@DisplayName( "It can call stored proc and map only the second result set (positional)" )
+	@Test
+	public void testCallStoredProcSecondResultSetOnlyPositional() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="OracleDatasource" result="variables.result" debug=false>
+		        <bx:procparam value="123" type="in" sqltype="integer" />
+		        <bx:procparam value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam value="10" type="inout" sqltype="integer" variable="inout1Positional" />
+		        <bx:procparam type="out" sqltype="nvarchar" variable="out1Positional" />
+		        <bx:procresult name="secondOnlyResultPositional" resultSet=2 />
+		    </bx:storedproc>
+		    """,
+		    context, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( variables.get( "inout1Positional" ) ).isEqualTo( 223 );
+		assertThat( variables.get( "out1Positional" ) ).isEqualTo( "foo-123-hello" );
+
+		assertThat( variables.get( "secondOnlyResultPositional" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "secondOnlyResultPositional" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+		IStruct resultStruct = variables.getAsStruct( result );
+		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
+	}
+
 	@DisplayName( "It can handle large blob and clob columns" )
 	@Test
 	public void testLargeBlobAndClobColumns() {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
@@ -198,6 +198,20 @@ public class OracleDriverTest extends AbstractDriverTest {
 		    """,
 		    context
 		);
+
+		// Stored procedure with OUT refcursor that returns NULL (never opened)
+		dataSource.execute(
+		    """
+		    CREATE OR REPLACE PROCEDURE testProcedureNullCursor (
+		    	cursor1 OUT SYS_REFCURSOR
+		    )
+		    IS
+		    BEGIN
+		    	NULL;
+		    END testProcedureNullCursor;
+		    """,
+		    context
+		);
 	}
 
 	@DisplayName( "It sets generatedKey in query meta" )
@@ -946,6 +960,28 @@ public class OracleDriverTest extends AbstractDriverTest {
 		Query rs1 = variables.getAsQuery( Key.of( "resultSet1" ) );
 		assertThat( rs1.size() ).isEqualTo( 1 );
 		assertThat( rs1.getRowAsStruct( 0 ).getAsNumber( Key.of( "numVal" ) ).doubleValue() ).isEqualTo( 1D );
+	}
+
+	@DisplayName( "It does not define the variable when a proc has an OUT refcursor that returns null" )
+	@Test
+	public void testCallStoredProcRequestMoreResultsThanExist() {
+		boolean previousNullEqualsEmptyString = Compare.nullEqualsEmptyString;
+		Compare.nullEqualsEmptyString = true;
+		try {
+			// testProcedureNullCursor declares an OUT refcursor but never opens it (returns null).
+			instance.executeSource(
+			    """
+			    <bx:storedproc procedure="testProcedureNullCursor" datasource="OracleDatasource" result="variables.result" debug=false>
+			        <bx:procresult name="extraResult" resultSet=1 />
+			    </bx:storedproc>
+			    """,
+			    context, BoxSourceType.BOXTEMPLATE );
+		} finally {
+			Compare.nullEqualsEmptyString = previousNullEqualsEmptyString;
+		}
+
+		// The result set does not exist (null refcursor) — variable must be NOT DEFINED, not an empty string.
+		assertThat( variables.containsKey( Key.of( "extraResult" ) ) ).isFalse();
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/drivers/OracleDriverTest.java
@@ -370,6 +370,62 @@ public class OracleDriverTest extends AbstractDriverTest {
 		assertThat( resultStruct.getAsNumber( Key.of( "executionTime" ) ).doubleValue() ).isGreaterThan( 0.0 );
 	}
 
+	@DisplayName( "It can call stored proc with some missing proc result resultSet attributes" )
+	@Test
+	public void testCallStoredProcWithMissingProcResultAttributes() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="OracleDatasource" result="variables.result" debug=false>
+		        <bx:procparam dbvarname="in1" value="123" type="in" sqltype="integer" />
+		        <bx:procparam dbvarname="in2" value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam dbvarname="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
+		        <bx:procparam dbvarname="out1" type="out" sqltype="nvarchar" variable="out1" />
+		          <bx:procresult name="resultSet1" />
+		          <bx:procresult name="resultSet2" resultSet=2 />
+		      </bx:storedproc>
+		      """,
+		    context, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( variables.get( "resultSet1" ) ).isInstanceOf( Query.class );
+		Query rs1 = variables.getAsQuery( Key.of( "resultSet1" ) );
+		assertThat( rs1.size() ).isEqualTo( 2 );
+		assertThat( rs1.getRowAsStruct( 0 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "foo" );
+		assertThat( rs1.getRowAsStruct( 1 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "bar" );
+
+		assertThat( variables.get( "resultSet2" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "resultSet2" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+	}
+
+	@DisplayName( "It can call stored proc with some missing proc result resultSet attributes 2" )
+	@Test
+	public void testCallStoredProcWithMissingProcResultAttributes2() {
+		instance.executeSource(
+		    """
+		    <bx:storedproc procedure="testProcedure" datasource="OracleDatasource" result="variables.result" debug=false>
+		        <bx:procparam dbvarname="in1" value="123" type="in" sqltype="integer" />
+		        <bx:procparam dbvarname="in2" value="hello" type="in" sqltype="nvarchar" />
+		        <bx:procparam dbvarname="inout1" value="10" type="inout" sqltype="integer" variable="inout1" />
+		        <bx:procparam dbvarname="out1" type="out" sqltype="nvarchar" variable="out1" />
+		          <bx:procresult name="resultSet1" resultSet=1 />
+		          <bx:procresult name="resultSet2" />
+		      </bx:storedproc>
+		      """,
+		    context, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( variables.get( "resultSet1" ) ).isInstanceOf( Query.class );
+		Query rs1 = variables.getAsQuery( Key.of( "resultSet1" ) );
+		assertThat( rs1.size() ).isEqualTo( 2 );
+		assertThat( rs1.getRowAsStruct( 0 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "foo" );
+		assertThat( rs1.getRowAsStruct( 1 ).getAsString( Key.of( "col" ) ) ).isEqualTo( "bar" );
+
+		assertThat( variables.get( "resultSet2" ) ).isInstanceOf( Query.class );
+		Query rs2 = variables.getAsQuery( Key.of( "resultSet2" ) );
+		assertThat( rs2.size() ).isEqualTo( 1 );
+		assertThat( rs2.getRowAsStruct( 0 ).getAsString( Key.of( "myColumn" ) ) ).isEqualTo( "second" );
+	}
+
 	@DisplayName( "It can call stored proc and map only the second result set (named)" )
 	@Test
 	public void testCallStoredProcSecondResultSetOnly() {

--- a/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordJavaConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordJavaConfigTest.java
@@ -330,7 +330,8 @@ class ModuleRecordJavaConfigTest {
 		}
 		if ( record.getModuleClassLoader() != null ) {
 			try {
-				record.getModuleClassLoader().close();
+				// This is causing concurrency issues elsewhere in the test suite
+				// record.getModuleClassLoader().close();
 			} catch ( Exception ignored ) {
 			}
 		}

--- a/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
@@ -434,7 +434,6 @@ public class HttpServiceTest {
 		assertThat( stats.get( "connectTimeoutSeconds" ) ).isEqualTo( 45 );
 		assertThat( stats.get( "connectTimeoutConfigured" ) ).isEqualTo( true );
 		assertThat( stats.get( "observedHosts" ) ).isNotNull();
-		assertThat( stats.get( "observedHostsTruncated" ) ).isEqualTo( false );
 	}
 
 	@DisplayName( "Test client statistics preserve an unconfigured connect timeout" )

--- a/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.net.BoxHttpClient;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class HttpServiceTest {
@@ -408,6 +409,53 @@ public class HttpServiceTest {
 
 		assertThat( client ).isNotNull();
 		assertThat( service.getClientCount() ).isEqualTo( 1 );
+	}
+
+	@DisplayName( "Test client statistics expose configuration metadata" )
+	@Test
+	void testClientStatisticsExposeConfigurationMetadata() {
+		BoxHttpClient	client	= service.getOrBuildClient(
+		    "HTTP/1.1",
+		    false,
+		    45,
+		    null,
+		    null,
+		    null,
+		    null,
+		    null,
+		    null
+		);
+
+		IStruct			stats	= client.getStatistics();
+
+		assertThat( stats.get( "clientKey" ) ).isEqualTo( service.buildClientKey( "HTTP/1.1", false, 45, null, null, null, null, null, null ) );
+		assertThat( stats.get( "httpVersion" ) ).isEqualTo( "HTTP/1.1" );
+		assertThat( stats.get( "followRedirects" ) ).isEqualTo( false );
+		assertThat( stats.get( "connectTimeoutSeconds" ) ).isEqualTo( 45 );
+		assertThat( stats.get( "connectTimeoutConfigured" ) ).isEqualTo( true );
+		assertThat( stats.get( "observedHosts" ) ).isNotNull();
+		assertThat( stats.get( "observedHostsTruncated" ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "Test client statistics preserve an unconfigured connect timeout" )
+	@Test
+	void testClientStatisticsPreserveUnconfiguredConnectTimeout() {
+		BoxHttpClient	client	= service.getOrBuildClient(
+		    "HTTP/2",
+		    true,
+		    null,
+		    null,
+		    null,
+		    null,
+		    null,
+		    null,
+		    null
+		);
+
+		IStruct			stats	= client.getStatistics();
+
+		assertThat( stats.get( "connectTimeoutSeconds" ) ).isEqualTo( 0 );
+		assertThat( stats.get( "connectTimeoutConfigured" ) ).isEqualTo( false );
 	}
 
 	@DisplayName( "Test multiple clients can coexist" )

--- a/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/HttpServiceTest.java
@@ -290,15 +290,15 @@ public class HttpServiceTest {
 		    null
 		);
 
-		Key clientKey = service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
-		assertThat( service.hasClient( clientKey ) ).isTrue();
+		String clientKey = service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
+		assertThat( service.hasClient( Key.of( clientKey ) ) ).isTrue();
 	}
 
 	@DisplayName( "Test hasClient returns false for non-existing client" )
 	@Test
 	void testHasClientReturnsFalse() {
-		Key clientKey = service.buildClientKey( "HTTP/1.1", false, 60, null, null, null, null, null, null );
-		assertThat( service.hasClient( clientKey ) ).isFalse();
+		String clientKey = service.buildClientKey( "HTTP/1.1", false, 60, null, null, null, null, null, null );
+		assertThat( service.hasClient( Key.of( clientKey ) ) ).isFalse();
 	}
 
 	@DisplayName( "Test getClient returns null for non-existing client" )
@@ -325,11 +325,11 @@ public class HttpServiceTest {
 
 		assertThat( service.getClientCount() ).isEqualTo( 1 );
 
-		Key clientKey = service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
-		service.removeClient( clientKey );
+		String clientKey = service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
+		service.removeClient( Key.of( clientKey ) );
 
 		assertThat( service.getClientCount() ).isEqualTo( 0 );
-		assertThat( service.hasClient( clientKey ) ).isFalse();
+		assertThat( service.hasClient( Key.of( clientKey ) ) ).isFalse();
 	}
 
 	@DisplayName( "Test removeClient returns service for method chaining" )
@@ -347,8 +347,8 @@ public class HttpServiceTest {
 		    null
 		);
 
-		Key			clientKey		= service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
-		HttpService	returnedService	= service.removeClient( clientKey );
+		String		clientKey		= service.buildClientKey( "HTTP/2", true, 30, null, null, null, null, null, null );
+		HttpService	returnedService	= service.removeClient( Key.of( clientKey ) );
 
 		assertThat( returnedService ).isSameInstanceAs( service );
 	}

--- a/src/test/java/ortus/boxlang/runtime/types/StructTest.java
+++ b/src/test/java/ortus/boxlang/runtime/types/StructTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.ref.SoftReference;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -383,6 +384,84 @@ class StructTest {
 
 		// If entrySet() called hashCode(), this would take 10+ seconds
 		assertThat( elapsed ).isLessThan( 5000 );
+	}
+
+	@DisplayName( "stream() returns unwrapped entries in struct order" )
+	@Test
+	void testStreamReturnsUnwrappedEntries() {
+		IStruct							linked	= Struct.linkedOf( "first", "one", "second", null, "third", "three" );
+
+		List<Map.Entry<Key, Object>>	entries	= linked.stream().toList();
+		assertThat( entries ).hasSize( 3 );
+		assertThat( entries.get( 0 ).getKey() ).isEqualTo( Key.of( "first" ) );
+		assertThat( entries.get( 0 ).getValue() ).isEqualTo( "one" );
+		assertThat( entries.get( 1 ).getKey() ).isEqualTo( Key.of( "second" ) );
+		assertThat( entries.get( 1 ).getValue() ).isNull();
+		assertThat( entries.get( 2 ).getKey() ).isEqualTo( Key.of( "third" ) );
+		assertThat( entries.get( 2 ).getValue() ).isEqualTo( "three" );
+	}
+
+	@DisplayName( "stream() can be called as a BoxLang struct member" )
+	@Test
+	void testStreamCallableFromBoxLangStructMember() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+			myStruct = { foo : "bar", baz : "bum" };
+			result = myStruct.stream().count();
+			""",
+		    context );
+		// @formatter:on
+
+		assertThat( variables.getAsNumber( result ).intValue() ).isEqualTo( 2 );
+	}
+
+	@DisplayName( "keyStream() returns keys in struct order" )
+	@Test
+	void testKeyStreamReturnsKeysInOrder() {
+		IStruct		linked	= Struct.linkedOf( "first", "one", "second", "two", "third", "three" );
+
+		List<Key>	keys	= linked.keyStream().toList();
+		assertThat( keys ).containsExactly( Key.of( "first" ), Key.of( "second" ), Key.of( "third" ) ).inOrder();
+	}
+
+	@DisplayName( "keyStream() can be called as a BoxLang struct member" )
+	@Test
+	void testKeyStreamCallableFromBoxLangStructMember() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+			myStruct = { foo : "bar", baz : "bum" };
+			result = myStruct.keyStream().count();
+			""",
+		    context );
+		// @formatter:on
+
+		assertThat( variables.getAsNumber( result ).intValue() ).isEqualTo( 2 );
+	}
+
+	@DisplayName( "valueStream() returns values in struct order" )
+	@Test
+	void testValueStreamReturnsValuesInOrder() {
+		IStruct			linked	= Struct.linkedOf( "first", "one", "second", null, "third", "three" );
+
+		List<Object>	values	= linked.valueStream().toList();
+		assertThat( values ).containsExactly( "one", null, "three" ).inOrder();
+	}
+
+	@DisplayName( "valueStream() can be called as a BoxLang struct member" )
+	@Test
+	void testValueStreamCallableFromBoxLangStructMember() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+			myStruct = { foo : "bar", baz : "bum" };
+			result = myStruct.valueStream().count();
+			""",
+		    context );
+		// @formatter:on
+
+		assertThat( variables.getAsNumber( result ).intValue() ).isEqualTo( 2 );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/util/EncryptionUtilTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/EncryptionUtilTest.java
@@ -107,7 +107,7 @@ public class EncryptionUtilTest {
 		// Empty array
 		byte[]	empty	= new byte[ 0 ];
 		String	encoded	= EncryptionUtil.uuEncode( empty );
-		assertEquals( "`", encoded );
+		assertEquals( "", encoded );
 		assertArrayEquals( empty, EncryptionUtil.uuDecode( encoded ) );
 
 		// Single byte
@@ -152,7 +152,7 @@ public class EncryptionUtilTest {
 		assertArrayEquals( allBytes, EncryptionUtil.uuDecode( encoded ) );
 
 		// Null input
-		assertEquals( "`", EncryptionUtil.uuEncode( null ) );
+		assertEquals( "", EncryptionUtil.uuEncode( null ) );
 		assertArrayEquals( new byte[ 0 ], EncryptionUtil.uuDecode( null ) );
 
 		// Empty string decode

--- a/src/test/java/ortus/boxlang/runtime/util/EncryptionUtilTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/EncryptionUtilTest.java
@@ -17,8 +17,11 @@
  */
 package ortus.boxlang.runtime.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
 
 import javax.crypto.SecretKey;
 
@@ -96,6 +99,79 @@ public class EncryptionUtilTest {
 
 		encrypted = EncryptionUtil.encrypt( "Hello, World!", "AES/CBC/PKCS5Padding", key, "Base64", null, null );
 		assertEquals( "Hello, World!", EncryptionUtil.decrypt( encrypted, "AES/CBC/PKCS5Padding", key, "Base64", null, null ) );
+	}
+
+	@DisplayName( "Can UUencode and UUdecode byte arrays" )
+	@Test
+	void testUUEncodeDecode() {
+		// Empty array
+		byte[]	empty	= new byte[ 0 ];
+		String	encoded	= EncryptionUtil.uuEncode( empty );
+		assertEquals( "`", encoded );
+		assertArrayEquals( empty, EncryptionUtil.uuDecode( encoded ) );
+
+		// Single byte
+		byte[] single = new byte[] { 65 }; // 'A'
+		encoded = EncryptionUtil.uuEncode( single );
+		assertArrayEquals( single, EncryptionUtil.uuDecode( encoded ) );
+
+		// Two bytes
+		byte[] twoBytes = new byte[] { 65, 66 }; // 'A', 'B'
+		encoded = EncryptionUtil.uuEncode( twoBytes );
+		assertArrayEquals( twoBytes, EncryptionUtil.uuDecode( encoded ) );
+
+		// Three bytes
+		byte[] threeBytes = new byte[] { 65, 66, 67 }; // 'A', 'B', 'C'
+		encoded = EncryptionUtil.uuEncode( threeBytes );
+		assertArrayEquals( threeBytes, EncryptionUtil.uuDecode( encoded ) );
+
+		// Full line (45 bytes)
+		byte[] fullLine = "123456789012345678901234567890123456789012345".getBytes( StandardCharsets.UTF_8 );
+		assertEquals( 45, fullLine.length );
+		encoded = EncryptionUtil.uuEncode( fullLine );
+		assertArrayEquals( fullLine, EncryptionUtil.uuDecode( encoded ) );
+
+		// 46 bytes (should produce two lines)
+		byte[] twoLines = "1234567890123456789012345678901234567890123456".getBytes( StandardCharsets.UTF_8 );
+		assertEquals( 46, twoLines.length );
+		encoded = EncryptionUtil.uuEncode( twoLines );
+		assertArrayEquals( twoLines, EncryptionUtil.uuDecode( encoded ) );
+
+		// Longer message
+		String	message		= "BoxLang is Great!";
+		byte[]	msgBytes	= message.getBytes( StandardCharsets.UTF_8 );
+		encoded = EncryptionUtil.uuEncode( msgBytes );
+		assertArrayEquals( msgBytes, EncryptionUtil.uuDecode( encoded ) );
+
+		// Binary data with all byte values
+		byte[] allBytes = new byte[ 256 ];
+		for ( int i = 0; i < 256; i++ ) {
+			allBytes[ i ] = ( byte ) i;
+		}
+		encoded = EncryptionUtil.uuEncode( allBytes );
+		assertArrayEquals( allBytes, EncryptionUtil.uuDecode( encoded ) );
+
+		// Null input
+		assertEquals( "`", EncryptionUtil.uuEncode( null ) );
+		assertArrayEquals( new byte[ 0 ], EncryptionUtil.uuDecode( null ) );
+
+		// Empty string decode
+		assertArrayEquals( new byte[ 0 ], EncryptionUtil.uuDecode( "" ) );
+	}
+
+	@DisplayName( "Can encrypt with UU encoding and produce expected output" )
+	@Test
+	void testEncryptWithUUEncoding() {
+		String encrypted = EncryptionUtil.encrypt( "password", "AES", "GA+KUbtz0NmF8goZ2Z4MFQ==", "UU", null, null );
+		assertEquals( "0:]LFXG.'VS9^=_V&L\\R41P", encrypted );
+	}
+
+	@DisplayName( "Can encrypt and decrypt with UU encoding round-trip" )
+	@Test
+	void testEncryptDecryptUU() {
+		String	key			= EncryptionUtil.encodeKey( EncryptionUtil.generateKey( "AES" ) );
+		String	encrypted	= EncryptionUtil.encrypt( "Hello, World!", "AES", key, "UU", null, null );
+		assertEquals( "Hello, World!", EncryptionUtil.decrypt( encrypted, "AES", key, "UU", null, null ) );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/util/jtar/TarInputStreamTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/jtar/TarInputStreamTest.java
@@ -1,0 +1,103 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class TarInputStreamTest {
+
+	@Test
+	public void testCurrentOffsetIncludesHeadersDataAndPaddingWhenSkipping() throws Exception {
+		ByteArrayOutputStream archive = new ByteArrayOutputStream();
+		try ( TarOutputStream tarOutput = new TarOutputStream( archive ) ) {
+			writeEntry( tarOutput, "one.txt", "one" );
+			writeEntry( tarOutput, "two.txt", "two" );
+		}
+
+		try ( TarInputStream tarInput = new TarInputStream( new ByteArrayInputStream( archive.toByteArray() ) ) ) {
+			tarInput.setDefaultSkip( true );
+			assertThat( tarInput.getNextEntry().getName() ).isEqualTo( "one.txt" );
+			assertThat( tarInput.getCurrentOffset() ).isEqualTo( 512L );
+			assertThat( tarInput.getNextEntry().getName() ).isEqualTo( "two.txt" );
+			assertThat( tarInput.getCurrentOffset() ).isEqualTo( 1536L );
+		}
+	}
+
+	@Test
+	public void testTarEntryPreservesPosixPermissionsWhenAvailable() throws Exception {
+		java.nio.file.Path file = Files.createTempFile( "jtar-permissions", ".txt" );
+		try {
+			if ( Files.getFileAttributeView( file, java.nio.file.attribute.PosixFileAttributeView.class ) == null ) {
+				return;
+			}
+			Files.setPosixFilePermissions( file, Set.of( PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.GROUP_READ ) );
+			TarEntry entry = new TarEntry( file.toFile(), "permissions.txt" );
+			assertThat( entry.getHeader().mode ).isEqualTo( 0640 );
+		} finally {
+			Files.deleteIfExists( file );
+		}
+	}
+
+	@Test
+	public void testTarEntryIdentifiesLinkTypes() throws Exception {
+		TarHeader header = TarHeader.createHeader( "link", 0, 0, false, 0644 );
+		header.typeflag = TarHeader.LF_SYMLINK;
+		TarEntry entry = new TarEntry( header );
+		assertThat( entry.isLink() ).isTrue();
+	}
+
+	@Test
+	public void testTarEntrySupportsLongUstarNames() throws Exception {
+		String				name	= "directory/" + "long-name-".repeat( 12 ) + "file.txt";
+		java.nio.file.Path	file	= Files.createTempFile( "jtar-long-name", ".txt" );
+		try {
+			Files.writeString( file, "long name" );
+			TarEntry				entry	= new TarEntry( file.toFile(), name );
+			ByteArrayOutputStream	archive	= new ByteArrayOutputStream();
+			try ( TarOutputStream output = new TarOutputStream( archive ) ) {
+				output.putNextEntry( entry );
+				output.write( "long name".getBytes( StandardCharsets.UTF_8 ) );
+			}
+			try ( TarInputStream input = new TarInputStream( new ByteArrayInputStream( archive.toByteArray() ) ) ) {
+				assertThat( input.getNextEntry().getName() ).isEqualTo( name );
+			}
+		} finally {
+			Files.deleteIfExists( file );
+		}
+	}
+
+	private void writeEntry( TarOutputStream tarOutput, String name, String content ) throws Exception {
+		java.nio.file.Path file = java.nio.file.Files.createTempFile( "jtar", ".txt" );
+		try {
+			java.nio.file.Files.writeString( file, content, StandardCharsets.UTF_8 );
+			tarOutput.putNextEntry( new TarEntry( file.toFile(), name ) );
+			tarOutput.write( content.getBytes( StandardCharsets.UTF_8 ) );
+		} finally {
+			java.nio.file.Files.deleteIfExists( file );
+		}
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/util/jtar/TarInteroperabilityTest.java
+++ b/src/test/java/ortus/boxlang/runtime/util/jtar/TarInteroperabilityTest.java
@@ -1,0 +1,82 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.util.jtar;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+public class TarInteroperabilityTest {
+
+	@Test
+	public void testReadsArchivesCreatedBySystemTar() throws Exception {
+		Assumptions.assumeTrue( commandExists( "tar" ) );
+		Path work = Files.createTempDirectory( "jtar-interoperability" );
+		try {
+			Path source = work.resolve( "source" );
+			Files.createDirectories( source );
+			String	fileName	= "interop.txt";
+			Path	file		= source.resolve( fileName );
+			Files.writeString( file, "system tar content" );
+			for ( String format : new String[] { "ustar", "pax" } ) {
+				Path archive = work.resolve( format + ".tar" );
+				run( work, "tar", "--format=" + format, "-cf", archive.toString(), "-C", source.toString(), fileName );
+				try ( TarInputStream input = new TarInputStream( new BufferedInputStream( Files.newInputStream( archive ) ) ) ) {
+					boolean		found	= false;
+					TarEntry	entry;
+					while ( ( entry = input.getNextEntry() ) != null ) {
+						if ( entry.getName().replace( "\\", "/" ).endsWith( fileName ) ) {
+							found = true;
+							assertThat( readCurrentEntry( input ) ).isEqualTo( "system tar content" );
+						}
+					}
+					assertThat( found ).isTrue();
+				}
+			}
+		} finally {
+			try ( var paths = Files.walk( work ) ) {
+				paths.sorted( ( left, right ) -> right.compareTo( left ) ).forEach( path -> path.toFile().delete() );
+			}
+		}
+	}
+
+	private boolean commandExists( String command ) {
+		try {
+			new ProcessBuilder( command, "--version" ).start().destroy();
+			return true;
+		} catch ( IOException e ) {
+			return false;
+		}
+	}
+
+	private void run( Path directory, String... command ) throws Exception {
+		Process process = new ProcessBuilder( command ).directory( directory.toFile() ).redirectErrorStream( true ).start();
+		if ( process.waitFor() != 0 )
+			throw new IOException( "tar command failed" );
+	}
+
+	private String readCurrentEntry( TarInputStream input ) throws IOException {
+		return new String( input.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8 );
+	}
+}

--- a/workbench/samples/bifs/zip/Compress.md
+++ b/workbench/samples/bifs/zip/Compress.md
@@ -22,3 +22,14 @@ compress( "zip", "example-directory", "output.zip" );
 
 ### Additional Examples
 
+### Compress a TAR or TGZ archive
+
+Use `tar` for a raw TAR archive and `tgz` for a gzip-compressed TAR archive.
+
+```java
+compress( format="tar", source="example-directory", destination="output.tar" );
+compress( format="tgz", source="example-directory", destination="output.tgz" );
+```
+
+When `format` is omitted, it is detected from the destination extension. An unrecognized extension requires an explicit `format`.
+

--- a/workbench/samples/bifs/zip/Extract.md
+++ b/workbench/samples/bifs/zip/Extract.md
@@ -28,4 +28,15 @@ extract( "zip", "D:\test.zip", "D:\zipresult" );
 
 ```
 
+### Extract a TAR or TGZ archive
+
+Use `tar` for a raw TAR archive and `tgz` for a gzip-compressed TAR archive.
+
+```java
+extract( format="tar", source="archive.tar", destination="output-directory" );
+extract( format="tgz", source="archive.tgz", destination="output-directory" );
+```
+
+When `format` is omitted, it is detected from the source extension. An unrecognized extension requires an explicit `format`.
+
 

--- a/workbench/samples/components/async/Schedule.md
+++ b/workbench/samples/components/async/Schedule.md
@@ -1,14 +1,87 @@
 ### Create a scheduled task
 
-Creates a new task that fires an HTTP URL on a recurring interval.
+Creates a new task that fires an HTTP GET request against a URL on a recurring interval.
 
 ```java
 <bx:schedule
     action="create"
     task="dailyReport"
-    url="/tasks/daily-report.bx"
+    url="https://example.com/tasks/daily-report.bx"
     interval="daily"
     startTime="08:00"
+>
+
+```
+
+### Create a task that runs a BoxLang class
+
+Instead of firing an HTTP request, point a task at a BoxLang class with `class` (mutually
+exclusive with `url`). The class is instantiated once and reused for the life of the task, and
+its `run()` method (or the method named by `method`) is invoked on every fire:
+
+```java
+<bx:schedule
+    action="create"
+    task="dailyReport"
+    class="tasks.DailyReport"
+    interval="daily"
+    startTime="08:00"
+>
+
+```
+
+```java
+// tasks/DailyReport.bx
+class {
+
+    function run() {
+        // do the work
+    }
+
+}
+```
+
+The class may optionally define any of `before()`, `after(result)`, `onSuccess(result)`, and
+`onError(exception)` — each is only invoked if defined, following the same convention as a
+BoxLang scheduler class's life-cycle methods:
+
+```java
+// tasks/DailyReport.bx
+class {
+
+    function before() {
+        logger.info( "About to generate the daily report" );
+    }
+
+    function run() {
+        // do the work and (optionally) return a result
+        return generateReport();
+    }
+
+    function onSuccess( result ) {
+        logger.info( "Daily report generated: #result#" );
+    }
+
+    function onError( exception ) {
+        logger.error( "Daily report failed: #exception.message#" );
+    }
+
+    function after( result ) {
+        logger.info( "Daily report task finished" );
+    }
+
+}
+```
+
+A custom method name can be used instead of `run()`:
+
+```java
+<bx:schedule
+    action="create"
+    task="cleanup"
+    class="tasks.Cleanup"
+    method="purgeOldFiles"
+    interval="daily"
 >
 
 ```


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on compiler logic, CFML compatibility in the transpiler, and minor versioning updates. The most significant changes are grouped below.

### Compiler logic and correctness

* Refactored the `ensureClassInfo` method in `Boxpiler.java` to return the ensured `ClassInfo` object, simplifying and correcting how class information is retrieved and used throughout the compilation methods. All usages are updated to use the returned value, reducing redundant lookups and improving thread safety. [[1]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aR157-R171) [[2]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL288-R292) [[3]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL307-R310) [[4]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL323-R327) [[5]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL334-R342) [[6]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL358-R364) [[7]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL379-R381) [[8]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aR396) [[9]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aR416) [[10]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aR426) [[11]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL438-R458) [[12]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL467-R475) [[13]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL481-R485) [[14]](diffhunk://#diff-b2cc3a7747d99b2974d7c8a7d4462f9764516b5eb5539e510ca58f3b3d251d0aL516-R519)

### CFML compatibility in transpiler

* Enhanced the `CFTranspilerVisitor` to automatically default the `includeEmptyFields` argument to `true` for all `listAppend()` calls (both function and member forms), matching CFML behavior. This includes a new shared method for fixing up arguments and ensures both positional and named argument forms are handled. [[1]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceR789-R846) [[2]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL805-R865) [[3]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL821-R875) [[4]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceL830-L834)
* Added new attribute and argument mappings for improved CFML compatibility: `loop` struct attribute mapped to `collection`, and `extract` BIF target mapped to `destination`. [[1]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceR312) [[2]](diffhunk://#diff-8ada0c0581bd7d9e121babf006922f967c72bf46f5dfe0be477e093fc1679bceR321)

### Minor fixes and cleanups

* Improved comments in `BoxLexerCustom.java` for clarity around `null` token handling.
* Removed commented-out legacy code in `SQLColumn.java` for better readability.

### Versioning and changelog

* Bumped project version to `1.16.0` in `gradle.properties`.
* Added `1.15.0` release section and updated comparison links in `changelog.md`. [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R12-R13) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3L76-R79)