### PR TITLE
misc. tweaks to ensure Application objects become GC'able after application shutdown

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -148,7 +148,7 @@ public class Application {
 	/**
 	 * session cleanup interceptor for: BEFORE_CACHE_ELEMENT_REMOVED
 	 */
-	private IInterceptorLambda				sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED;
+	private IInterceptorLambda				sessionCacheInterceptorBeforeCacheElementRemoved;
 
 	/**
 	 * The listener that started this application (used for stopping it)
@@ -755,7 +755,7 @@ public class Application {
 
 		this.sessionsCache
 		    .getInterceptorPool()
-		    .register( this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED = data -> {
+		    .register( this.sessionCacheInterceptorBeforeCacheElementRemoved = data -> {
 			    ICacheProvider targetCache = ( ICacheProvider ) data.get( "cache" );
 			    String		key			= ( String ) data.get( "key" );
 
@@ -1029,11 +1029,11 @@ public class Application {
 			    .forEach( session -> session.shutdown( this.getStartingListener() ) );
 		}
 
-		if ( this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED != null ) {
+		if ( this.sessionCacheInterceptorBeforeCacheElementRemoved != null ) {
 			this.sessionsCache.getInterceptorPool().unregister(
-			    this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED
+			    this.sessionCacheInterceptorBeforeCacheElementRemoved
 			);
-			this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED = null;
+			this.sessionCacheInterceptorBeforeCacheElementRemoved = null;
 		}
 
 		// Announce it to the listener

--- a/src/main/java/ortus/boxlang/runtime/application/Application.java
+++ b/src/main/java/ortus/boxlang/runtime/application/Application.java
@@ -52,6 +52,7 @@ import ortus.boxlang.runtime.dynamic.casters.LongCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
+import ortus.boxlang.runtime.events.IInterceptorLambda;
 import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
@@ -143,6 +144,11 @@ public class Application {
 	 * The sessions for this application
 	 */
 	private ICacheProvider					sessionsCache;
+
+	/**
+	 * session cleanup interceptor for: BEFORE_CACHE_ELEMENT_REMOVED
+	 */
+	private IInterceptorLambda				sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED;
 
 	/**
 	 * The listener that started this application (used for stopping it)
@@ -746,9 +752,10 @@ public class Application {
 		// Now store it
 		this.sessionsCache = this.cacheService.getCache( sessionCacheName );
 		// Register the session cleanup interceptor for: BEFORE_CACHE_ELEMENT_REMOVED
+
 		this.sessionsCache
 		    .getInterceptorPool()
-		    .register( data -> {
+		    .register( this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED = data -> {
 			    ICacheProvider targetCache = ( ICacheProvider ) data.get( "cache" );
 			    String		key			= ( String ) data.get( "key" );
 
@@ -1020,6 +1027,13 @@ public class Application {
 			    .map( Key::of )
 			    .map( sessionKey -> ( Session ) this.sessionsCache.get( sessionKey.getName() ).get() )
 			    .forEach( session -> session.shutdown( this.getStartingListener() ) );
+		}
+
+		if ( this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED != null ) {
+			this.sessionsCache.getInterceptorPool().unregister(
+			    this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED
+			);
+			this.sessionInterceptor_BEFORE_CACHE_ELEMENT_REMOVED = null;
 		}
 
 		// Announce it to the listener

--- a/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.java
+++ b/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.java
@@ -228,6 +228,10 @@ public class BoxCacheProvider extends AbstractCacheProvider {
 	 * Shutdown the cache provider
 	 */
 	public void shutdown() {
+		if ( this.reapingFuture != null ) {
+			this.reapingFuture.cancel( true );
+		}
+		this.enabled.set( false );
 		this.objectStore.shutdown();
 		logger.debug( "BoxCache [{}] has been shutdown", getName().getName() );
 	}

--- a/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
+++ b/src/main/java/ortus/boxlang/runtime/events/InterceptorPool.java
@@ -453,6 +453,10 @@ public class InterceptorPool {
 		return unregister( target, states.toArray( new Key[ 0 ] ) );
 	}
 
+	public InterceptorPool unregister( IInterceptorLambda interceptor ) {
+		return unregister( DynamicObject.of( interceptor ) );
+	}
+
 	/**
 	 * This method registers a BoxLang interceptor with the pool by metadata inspection.
 	 * It will inspect the interceptor for methods that match the states that the

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
@@ -676,7 +676,12 @@ public class DynamicObject implements IReferenceable, Serializable {
 	}
 
 	/**
-	 * Equals override. Tests if the target class or instance is equal to the other object
+	 * Equals override.
+	 * Check for instance equality (by both reference and logical equality)
+	 * Then for class equality (by reference equality against Class<?> obj)
+	 * 
+	 * If there is an instance, do not consider class equality, because two DynamicObjects of different
+	 * instances should not be considered equal if they only share a Class
 	 */
 	@Override
 	public boolean equals( Object obj ) {
@@ -684,27 +689,32 @@ public class DynamicObject implements IReferenceable, Serializable {
 			return false;
 		}
 
-		if ( obj instanceof DynamicObject ) {
-			DynamicObject other = ( DynamicObject ) obj;
+		if ( this == obj ) {
+			return true;
+		}
 
-			if ( this.targetClass != null && other.targetClass != null ) {
-				return this.targetClass.equals( other.targetClass );
-			}
-
+		if ( obj instanceof DynamicObject other ) {
 			if ( this.targetInstance != null && other.targetInstance != null ) {
-				return this.targetInstance.equals( other.targetInstance );
+				// Both sides wrap an instance, check instance equality
+				return this.targetInstance == other.targetInstance || this.targetInstance.equals( other.targetInstance );
 			}
+
+			if ( this.targetInstance == null && this.targetClass != null && other.targetInstance == null && other.targetClass != null ) {
+				// Neither side wraps an instance, check class equality
+				return this.targetClass == other.targetClass;
+			}
+
+			return false;
 		}
 
-		// If the object is a Class, then compare the class
-		if ( obj instanceof Class && this.targetClass != null ) {
-			return this.targetClass.equals( obj );
-		}
-
-		// Else we tests if the object is equal to the instance,
-		// if ther is no instance, then we return false
 		if ( this.targetInstance != null ) {
-			return this.targetInstance.equals( obj );
+			// We wrap an instance, check if it is equal to target
+			return this.targetInstance == obj || this.targetInstance.equals( obj );
+		}
+
+		if ( this.targetInstance == null && this.targetClass != null && obj instanceof Class<?> ) {
+			// We do not wrap an instance, check if we're wrapping a class that is equal to the target
+			return this.targetClass == obj;
 		}
 
 		return false;

--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicObject.java
@@ -726,12 +726,12 @@ public class DynamicObject implements IReferenceable, Serializable {
 	 */
 	@Override
 	public int hashCode() {
-		if ( this.targetClass != null ) {
-			return this.targetClass.hashCode();
-		}
-
 		if ( this.targetInstance != null ) {
 			return this.targetInstance.hashCode();
+		}
+
+		if ( this.targetClass != null ) {
+			return this.targetClass.hashCode();
 		}
 
 		return 0;

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectable.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectable.java
@@ -1,0 +1,148 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.system;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.management.ManagementFactory;
+import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.application.Application;
+import ortus.boxlang.runtime.context.ApplicationBoxContext;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.services.ApplicationService;
+
+public class ApplicationBecomesGarbageCollectable {
+
+	static BoxRuntime			runtime;
+	static ApplicationService	applicationService;
+
+	@BeforeAll
+	public static void setUp() {
+		runtime				= BoxRuntime.getInstance( true );
+		applicationService	= runtime.getApplicationService();
+	}
+
+	@DisplayName( "It can stop an application and the Application object becomes unreachable" )
+	@Test
+	@Timeout( 60 )
+	void testItCanStopAnApplication() {
+		String						appName	= "unit-test-app-collect-" + UUID.randomUUID();
+		Key							appKey	= Key.of( appName );
+		WeakReference<Application>	appRef	= startAndStopApplication( appName, appKey );
+
+		assertThatWeakReferentIsNoLongerStronglyReachable( appRef );
+	}
+
+	/**
+	 * Run start/stop in a callee so the request context is not a Java-frame local
+	 * on the thread that GCs and dumps the heap.
+	 */
+	private static WeakReference<Application> startAndStopApplication( String appName, Key appKey ) {
+		IBoxContext context = new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		try {
+			runtime.executeSource(
+			    """
+			    bx:application name="%s" sessionmanagement="true";
+			         """.formatted( appName ),
+			    context );
+
+			Application					targetApp	= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+			WeakReference<Application>	appRef		= new WeakReference<>( targetApp );
+
+			assertThat( targetApp.hasStarted() ).isTrue();
+			assertThat( targetApp.getSessionCount() ).isEqualTo( 1 );
+			assertThat( targetApp.getStartTime() ).isNotNull();
+			assertThat( applicationService.hasApplication( appKey ) ).isTrue();
+
+			runtime.executeSource(
+			    """
+			    applicationStop();
+			    """,
+			    context );
+
+			assertThat( targetApp.hasStarted() ).isFalse();
+			assertThat( targetApp.getSessionCount() ).isEqualTo( 0 );
+			assertThat( targetApp.getStartTime() ).isNull();
+			assertThat( applicationService.hasApplication( appKey ) ).isFalse();
+
+			return appRef;
+		} finally {
+			context.shutdown();
+		}
+	}
+
+	public static volatile byte[] __garbage = null;
+
+	// Try (best effort) to force a GC run, with the caller expecting that the supplied WeakRef refers
+	// to something no longer strongly reachable, meaning that the referent will be GC'd, and before this
+	// function returns we assert that calling `get` returns null because the object was absolutely collected.
+	private static void assertThatWeakReferentIsNoLongerStronglyReachable( WeakReference<?> ref ) {
+		for ( int i = 0; i < 50; i++ ) {
+			System.gc();
+			if ( ref.get() == null ) {
+				return;
+			}
+			__garbage		= new byte[ 1024 * 1024 ];
+			__garbage[ 0 ]	= 1;
+			try {
+				Thread.sleep( 20 );
+			} catch ( InterruptedException e ) {
+				Thread.currentThread().interrupt();
+				break;
+			}
+		}
+		try {
+			assertThat( ref.get() ).isNull();
+		} catch ( Throwable e ) {
+			if ( System.getenv( "HEAPDUMPS" ) instanceof String s && s.equals( "1" ) ) {
+				Path dump = dumpHeap( "application-still-reachable" );
+				System.out.println( "Heap dump written to " + dump.toAbsolutePath() );
+			}
+
+			throw e;
+		}
+	}
+
+	private static Path dumpHeap( String label ) {
+		try {
+			Path dir = Path.of( "build", "heapdumps" );
+			Files.createDirectories( dir );
+			String					stamp	= LocalDateTime.now().format( DateTimeFormatter.ofPattern( "yyyyMMddHHmmss" ) );
+			Path					dump	= dir.resolve( label + "-" + stamp + ".hprof" );
+			HotSpotDiagnosticMXBean	mxBean	= ManagementFactory.getPlatformMXBean( HotSpotDiagnosticMXBean.class );
+			mxBean.dumpHeap( dump.toAbsolutePath().toString(), true );
+			return dump;
+		} catch ( Exception e ) {
+			throw new RuntimeException( "Failed to write heap dump", e );
+		}
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectableTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectableTest.java
@@ -39,7 +39,7 @@ import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ApplicationService;
 
-public class ApplicationBecomesGarbageCollectable {
+public class ApplicationBecomesGarbageCollectableTest {
 
 	static BoxRuntime			runtime;
 	static ApplicationService	applicationService;

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectableTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/ApplicationBecomesGarbageCollectableTest.java
@@ -15,6 +15,7 @@
 package ortus.boxlang.runtime.bifs.global.system;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.lang.management.ManagementFactory;
 import java.lang.ref.WeakReference;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Timeout;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.application.Application;
+import ortus.boxlang.runtime.cache.providers.BoxCacheProvider;
 import ortus.boxlang.runtime.context.ApplicationBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
@@ -59,6 +61,87 @@ public class ApplicationBecomesGarbageCollectableTest {
 		WeakReference<Application>	appRef	= startAndStopApplication( appName, appKey );
 
 		assertThatWeakReferentIsNoLongerStronglyReachable( appRef );
+	}
+
+	@DisplayName( "Stopping an application with a cache does not leave boxcache-reaper tasks holding the Application" )
+	@Test
+	@Timeout( 60 )
+	void testBoxCacheReaperDoesNotRetainApplicationAfterStop() {
+		String		appName		= "unit-test-app-reaper-" + UUID.randomUUID();
+		Key			appKey		= Key.of( appName );
+		Key			cacheKey	= Key.of( appName + ":reaperProbe" );
+		ReaperProbe	probe		= startAppWithCacheAndStop( appName, appKey, cacheKey );
+
+		try {
+			assertThat( applicationService.hasApplication( appKey ) ).isFalse();
+			assertThat( runtime.getCacheService().hasCache( cacheKey ) ).isFalse();
+
+			BoxCacheProvider leftoverCache = probe.cacheRef().get();
+			if ( leftoverCache != null && leftoverCache.getReapingFuture() != null ) {
+				assertWithMessage(
+				    "boxcache-reaper should be cancelled on applicationStop so it cannot pin the Application"
+				).that( leftoverCache.getReapingFuture().isCancelled() ).isTrue();
+			}
+			leftoverCache = null;
+
+			assertThatWeakReferentIsNoLongerStronglyReachable( probe.appRef() );
+			assertThatWeakReferentIsNoLongerStronglyReachable( probe.cacheRef() );
+		} finally {
+			BoxCacheProvider leftoverCache = probe.cacheRef().get();
+			if ( leftoverCache != null && leftoverCache.getReapingFuture() != null ) {
+				leftoverCache.getReapingFuture().cancel( true );
+			}
+		}
+	}
+
+	private record ReaperProbe( WeakReference<Application> appRef, WeakReference<BoxCacheProvider> cacheRef ) {
+	}
+
+	/**
+	 * Start an application with a dedicated cache (which starts a boxcache-reaper),
+	 * then applicationStop(). Done in a callee so the request context is not a
+	 * Java-frame local on the asserting thread.
+	 */
+	private static ReaperProbe startAppWithCacheAndStop( String appName, Key appKey, Key cacheKey ) {
+		IBoxContext context = new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		try {
+			runtime.executeSource(
+			    """
+			    bx:application name="%s" caches={
+			    	reaperProbe : {
+			    		provider : "BoxCache",
+			    		properties : {
+			    			maxObjects : 10,
+			    			reapFrequency : 120
+			    		}
+			    	}
+			    };
+			    """.formatted( appName ),
+			    context );
+
+			Application						targetApp	= context.getParentOfType( ApplicationBoxContext.class ).getApplication();
+			BoxCacheProvider				cache		= ( BoxCacheProvider ) runtime.getCacheService().getCache( cacheKey );
+			WeakReference<Application>		appRef		= new WeakReference<>( targetApp );
+			WeakReference<BoxCacheProvider>	cacheRef	= new WeakReference<>( cache );
+
+			assertThat( targetApp.hasStarted() ).isTrue();
+			assertThat( applicationService.hasApplication( appKey ) ).isTrue();
+			assertThat( cache.getReapingFuture().isCancelled() ).isFalse();
+
+			runtime.executeSource(
+			    """
+			    applicationStop();
+			    """,
+			    context );
+
+			assertThat( targetApp.hasStarted() ).isFalse();
+			assertThat( applicationService.hasApplication( appKey ) ).isFalse();
+			assertThat( runtime.getCacheService().hasCache( cacheKey ) ).isFalse();
+
+			return new ReaperProbe( appRef, cacheRef );
+		} finally {
+			context.shutdown();
+		}
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
+++ b/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
@@ -81,6 +81,20 @@ public class BoxCacheProviderTest {
 	}
 
 	@Test
+	@DisplayName( "Shutdown cancels the reaping future" )
+	void testShutdownCancelsReaper() {
+		BoxCacheProvider cache = new BoxCacheProvider();
+		cache.configure( cacheService, new CacheConfig( Key.of( "shutdown-reaper-test" ) ) );
+		assertThat( cache.getReapingFuture() ).isNotNull();
+		assertThat( cache.getReapingFuture().isCancelled() ).isFalse();
+
+		cache.shutdown();
+
+		assertThat( cache.getReapingFuture().isCancelled() ).isTrue();
+		assertThat( cache.isEnabled() ).isFalse();
+	}
+
+	@Test
 	@DisplayName( "Get the cache store metdata key map" )
 	void testGetCacheStoreMetadataKeyMap() {
 		assertThat( boxCache.getStoreMetadataKeyMap() ).isNotNull();

--- a/src/test/java/ortus/boxlang/runtime/events/InterceptorPoolTest.java
+++ b/src/test/java/ortus/boxlang/runtime/events/InterceptorPoolTest.java
@@ -119,6 +119,95 @@ public class InterceptorPoolTest {
 		assertThat( data.get( "counter" ) ).isEqualTo( 1 );
 	}
 
+	@DisplayName( "It can unregister lambdas as interceptors" )
+	@Test
+	void testItCanUnregisterLambdasAsInterceptors() {
+		Key k = Key.of( "onRequestStart" );
+
+		{
+			IInterceptorLambda handler;
+			pool.register(
+			    handler = data -> false,
+			    k
+			);
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler ) ) ).isTrue();
+
+			pool.unregister( handler );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler ) ) ).isFalse();
+		}
+
+		{
+			IInterceptorLambda handler;
+			pool.register(
+			    handler = data -> false,
+			    k
+			);
+
+			// double register, appears to be a no-op 2nd time around
+			pool.register( handler );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler ) ) ).isTrue();
+
+			pool.unregister( handler );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler ) ) ).isFalse();
+		}
+
+		{
+			IInterceptorLambda	handler1;
+			IInterceptorLambda	handler2;
+			pool.register(
+			    handler1 = data -> false,
+			    k
+			);
+			pool.register(
+			    handler2 = data -> false,
+			    k
+			);
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isTrue();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isTrue();
+
+			pool.unregister( handler1 );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isFalse();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isTrue();
+
+			pool.unregister( handler2 );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isFalse();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isFalse();
+		}
+
+		{
+			IInterceptorLambda	handler1;
+			IInterceptorLambda	handler2;
+			pool.register(
+			    handler1 = data -> false,
+			    k
+			);
+			pool.register(
+			    handler2 = data -> false,
+			    k
+			);
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isTrue();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isTrue();
+
+			pool.unregister( handler2 );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isTrue();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isFalse();
+
+			pool.unregister( handler1 );
+
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler1 ) ) ).isFalse();
+			assertThat( pool.getState( k ).exists( DynamicObject.of( handler2 ) ) ).isFalse();
+		}
+	}
+
 	@DisplayName( "it can unregister interceptors with a specific state" )
 	@Test
 	void testItCanUnregisterInterceptors() {

--- a/src/test/java/ortus/boxlang/runtime/interop/DynamicObjectTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interop/DynamicObjectTest.java
@@ -626,4 +626,16 @@ public class DynamicObjectTest {
 		assertThat( stringClass.equals( stringClass2 ) ).isTrue();
 	}
 
+	@DisplayName( "A DynamicObject(foo) is not equal to DynamicObject(Foo.class)" )
+	@Test
+	void dynamicObjectOfInstanceNotEqualToDynamicObjectOfClass() {
+		record Foo() {
+		}
+		var foo = new Foo();
+
+		assertThat( DynamicObject.of( foo ) ).isNotEqualTo( DynamicObject.of( Foo.class ) );
+		assertThat( DynamicObject.of( Foo.class ) ).isNotEqualTo( DynamicObject.of( foo ) );
+		assertThat( DynamicObject.of( foo ) ).isEqualTo( DynamicObject.of( foo ) );
+	}
+
 }


### PR DESCRIPTION
draft of work to try to find why Application objects are being retained after `applicationStop()`.

Primarily this holds a reference to the interceptor lambda, and then uses that reference to unregister the listener during shutdown. There is some noise to make "unregister" work a little nicer with `IInterceptorLambda`.


## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
