### PR TITLE
BL-2617 xml security settings

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.bifs.global.decision.IsJSON;
 import ortus.boxlang.runtime.config.Configuration;
+import ortus.boxlang.runtime.config.segments.XMLConfig;
 import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext.ScopeSearchResult;
@@ -202,7 +203,7 @@ public abstract class BaseApplicationListener {
 	    Key.secureJsonPrefix, "",
 	    // Default Timezone
 	    Key.timezone, runtime.getConfiguration().timezone.getId(),
-	    Key.XMLSettings, XML.DEFAULT_XML_SETTINGS
+	    Key.XMLSettings, runtime.getConfiguration().xml.asStruct()
 	);
 
 	/**
@@ -284,6 +285,10 @@ public abstract class BaseApplicationListener {
 	 * @param settings The settings to update
 	 */
 	public void updateSettings( IStruct settings ) {
+		// Normalize XML settings using the config segment for backward compatibility
+		if ( settings.containsKey( Key.XMLSettings ) ) {
+			settings.put( Key.XMLSettings, XMLConfig.normalize( settings.getAsStruct( Key.XMLSettings ) ) );
+		}
 		this.settings.addAll( settings );
 		// If the settings have changed, see if the app and session contexts need updated or initialized as well
 		defineApplication();

--- a/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
+++ b/src/main/java/ortus/boxlang/runtime/application/BaseApplicationListener.java
@@ -201,7 +201,8 @@ public abstract class BaseApplicationListener {
 	    Key.secureJson, false,
 	    Key.secureJsonPrefix, "",
 	    // Default Timezone
-	    Key.timezone, runtime.getConfiguration().timezone.getId()
+	    Key.timezone, runtime.getConfiguration().timezone.getId(),
+	    Key.XMLSettings, XML.DEFAULT_XML_SETTINGS
 	);
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
@@ -16,11 +16,14 @@ package ortus.boxlang.runtime.bifs.global.xml;
 
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.config.segments.XMLConfig;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.XML;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 
@@ -74,9 +77,18 @@ public class XMLParse extends BIF {
 
 		Boolean	caseSensitive	= arguments.getAsBoolean( Key.caseSensitive );
 		Object	validator		= arguments.get( Key.validator );
-		Boolean	lenient			= arguments.getAsBoolean( Key.of( "lenient" ) );
+		Boolean	lenient			= arguments.getAsBoolean( Key.lenient );
+		IStruct validatorSettings = context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
 		if ( validator == null ) {
-			validator = context.getRequestContext().getApplicationListener().getSettings().get( Key.XMLSettings );
+			validator = validatorSettings;
+		} else if( validator instanceof IStruct validatorStruct ){
+			// Normalize any setting names for backward compat
+			final IStruct normalized = XMLConfig.normalize( validatorStruct );
+			// make sure our application context defaults are applied to the validator struct, but do not override any explicitly passed values
+			validatorSettings.keySet().stream().forEach( key -> {
+				normalized.putIfAbsent( key, validatorSettings.get( key ) );
+			} );
+			validator = normalized;
 		} else if ( validator instanceof String validatorString && !validatorString.trim().isEmpty() ) {
 			// If the validator is a local file path (not an HTTP/HTTPS URL), expand it
 			if ( !validatorString.toLowerCase().startsWith( "http" ) ) {
@@ -84,7 +96,16 @@ public class XMLParse extends BIF {
 			}
 		}
 
-		return new XML( xml, caseSensitive, validator, lenient );
+		// If lenient is explicitly passed, inject it as an override into the validator struct
+		if ( lenient ) {
+			if ( validator instanceof IStruct validatorStruct ) {
+				validatorStruct.put( Key.lenientProcessing, true );
+			} else if ( validator == null ) {
+				validator = Struct.of( Key.lenientProcessing, true );
+			}
+		}
+
+		return new XML( xml, caseSensitive, validator );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
@@ -35,7 +35,10 @@ public class XMLParse extends BIF {
 	public XMLParse() {
 		super();
 		this.declaredArguments = new Argument[] {
-		    new Argument( false, "string", Key.XML )
+		    new Argument( false, "string", Key.XML ),
+		    new Argument( false, "boolean", Key.caseSensitive, true ),
+		    new Argument( false, "any", Key.validator ),
+		    new Argument( false, "boolean", Key.lenient, true )
 		};
 	}
 
@@ -44,6 +47,14 @@ public class XMLParse extends BIF {
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
+	 * 
+	 * @argument.XML The XML string to parse.
+	 * 
+	 * @argument.caseSensitive Whether the XML parsing should be case-sensitive.
+	 * 
+	 * @argument.validator An optional validator to apply to the parsed XML. This can be a a string containing a DTD or Schema, the URL of a DTD or Schema file, or a struct of xmlFeatures directives
+	 * 
+	 * @argument.lenient Whether the XML parsing should be lenient.
 	 *
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
@@ -60,7 +71,20 @@ public class XMLParse extends BIF {
 		if ( !xml.trim().startsWith( "<" ) ) {
 			xml = StringCaster.cast( FileSystemUtil.read( xml ) );
 		}
-		return new XML( xml );
+
+		Boolean	caseSensitive	= arguments.getAsBoolean( Key.caseSensitive );
+		Object	validator		= arguments.get( Key.validator );
+		Boolean	lenient			= arguments.getAsBoolean( Key.of( "lenient" ) );
+		if ( validator == null ) {
+			validator = context.getRequestContext().getApplicationListener().getSettings().get( Key.XMLSettings );
+		} else if ( validator instanceof String validatorString && !validatorString.trim().isEmpty() ) {
+			// If the validator is a local file path (not an HTTP/HTTPS URL), expand it
+			if ( !validatorString.toLowerCase().startsWith( "http" ) ) {
+				validator = FileSystemUtil.expandPath( context, validatorString ).absolutePath().toString();
+			}
+		}
+
+		return new XML( xml, caseSensitive, validator, lenient );
 	}
 
 }

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
@@ -78,7 +78,7 @@ public class XMLParse extends BIF {
 		Boolean	caseSensitive		= arguments.getAsBoolean( Key.caseSensitive );
 		Object	validator			= arguments.get( Key.validator );
 		Boolean	lenient				= arguments.getAsBoolean( Key.lenient );
-		IStruct	validatorSettings	= context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+		IStruct	validatorSettings	= context.getConfig().getAsStruct( Key.applicationSettings ).getAsStruct( Key.XMLSettings );
 		if ( validator == null ) {
 			validator = validatorSettings;
 		} else if ( validator instanceof IStruct validatorStruct ) {

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLParse.java
@@ -55,7 +55,7 @@ public class XMLParse extends BIF {
 	 * 
 	 * @argument.caseSensitive Whether the XML parsing should be case-sensitive.
 	 * 
-	 * @argument.validator An optional validator to apply to the parsed XML. This can be a a string containing a DTD or Schema, the URL of a DTD or Schema file, or a struct of xmlFeatures directives
+	 * @argument.validator An optional validator to apply to the parsed XML. This can be a string containing a path or URL to an XSD schema file, or a struct of XML security settings
 	 * 
 	 * @argument.lenient Whether the XML parsing should be lenient.
 	 *
@@ -75,13 +75,13 @@ public class XMLParse extends BIF {
 			xml = StringCaster.cast( FileSystemUtil.read( xml ) );
 		}
 
-		Boolean	caseSensitive	= arguments.getAsBoolean( Key.caseSensitive );
-		Object	validator		= arguments.get( Key.validator );
-		Boolean	lenient			= arguments.getAsBoolean( Key.lenient );
-		IStruct validatorSettings = context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+		Boolean	caseSensitive		= arguments.getAsBoolean( Key.caseSensitive );
+		Object	validator			= arguments.get( Key.validator );
+		Boolean	lenient				= arguments.getAsBoolean( Key.lenient );
+		IStruct	validatorSettings	= context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
 		if ( validator == null ) {
 			validator = validatorSettings;
-		} else if( validator instanceof IStruct validatorStruct ){
+		} else if ( validator instanceof IStruct validatorStruct ) {
 			// Normalize any setting names for backward compat
 			final IStruct normalized = XMLConfig.normalize( validatorStruct );
 			// make sure our application context defaults are applied to the validator struct, but do not override any explicitly passed values
@@ -96,12 +96,13 @@ public class XMLParse extends BIF {
 			}
 		}
 
-		// If lenient is explicitly passed, inject it as an override into the validator struct
-		if ( lenient ) {
+		// If lenient is explicitly passed, inject it as an override into the validator struct.
+		// The caller's value (true or false) is authoritative — it overrides any config-level default.
+		if ( lenient != null ) {
 			if ( validator instanceof IStruct validatorStruct ) {
-				validatorStruct.put( Key.lenientProcessing, true );
+				validatorStruct.put( Key.lenientProcessing, Boolean.TRUE.equals( lenient ) );
 			} else if ( validator == null ) {
-				validator = Struct.of( Key.lenientProcessing, true );
+				validator = Struct.of( Key.lenientProcessing, Boolean.TRUE.equals( lenient ) );
 			}
 		}
 

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
@@ -78,7 +78,7 @@ public class XMLTransform extends BIF {
 			xml = xmlCast;
 		} else {
 			IStruct xmlSettings = context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
-			xml = new XML( StringCaster.cast( xmlAny ), false, xmlSettings, false );
+			xml = new XML( StringCaster.cast( xmlAny ), false, xmlSettings );
 		}
 		String xsl = arguments.getAsString( Key.XSL );
 		// Is not XML. Must be file or URL

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
@@ -77,7 +77,7 @@ public class XMLTransform extends BIF {
 		if ( xmlAny instanceof XML xmlCast ) {
 			xml = xmlCast;
 		} else {
-			IStruct xmlSettings = context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+			IStruct xmlSettings = context.getConfig().getAsStruct( Key.applicationSettings ).getAsStruct( Key.XMLSettings );
 			xml = new XML( StringCaster.cast( xmlAny ), false, xmlSettings );
 		}
 		String xsl = arguments.getAsString( Key.XSL );

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/xml/XMLTransform.java
@@ -77,7 +77,8 @@ public class XMLTransform extends BIF {
 		if ( xmlAny instanceof XML xmlCast ) {
 			xml = xmlCast;
 		} else {
-			xml = new XML( StringCaster.cast( xmlAny ) );
+			IStruct xmlSettings = context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+			xml = new XML( StringCaster.cast( xmlAny ), false, xmlSettings, false );
 		}
 		String xsl = arguments.getAsString( Key.XSL );
 		// Is not XML. Must be file or URL

--- a/src/main/java/ortus/boxlang/runtime/config/Configuration.java
+++ b/src/main/java/ortus/boxlang/runtime/config/Configuration.java
@@ -48,6 +48,7 @@ import ortus.boxlang.runtime.config.segments.QueriesConfig;
 import ortus.boxlang.runtime.config.segments.SchedulerConfig;
 import ortus.boxlang.runtime.config.segments.SecurityConfig;
 import ortus.boxlang.runtime.config.segments.WatcherConfig;
+import ortus.boxlang.runtime.config.segments.XMLConfig;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
@@ -388,6 +389,11 @@ public class Configuration implements IConfigSegment {
 	 * The queries configuration — default query execution settings
 	 */
 	public QueriesConfig														queries								= new QueriesConfig();
+
+	/**
+	 * The XML parsing configuration — security and validation settings
+	 */
+	public XMLConfig															xml									= new XMLConfig();
 
 	/**
 	 * The container of runtimes configurations. Each runtime can collaborate settings by their name in this struct
@@ -837,6 +843,11 @@ public class Configuration implements IConfigSegment {
 			queries.process( StructCaster.cast( config.get( Key.queries ) ) );
 		}
 
+		// Process our xml configuration
+		if ( config.containsKey( Key.xml ) ) {
+			xml.process( StructCaster.cast( config.get( Key.xml ) ) );
+		}
+
 		return this;
 	}
 
@@ -1216,6 +1227,7 @@ public class Configuration implements IConfigSegment {
 		    Key.security, this.security.asStruct(),
 		    Key.scheduler, this.scheduler.asStruct(),
 		    Key.watcher, this.watcher.asStruct(),
+		    Key.xml, this.xml.asStruct(),
 		    Key.queries, this.queries.asStruct(),
 		    Key.timezone, this.timezone,
 		    Key.trustedCache, this.trustedCache,

--- a/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
@@ -1,0 +1,149 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.config.segments;
+
+import ortus.boxlang.runtime.config.util.PropertyHelper;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+
+/**
+ * This config segment is used to configure the default XML parsing security
+ * and validation settings for the BoxLang runtime.
+ *
+ * All settings use descriptive, unabbreviated names. Backward compatibility
+ * with legacy Lucee/CFML key names is handled in {@link #process(IStruct)}.
+ */
+public class XMLConfig implements IConfigSegment {
+
+	/**
+	 * Enable JAXP secure processing mode.
+	 * When true, the XML parser applies security limits to prevent XML
+	 * processing attacks.
+	 * Defaults to {@code true}.
+	 */
+	public boolean	secureProcessing			= true;
+
+	/**
+	 * Disallow DOCTYPE declarations in the XML document.
+	 * When true, parsing fails if the XML contains a DOCTYPE declaration.
+	 * Defaults to {@code true}.
+	 */
+	public boolean	disallowDoctypeDeclaration	= true;
+
+	/**
+	 * Allow external general entities in the XML document.
+	 * When false, external entities are disabled for security.
+	 * Defaults to {@code false}.
+	 * was {@code false} to mean "do not allow", which matches this default)
+	 */
+	public boolean	allowExternalEntities		= false;
+
+	/**
+	 * Enable lenient XML parsing.
+	 * When true, the parser relaxes well-formedness and validation
+	 * requirements — skipping external DTD loading when it is inaccessible.
+	 * Defaults to {@code false}.
+	 */
+	public boolean	lenientProcessing			= false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Default empty constructor
+	 */
+	public XMLConfig() {
+	}
+
+	/**
+	 * Processes the configuration struct. Each property supports both the new
+	 * canonical key name and the legacy Lucee/CFML key name for backward
+	 * compatibility.
+	 *
+	 * @param config the configuration struct
+	 *
+	 * @return the configuration
+	 */
+	@Override
+	public IConfigSegment process( IStruct config ) {
+		this.secureProcessing			= processBooleanCompat( config, Key.secureProcessing, Key.secure, this.secureProcessing );
+		this.disallowDoctypeDeclaration	= processBooleanCompat( config, Key.disallowDoctypeDeclaration, Key.disallowDoctypeDecl,
+		    this.disallowDoctypeDeclaration );
+		this.allowExternalEntities		= processBooleanCompat( config, Key.allowExternalEntities, Key.externalGeneralEntities,
+		    this.allowExternalEntities );
+		this.lenientProcessing			= processBooleanCompat( config, Key.lenientProcessing, Key.lenient, this.lenientProcessing );
+
+		return this;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	@Override
+	public IStruct asStruct() {
+		return Struct.ofNonConcurrent(
+		    Key.secureProcessing, this.secureProcessing,
+		    Key.disallowDoctypeDeclaration, this.disallowDoctypeDeclaration,
+		    Key.allowExternalEntities, this.allowExternalEntities,
+		    Key.lenientProcessing, this.lenientProcessing
+		);
+	}
+
+	/**
+	 * Utility method to read a boolean property with backward-compat fallback.
+	 * Checks the canonical key first, then falls back to the legacy key.
+	 *
+	 * @param config       The config struct
+	 * @param primaryKey   The canonical key to check first
+	 * @param legacyKey    The legacy key to check as fallback
+	 * @param defaultValue The default value if neither key is present
+	 *
+	 * @return The resolved boolean value
+	 */
+	private static boolean processBooleanCompat( IStruct config, Key primaryKey, Key legacyKey, boolean defaultValue ) {
+		// Check canonical key first
+		if ( config.containsKey( primaryKey ) ) {
+			return PropertyHelper.processBoolean( config, primaryKey, defaultValue );
+		}
+		// Fall back to legacy key
+		if ( config.containsKey( legacyKey ) ) {
+			return PropertyHelper.processBoolean( config, legacyKey, defaultValue );
+		}
+		return defaultValue;
+	}
+
+	/**
+	 * Normalize a raw settings struct by running it through an XMLConfig
+	 * and returning the canonicalized result. This is for use when Application.bx
+	 * settings may contain legacy key names.
+	 *
+	 * @param raw The raw settings struct (may contain legacy keys)
+	 *
+	 * @return A new struct with only canonical key names
+	 */
+	public static IStruct normalize( IStruct raw ) {
+		XMLConfig config = new XMLConfig();
+		config.process( raw );
+		return config.asStruct();
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
@@ -50,7 +50,7 @@ public class XMLConfig implements IConfigSegment {
 	 * Allow external general entities in the XML document.
 	 * When false, external entities are disabled for security.
 	 * Defaults to {@code false}.
-	 * was {@code false} to mean "do not allow", which matches this default)
+	 * Old key: {@code externalGeneralEntities}
 	 */
 	public boolean	allowExternalEntities		= false;
 

--- a/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/XMLConfig.java
@@ -50,7 +50,6 @@ public class XMLConfig implements IConfigSegment {
 	 * Allow external general entities in the XML document.
 	 * When false, external entities are disabled for security.
 	 * Defaults to {@code false}.
-	 * Old key: {@code externalGeneralEntities}
 	 */
 	public boolean	allowExternalEntities		= false;
 

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -323,6 +323,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		directoryList						= Key.of( "directoryList" );
 	public static final Key		directoryMove						= Key.of( "directoryMove" );
 	public static final Key		disabled							= Key.of( "disabled" );
+	public static final Key		disallowDoctypeDecl					= Key.of( "disallowDoctypeDecl" );
 	public static final Key		disallowedBIFs						= Key.of( "disallowedBIFs" );
 	public static final Key		disallowedComponents				= Key.of( "disallowedComponents" );
 	public static final Key		disallowedFileOperationExtensions	= Key.of( "disallowedFileOperationExtensions" );
@@ -405,6 +406,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		expressions							= Key.of( "expressions" );
 	public static final Key		extendedinfo						= Key.of( "extendedinfo" );
 	public static final Key		external							= Key.of( "external" );
+	public static final Key		externalGeneralEntities				= Key.of( "externalGeneralEntities" );
 	public static final Key		externalOnly						= Key.of( "externalOnly" );
 	public static final Key		exclude								= Key.of( "exclude" );
 	public static final Key		extrainfo							= Key.of( "extrainfo" );
@@ -569,6 +571,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		leaveIndex							= Key.of( "leaveIndex" );
 	public static final Key		len									= Key.of( "len" );
 	public static final Key		length								= Key.of( "length" );
+	public static final Key		lenient								= Key.of( "lenient" );
 	public static final Key		level								= Key.of( "level" );
 	public static final Key		lexical								= Key.of( "lexical" );
 	public static final Key		limit								= Key.of( "limit" );
@@ -1048,6 +1051,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		XMLNsURI							= Key.of( "XMLNsURI" );
 	public static final Key		XMLParent							= Key.of( "XMLParent" );
 	public static final Key		XMLRoot								= Key.of( "XMLRoot" );
+	public static final Key		XMLSettings							= Key.of( "XMLSettings" );
 	public static final Key		XMLString							= Key.of( "XMLString" );
 	public static final Key		XMLText								= Key.of( "XMLText" );
 	public static final Key		XMLType								= Key.of( "XMLType" );

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -324,6 +324,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		directoryMove						= Key.of( "directoryMove" );
 	public static final Key		disabled							= Key.of( "disabled" );
 	public static final Key		disallowDoctypeDecl					= Key.of( "disallowDoctypeDecl" );
+	public static final Key		disallowDoctypeDeclaration			= Key.of( "disallowDoctypeDeclaration" );
 	public static final Key		disallowedBIFs						= Key.of( "disallowedBIFs" );
 	public static final Key		disallowedComponents				= Key.of( "disallowedComponents" );
 	public static final Key		disallowedFileOperationExtensions	= Key.of( "disallowedFileOperationExtensions" );
@@ -405,6 +406,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		expression2							= Key.of( "expression2" );
 	public static final Key		expressions							= Key.of( "expressions" );
 	public static final Key		extendedinfo						= Key.of( "extendedinfo" );
+	public static final Key		allowExternalEntities				= Key.of( "allowExternalEntities" );
 	public static final Key		external							= Key.of( "external" );
 	public static final Key		externalGeneralEntities				= Key.of( "externalGeneralEntities" );
 	public static final Key		externalOnly						= Key.of( "externalOnly" );
@@ -572,6 +574,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		len									= Key.of( "len" );
 	public static final Key		length								= Key.of( "length" );
 	public static final Key		lenient								= Key.of( "lenient" );
+	public static final Key		lenientProcessing					= Key.of( "lenientProcessing" );
 	public static final Key		level								= Key.of( "level" );
 	public static final Key		lexical								= Key.of( "lexical" );
 	public static final Key		limit								= Key.of( "limit" );
@@ -840,6 +843,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		second								= Key.of( "second" );
 	public static final Key		seconds								= Key.of( "seconds" );
 	public static final Key		secure								= Key.of( "secure" );
+	public static final Key		secureProcessing					= Key.of( "secureProcessing" );
 	public static final Key		security							= Key.of( "security" );
 	public static final Key		seed								= Key.of( "seed" );
 	public static final Key		seekable							= Key.of( "seekable" );
@@ -1054,6 +1058,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		XMLSettings							= Key.of( "XMLSettings" );
 	public static final Key		XMLString							= Key.of( "XMLString" );
 	public static final Key		XMLText								= Key.of( "XMLText" );
+	public static final Key		xml									= Key.of( "xml" );
 	public static final Key		XMLType								= Key.of( "XMLType" );
 	public static final Key		XMLValue							= Key.of( "XMLValue" );
 	public static final Key		xpath								= Key.of( "xpath" );

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -64,6 +64,7 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.bifs.BoxMemberExpose;
 import ortus.boxlang.runtime.bifs.MemberDescriptor;
 import ortus.boxlang.runtime.bifs.global.string.UCFirst;
+import ortus.boxlang.runtime.config.segments.XMLConfig;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.KeyCaster;
@@ -104,60 +105,50 @@ public class XML implements Serializable, IStruct {
 	/**
 	 * Function service
 	 */
-	private static FunctionService	functionService			= BoxRuntime.getInstance().getFunctionService();
+	private static FunctionService	functionService		= BoxRuntime.getInstance().getFunctionService();
 
 	/**
 	 * Keys that are only valid for document nodes
 	 */
-	private static final Set<Key>	documentOnlyKeys		= Set.of( Key.XMLRoot, Key.XMLDocType );
+	private static final Set<Key>	documentOnlyKeys	= Set.of( Key.XMLRoot, Key.XMLDocType );
 
 	/**
 	 * Keys that are only valid for element nodes
 	 */
-	private static final Set<Key>	elementOnlyKeys			= Set.of( Key.XMLText, Key.XMLCdata, Key.XMLAttributes, Key.XMLChildren, Key.XMLParent,
+	private static final Set<Key>	elementOnlyKeys		= Set.of( Key.XMLText, Key.XMLCdata, Key.XMLAttributes, Key.XMLChildren, Key.XMLParent,
 	    Key.XMLNodes, Key.XMLNsPrefix, Key.XMLNsURI );
 
 	/**
 	 * Serial version UID
 	 */
-	private static final long		serialVersionUID		= 1L;
-
-	/**
-	 * Default XML security settings for parsing and validation
-	 */
-	public static final IStruct		DEFAULT_XML_SETTINGS	= Struct.of(
-	    Key.secure, true,
-	    Key.disallowDoctypeDecl, true,
-	    Key.externalGeneralEntities, false
-	);
+	private static final long		serialVersionUID	= 1L;
 
 	/**
 	 * CDATA contstants
 	 */
-	public static final String		cdataStart				= "<![CDATA[";
-	public static final String		cdataEnd				= "]]>";
+	public static final String		cdataStart			= "<![CDATA[";
+	public static final String		cdataEnd			= "]]>";
 
-	public static final String		xmlnsSeparator			= ":";
+	public static final String		xmlnsSeparator		= ":";
 
 	/**
 	 * Create a new XML Document from the given string
 	 */
 	public XML( String xmlData ) {
-		this( xmlData, false, DEFAULT_XML_SETTINGS, false );
+		this( xmlData, false, getDefaultXMLSettings() );
 	}
 
 	/**
-	 * Create a new XML Document from the given string with options for case sensitivity, validation, and leniency
+	 * Create a new XML Document from the given string with options for case sensitivity and validation
 	 * 
 	 * @param xmlData       The XML string to parse
 	 * @param caseSensitive Whether the XML parsing should be case-sensitive
-	 * @param validator     An optional struct of XML security settings to override the defaults
-	 * @param lenient       Whether the XML parsing should be lenient
+	 * @param validator     An optional struct of XML security settings to override the defaults, or a string path/URL to an XSD schema
 	 */
-	public XML( String xmlData, boolean caseSensitive, Object validator, boolean lenient ) {
+	public XML( String xmlData, boolean caseSensitive, Object validator ) {
 
 		this.type = caseSensitive ? TYPES.CASE_SENSITIVE : TYPES.DEFAULT;
-		DocumentBuilder	builder		= newDocumentBuilder( validator, lenient );
+		DocumentBuilder	builder		= newDocumentBuilder( validator );
 		InputSource		inputSource	= new InputSource( new StringReader( xmlData ) );
 		try {
 			node = builder.parse( inputSource );
@@ -186,19 +177,23 @@ public class XML implements Serializable, IStruct {
 	/**
 	 * Creates a new document builder for either parsing or document creation
 	 */
-	private static DocumentBuilder newDocumentBuilder( Object validator, boolean lenient ) {
+	private static DocumentBuilder newDocumentBuilder( Object validator ) {
 		DocumentBuilderFactory	factory	= DocumentBuilderFactory.newNSInstance();
 
 		final IStruct			xmlSettings;
 
 		if ( validator instanceof IStruct structValidator ) {
-			IStruct merged = StructCaster.cast( structValidator );
-			DEFAULT_XML_SETTINGS.keySet().forEach( key -> {
-				merged.putIfAbsent( key, DEFAULT_XML_SETTINGS.get( key ) );
+			IStruct	merged		= StructCaster.cast( structValidator );
+			// Normalize first to map any legacy keys to canonical keys
+			IStruct	normalized	= XMLConfig.normalize( merged );
+			// Then fill in defaults for any canonical keys not already set
+			IStruct	defaults	= getDefaultXMLSettings();
+			defaults.keySet().forEach( key -> {
+				normalized.putIfAbsent( key, defaults.get( key ) );
 			} );
-			xmlSettings = merged;
+			xmlSettings = normalized;
 		} else {
-			xmlSettings = DEFAULT_XML_SETTINGS;
+			xmlSettings = getDefaultXMLSettings();
 		}
 
 		if ( validator instanceof String validatorString && !validatorString.trim().isEmpty() ) {
@@ -221,28 +216,42 @@ public class XML implements Serializable, IStruct {
 		DocumentBuilder builder;
 		try {
 			// Security settings are always enforced regardless of leniency
-			if ( xmlSettings.containsKey( Key.secure ) ) {
-				factory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, xmlSettings.getAsBoolean( Key.secure ) );
+			if ( xmlSettings.containsKey( Key.secureProcessing ) ) {
+				factory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, xmlSettings.getAsBoolean( Key.secureProcessing ) );
 			}
-			if ( xmlSettings.containsKey( Key.disallowDoctypeDecl ) ) {
+			if ( xmlSettings.containsKey( Key.disallowDoctypeDeclaration ) ) {
 				factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl",
-				    xmlSettings.getAsBoolean( Key.disallowDoctypeDecl ) );
+				    xmlSettings.getAsBoolean( Key.disallowDoctypeDeclaration ) );
 			}
-			if ( xmlSettings.containsKey( Key.externalGeneralEntities ) ) {
+			if ( xmlSettings.containsKey( Key.allowExternalEntities ) ) {
 				factory.setFeature( "http://xml.org/sax/features/external-general-entities",
-				    xmlSettings.getAsBoolean( Key.externalGeneralEntities ) );
+				    xmlSettings.getAsBoolean( Key.allowExternalEntities ) );
 			}
+
+			// Determine lenient mode from the struct
+			boolean isLenient = xmlSettings.containsKey( Key.lenientProcessing )
+			    && xmlSettings.getAsBoolean( Key.lenientProcessing );
 
 			// When lenient is true, relax validation and well-formed XML requirements
 			// by skipping external DTD loading (which may be inaccessible) and disabling validation
-			factory.setFeature( "http://xml.org/sax/features/validation", !lenient );
-			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", !lenient );
+			factory.setFeature( "http://xml.org/sax/features/validation", !isLenient );
+			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", !isLenient );
 
 			builder = factory.newDocumentBuilder();
 		} catch ( ParserConfigurationException e ) {
 			throw new BoxRuntimeException( "Error creating XML document builder", e );
 		}
 		return builder;
+	}
+
+	/**
+	 * Get the default XML settings from the XMLConfig segment.
+	 * This is the canonical source of XML parsing defaults for the runtime.
+	 *
+	 * @return A struct with the default XML security and validation settings
+	 */
+	private static IStruct getDefaultXMLSettings() {
+		return BoxRuntime.getInstance().getConfiguration().xml.asStruct();
 	}
 
 	/**
@@ -542,7 +551,7 @@ public class XML implements Serializable, IStruct {
 
 		// If we were initialized with an empty XML object and an attempt is made to access a property, then we need to create the document now.
 		if ( node == null ) {
-			node = newDocumentBuilder( DEFAULT_XML_SETTINGS, false ).newDocument();
+			node = newDocumentBuilder( getDefaultXMLSettings() ).newDocument();
 			if ( name.equals( Key.XMLRoot ) ) {
 				return this;
 			} else if ( name.equals( Key.XMLAttributes ) ) {

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -17,10 +17,12 @@
  */
 package ortus.boxlang.runtime.types;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -31,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -39,6 +42,8 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -64,6 +69,7 @@ import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.KeyCaster;
 import ortus.boxlang.runtime.dynamic.casters.NumberCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.interop.DynamicInteropService;
 import ortus.boxlang.runtime.scopes.IntKey;
 import ortus.boxlang.runtime.scopes.Key;
@@ -98,39 +104,60 @@ public class XML implements Serializable, IStruct {
 	/**
 	 * Function service
 	 */
-	private static FunctionService	functionService		= BoxRuntime.getInstance().getFunctionService();
+	private static FunctionService	functionService			= BoxRuntime.getInstance().getFunctionService();
 
 	/**
 	 * Keys that are only valid for document nodes
 	 */
-	private static final Set<Key>	documentOnlyKeys	= Set.of( Key.XMLRoot, Key.XMLDocType );
+	private static final Set<Key>	documentOnlyKeys		= Set.of( Key.XMLRoot, Key.XMLDocType );
 
 	/**
 	 * Keys that are only valid for element nodes
 	 */
-	private static final Set<Key>	elementOnlyKeys		= Set.of( Key.XMLText, Key.XMLCdata, Key.XMLAttributes, Key.XMLChildren, Key.XMLParent,
+	private static final Set<Key>	elementOnlyKeys			= Set.of( Key.XMLText, Key.XMLCdata, Key.XMLAttributes, Key.XMLChildren, Key.XMLParent,
 	    Key.XMLNodes, Key.XMLNsPrefix, Key.XMLNsURI );
 
 	/**
 	 * Serial version UID
 	 */
-	private static final long		serialVersionUID	= 1L;
+	private static final long		serialVersionUID		= 1L;
+
+	/**
+	 * Default XML security settings for parsing and validation
+	 */
+	public static final IStruct		DEFAULT_XML_SETTINGS	= Struct.of(
+	    Key.secure, true,
+	    Key.disallowDoctypeDecl, true,
+	    Key.externalGeneralEntities, false
+	);
 
 	/**
 	 * CDATA contstants
 	 */
-	public static final String		cdataStart			= "<![CDATA[";
-	public static final String		cdataEnd			= "]]>";
+	public static final String		cdataStart				= "<![CDATA[";
+	public static final String		cdataEnd				= "]]>";
 
-	public static final String		xmlnsSeparator		= ":";
+	public static final String		xmlnsSeparator			= ":";
 
 	/**
 	 * Create a new XML Document from the given string
 	 */
 	public XML( String xmlData ) {
+		this( xmlData, false, DEFAULT_XML_SETTINGS, false );
+	}
 
-		this.type = TYPES.DEFAULT;
-		DocumentBuilder	builder		= newDocumentBuilder();
+	/**
+	 * Create a new XML Document from the given string with options for case sensitivity, validation, and leniency
+	 * 
+	 * @param xmlData       The XML string to parse
+	 * @param caseSensitive Whether the XML parsing should be case-sensitive
+	 * @param validator     An optional struct of XML security settings to override the defaults
+	 * @param lenient       Whether the XML parsing should be lenient
+	 */
+	public XML( String xmlData, boolean caseSensitive, Object validator, boolean lenient ) {
+
+		this.type = caseSensitive ? TYPES.CASE_SENSITIVE : TYPES.DEFAULT;
+		DocumentBuilder	builder		= newDocumentBuilder( validator, lenient );
 		InputSource		inputSource	= new InputSource( new StringReader( xmlData ) );
 		try {
 			node = builder.parse( inputSource );
@@ -159,15 +186,57 @@ public class XML implements Serializable, IStruct {
 	/**
 	 * Creates a new document builder for either parsing or document creation
 	 */
-	private static DocumentBuilder newDocumentBuilder() {
+	private static DocumentBuilder newDocumentBuilder( Object validator, boolean lenient ) {
 		DocumentBuilderFactory	factory	= DocumentBuilderFactory.newNSInstance();
 
-		DocumentBuilder			builder;
+		final IStruct			xmlSettings;
+
+		if ( validator instanceof IStruct structValidator ) {
+			IStruct merged = StructCaster.cast( structValidator );
+			DEFAULT_XML_SETTINGS.keySet().forEach( key -> {
+				merged.putIfAbsent( key, DEFAULT_XML_SETTINGS.get( key ) );
+			} );
+			xmlSettings = merged;
+		} else {
+			xmlSettings = DEFAULT_XML_SETTINGS;
+		}
+
+		if ( validator instanceof String validatorString && !validatorString.trim().isEmpty() ) {
+			String validatorLower = validatorString.toLowerCase();
+
+			try {
+				SchemaFactory	schemaFactory	= SchemaFactory.newInstance( XMLConstants.W3C_XML_SCHEMA_NS_URI );
+				Schema			schema;
+				if ( validatorLower.startsWith( "http" ) ) {
+					schema = schemaFactory.newSchema( new URL( validatorString ) );
+				} else {
+					schema = schemaFactory.newSchema( new File( validatorString ) );
+				}
+				factory.setSchema( schema );
+			} catch ( Exception e ) {
+				throw new BoxRuntimeException( "Error loading XML validator: " + validatorString, e );
+			}
+		}
+
+		DocumentBuilder builder;
 		try {
-			// Disable DTD validation
-			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false );
-			factory.setFeature( "http://xml.org/sax/features/validation", false );
-			factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", false );
+			// Security settings are always enforced regardless of leniency
+			if ( xmlSettings.containsKey( Key.secure ) ) {
+				factory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, xmlSettings.getAsBoolean( Key.secure ) );
+			}
+			if ( xmlSettings.containsKey( Key.disallowDoctypeDecl ) ) {
+				factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl",
+				    xmlSettings.getAsBoolean( Key.disallowDoctypeDecl ) );
+			}
+			if ( xmlSettings.containsKey( Key.externalGeneralEntities ) ) {
+				factory.setFeature( "http://xml.org/sax/features/external-general-entities",
+				    xmlSettings.getAsBoolean( Key.externalGeneralEntities ) );
+			}
+
+			// When lenient is true, relax validation and well-formed XML requirements
+			// by skipping external DTD loading (which may be inaccessible) and disabling validation
+			factory.setFeature( "http://xml.org/sax/features/validation", !lenient );
+			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", !lenient );
 
 			builder = factory.newDocumentBuilder();
 		} catch ( ParserConfigurationException e ) {
@@ -473,7 +542,7 @@ public class XML implements Serializable, IStruct {
 
 		// If we were initialized with an empty XML object and an attempt is made to access a property, then we need to create the document now.
 		if ( node == null ) {
-			node = newDocumentBuilder().newDocument();
+			node = newDocumentBuilder( DEFAULT_XML_SETTINGS, false ).newDocument();
 			if ( name.equals( Key.XMLRoot ) ) {
 				return this;
 			} else if ( name.equals( Key.XMLAttributes ) ) {

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -66,6 +66,7 @@ import ortus.boxlang.runtime.bifs.MemberDescriptor;
 import ortus.boxlang.runtime.bifs.global.string.UCFirst;
 import ortus.boxlang.runtime.config.segments.XMLConfig;
 import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.RequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
 import ortus.boxlang.runtime.dynamic.casters.KeyCaster;
 import ortus.boxlang.runtime.dynamic.casters.NumberCaster;
@@ -253,7 +254,12 @@ public class XML implements Serializable, IStruct {
 	 * @return A struct with the default XML security and validation settings
 	 */
 	private static IStruct getDefaultXMLSettings() {
-		return BoxRuntime.getInstance().getConfiguration().xml.asStruct();
+		IBoxContext context = RequestBoxContext.getCurrent();
+		if ( context != null ) {
+			return context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+		} else {
+			return BoxRuntime.getInstance().getConfiguration().xml.asStruct();
+		}
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -233,9 +233,11 @@ public class XML implements Serializable, IStruct {
 			    && xmlSettings.getAsBoolean( Key.lenientProcessing );
 
 			// When lenient is true, relax validation and well-formed XML requirements
-			// by skipping external DTD loading (which may be inaccessible) and disabling validation
 			factory.setFeature( "http://xml.org/sax/features/validation", !isLenient );
-			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", !isLenient );
+
+			// Always disable external DTD loading for security — even in lenient mode.
+			// External DTD fetching is an SSRF/XXE vector when disallowDoctypeDeclaration is false.
+			factory.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false );
 
 			builder = factory.newDocumentBuilder();
 		} catch ( ParserConfigurationException e ) {

--- a/src/main/java/ortus/boxlang/runtime/types/XML.java
+++ b/src/main/java/ortus/boxlang/runtime/types/XML.java
@@ -256,7 +256,7 @@ public class XML implements Serializable, IStruct {
 	private static IStruct getDefaultXMLSettings() {
 		IBoxContext context = RequestBoxContext.getCurrent();
 		if ( context != null ) {
-			return context.getRequestContext().getApplicationListener().getSettings().getAsStruct( Key.XMLSettings );
+			return context.getConfig().getAsStruct( Key.applicationSettings ).getAsStruct( Key.XMLSettings );
 		} else {
 			return BoxRuntime.getInstance().getConfiguration().xml.asStruct();
 		}

--- a/src/main/resources/config/boxlang.json
+++ b/src/main/resources/config/boxlang.json
@@ -93,17 +93,11 @@
 		"${boxlang-home}/modules"
 	],
 	// A collection of BoxLang custom component directories, they must be absolute paths
-	"customComponentsDirectory": [
-		"${boxlang-home}/global/components"
-	],
+	"customComponentsDirectory": ["${boxlang-home}/global/components"],
 	// A collection of directories to lookup box classes in (.bx files), they must be absolute paths
-	"classPaths": [
-		"${boxlang-home}/global/classes"
-	],
+	"classPaths": ["${boxlang-home}/global/classes"],
 	// A collection of directories we will class load all Java *.jar files from
-	"javaLibraryPaths": [
-		"${boxlang-home}/lib"
-	],
+	"javaLibraryPaths": ["${boxlang-home}/lib"],
 	// Query Default Options
 	"queries": {
 		// The default timeout for queries in seconds. 0 means no timeout. This can be overridden per query.
@@ -117,6 +111,17 @@
 		// The default named cache to use for query caching.
 		// This cache must be defined in the "caches" section of this config file.
 		"cacheProvider": "default"
+	},
+	// XML Parsing Settings
+	"xml": {
+		// Enable JAXP secure processing mode to prevent XML processing attacks
+		"secureProcessing": true,
+		// Disallow DOCTYPE declarations in XML documents
+		"disallowDoctypeDeclaration": true,
+		// Allow external general entities (disabled by default for security)
+		"allowExternalEntities": false,
+		// Enable lenient XML parsing — relaxes well-formedness and validation requirements
+		"lenientProcessing": false
 	},
 	// Logging Settings for the runtime
 	"logging": {
@@ -322,9 +327,7 @@
 				"appender": "file",
 				"encoder": "text",
 				"additive": false,
-				"categories": [
-					"com.zaxxer.hikari"
-				]
+				"categories": ["com.zaxxer.hikari"]
 			}
 		}
 	},
@@ -480,12 +483,12 @@
 	// When null, the runtime will use "struct" as the default format.
 	"defaultJSONQuerySerializationFormat": null,
 	/**
-	* Register any named caches here.
-	* The key is the name of the cache and the value is the cache configuration.
-	*
-	* A `provider` property is required and the value is the name of the cache provider or the fully qualified class name.
-	* The `properties` property is optional and is a struct of properties that are specific to the cache provider.
-	*/
+	 * Register any named caches here.
+	 * The key is the name of the cache and the value is the cache configuration.
+	 *
+	 * A `provider` property is required and the value is the name of the cache provider or the fully qualified class name.
+	 * The `properties` property is optional and is a struct of properties that are specific to the cache provider.
+	 */
 	"caches": {
 		// The configuration for the BoxLang `default` cache.  If empty, we use the defaults
 		// See the ortus.boxlang.runtime.config.segments.CacheConfig for all the available settings

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLParseTest.java
@@ -87,8 +87,13 @@ public class XMLParseTest {
 	public void testCanParseWithInaccessibleDTD() {
 		instance.executeSource(
 		    """
-		    result = XMLParse( '<!DOCTYPE root SYSTEM "http://www.mach-ii.com/dtds/mach-ii_1_9_0.dtd"><root><brad name="wood" /></root>' );
-		    """,
+		       result = XMLParse(
+		    	xml='<!DOCTYPE root SYSTEM "http://www.mach-ii.com/dtds/mach-ii_1_9_0.dtd"><root><brad name="wood" /></root>',
+		    	caseSensitive=false,
+		    	validator={ "disallowDoctypeDecl": false },
+		    	lenient=true
+		    );
+		       """,
 		    context
 		);
 		assertThat( variables.get( result ) ).isInstanceOf( XML.class );

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/xml/XMLParseTest.java
@@ -19,6 +19,7 @@
 package ortus.boxlang.runtime.bifs.global.xml;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,6 +34,7 @@ import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
 import ortus.boxlang.runtime.types.XML;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class XMLParseTest {
 
@@ -96,6 +98,222 @@ public class XMLParseTest {
 		       """,
 		    context
 		);
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	// -------------------------------------------------------------------
+	// Default security settings tests (no bx:application overrides)
+	// -------------------------------------------------------------------
+
+	@DisplayName( "It fails to parse XML with DOCTYPE when disallowDoctypeDeclaration is true (default)" )
+	@Test
+	public void testFailsToParseWithDoctypeByDefault() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item/></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		assertThrows(
+		    BoxRuntimeException.class,
+		    () -> instance.executeSource(
+		        """
+		        result = XMLParse( xmlWithDoctype );
+		        """,
+		        context )
+		);
+	}
+
+	@DisplayName( "It parses well-formed XML successfully with default settings" )
+	@Test
+	public void testParsesWellFormedXmlWithDefaults() {
+		instance.executeSource(
+		    """
+		    result = XMLParse( '<root><item>hello</item></root>' );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	// -------------------------------------------------------------------
+	// bx:application xmlSettings override tests
+	// -------------------------------------------------------------------
+
+	@DisplayName( "It parses XML with DOCTYPE when disallowDoctypeDeclaration is false via bx:application" )
+	@Test
+	public void testParsesWithDoctypeWhenDisallowDoctypeDeclarationFalse() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item>test</item></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp1" xmlSettings={ disallowDoctypeDeclaration: false, lenientProcessing: true };
+
+		    result = XMLParse( xmlWithDoctype );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "It fails to parse XML with DOCTYPE when disallowDoctypeDeclaration is true via bx:application" )
+	@Test
+	public void testFailsWithDoctypeWhenDisallowDoctypeDeclarationTrue() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item/></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		assertThrows(
+		    BoxRuntimeException.class,
+		    () -> instance.executeSource(
+		        """
+		        bx:application name="xmlTestApp2" xmlSettings={ disallowDoctypeDeclaration: true };
+		        result = XMLParse( xmlWithDoctype );
+		        """,
+		        context )
+		);
+	}
+
+	@DisplayName( "It parses with lenientProcessing true in bx:application settings" )
+	@Test
+	public void testParsesWithLenientProcessingTrueInAppSettings() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://www.mach-ii.com/dtds/mach-ii_1_9_0.dtd\"><root><item>test</item></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp3" xmlSettings={ disallowDoctypeDeclaration: false, lenientProcessing: true };
+
+		    result = XMLParse( xmlWithDoctype );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "It rejects well-formed DOCTYPE when disallowDoctypeDeclaration is true even with lenientProcessing" )
+	@Test
+	public void testRejectsDoctypeWithDisallowDoctypeDeclarationTrueAndLenientProcessing() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item/></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		assertThrows(
+		    BoxRuntimeException.class,
+		    () -> instance.executeSource(
+		        """
+		        bx:application name="xmlTestApp4" xmlSettings={ disallowDoctypeDeclaration: true, lenientProcessing: true };
+		        result = XMLParse( xmlWithDoctype );
+		        """,
+		        context )
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Legacy key backward compatibility tests (non-canonical key names)
+	// -------------------------------------------------------------------
+
+	@DisplayName( "It supports legacy key disallowDoctypeDecl in bx:application xmlSettings" )
+	@Test
+	public void testSupportsLegacyDisallowDoctypeDeclInAppSettings() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item>test</item></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp5" xmlSettings={ disallowDoctypeDecl: false, lenient: true };
+
+		    result = XMLParse( xmlWithDoctype );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "It supports legacy key secure in bx:application xmlSettings" )
+	@Test
+	public void testSupportsLegacySecureInAppSettings() {
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp6" xmlSettings={ secure: true, lenient: false };
+
+		    result = XMLParse( '<root><item>secure</item></root>' );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "It supports legacy key externalGeneralEntities in bx:application xmlSettings" )
+	@Test
+	public void testSupportsLegacyExternalGeneralEntitiesInAppSettings() {
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp7" xmlSettings={ externalGeneralEntities: false, lenient: false };
+
+		    result = XMLParse( '<root><item>entities</item></root>' );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "It supports all legacy keys together in bx:application xmlSettings" )
+	@Test
+	public void testSupportsAllLegacyKeysInAppSettings() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://example.invalid/dtd\"><root><item>test</item></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestAppAllLegacy" xmlSettings={ secure: false, disallowDoctypeDecl: false, externalGeneralEntities: false, lenient: true };
+
+		    result = XMLParse( xmlWithDoctype );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	// -------------------------------------------------------------------
+	// BIF argument override tests
+	// -------------------------------------------------------------------
+
+	@DisplayName( "Explicit lenient=true argument overrides config lenientProcessing=false" )
+	@Test
+	public void testLenientArgumentOverridesConfig() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://www.mach-ii.com/dtds/mach-ii_1_9_0.dtd\"><root><item>test</item></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp8" xmlSettings={ disallowDoctypeDeclaration: false, lenientProcessing: false };
+
+		    // lenient=true in the BIF call should override the config's lenientProcessing=false
+		    result = XMLParse( xmlWithDoctype, false, { "disallowDoctypeDecl": false }, true );
+		    """,
+		    context );
+		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
+	}
+
+	@DisplayName( "Explicit lenient=false argument overrides config lenientProcessing=true" )
+	@Test
+	public void testLenientFalseArgumentOverridesConfig() {
+		String xmlWithDoctype = "<!DOCTYPE root SYSTEM \"http://www.mach-ii.com/dtds/mach-ii_1_9_0.dtd\"><root><item/></root>";
+		variables.put( Key.of( "xmlWithDoctype" ), xmlWithDoctype );
+
+		assertThrows(
+		    BoxRuntimeException.class,
+		    () -> instance.executeSource(
+		        """
+		        bx:application name="xmlTestApp9" xmlSettings={ disallowDoctypeDeclaration: false, lenientProcessing: true };
+
+		        // lenient=false in the BIF call should override the config's lenientProcessing=true
+		        result = XMLParse( xmlWithDoctype, false, { "disallowDoctypeDeclaration": false }, false );
+		        """,
+		        context )
+		);
+	}
+
+	@DisplayName( "It parses with secureProcessing false via bx:application" )
+	@Test
+	public void testParsesWithSecureProcessingFalseInAppSettings() {
+		instance.executeSource(
+		    """
+		    bx:application name="xmlTestApp10" xmlSettings={ secureProcessing: false };
+
+		    result = XMLParse( '<root><item>hello</item></root>' );
+		    """,
+		    context );
 		assertThat( variables.get( result ) ).isInstanceOf( XML.class );
 	}
 


### PR DESCRIPTION
# Description

Adds default XML security settings handling for the runtime config, as well as handling in the XMLParse BIF.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-2617


## Type of change

Please delete options that are not relevant.

- [X] Improvement
- [X] New Feature
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
