### PR TITLE
BL-2627 Add `check` CLI action command for syntax-only validation

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/SyntaxCheck.java
+++ b/src/main/java/ortus/boxlang/compiler/SyntaxCheck.java
@@ -68,6 +68,14 @@ public final class SyntaxCheck {
 	 * @param args command-line arguments
 	 */
 	public static void main( String[] args ) {
+		// Check for help first before initializing BoxRuntime
+		for ( String arg : args ) {
+			if ( arg.equalsIgnoreCase( "--help" ) || arg.equalsIgnoreCase( "-h" ) ) {
+				printHelp( System.out );
+				System.exit( 0 );
+			}
+		}
+
 		BoxRuntime runtime = BoxRuntime.getInstance();
 		try {
 			System.exit( run( args, System.out, System.err ) );
@@ -133,9 +141,8 @@ public final class SyntaxCheck {
 				return 1;
 			}
 			if ( Files.isDirectory( sourcePath ) ) {
-				try {
-					Files.walk( sourcePath, FileVisitOption.FOLLOW_LINKS )
-					    .filter( Files::isRegularFile )
+				try ( var walk = Files.walk( sourcePath, FileVisitOption.FOLLOW_LINKS ) ) {
+					walk.filter( Files::isRegularFile )
 					    .filter( path -> SUPPORTED_EXTENSIONS.contains( extensionOf( path ) ) )
 					    .filter( path -> !DiskClassUtil.isJavaByteCode( path.toFile() ) )
 					    .forEach( targets::add );
@@ -204,8 +211,8 @@ public final class SyntaxCheck {
 			}
 			ParsingResult result = new Parser().parse( path.toFile() );
 			return new FileResult( path, result.isCorrect(), result.getIssues() );
-		} catch ( Throwable t ) {
-			String message = t.getMessage() != null ? t.getMessage() : t.toString();
+		} catch ( Exception e ) {
+			String message = e.getMessage() != null ? e.getMessage() : e.toString();
 			return new FileResult( path, false, List.of( new Issue( message, null ) ) );
 		}
 	}

--- a/src/main/java/ortus/boxlang/compiler/SyntaxCheck.java
+++ b/src/main/java/ortus/boxlang/compiler/SyntaxCheck.java
@@ -1,0 +1,338 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.compiler;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import ortus.boxlang.compiler.ast.Issue;
+import ortus.boxlang.compiler.parser.Parser;
+import ortus.boxlang.compiler.parser.ParsingResult;
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.types.util.JSONUtil;
+
+/**
+ * I am a CLI tool that checks whether one or more BoxLang/CFML source files are syntactically
+ * valid, without executing them or compiling them to bytecode - similar to {@code bash -n} or
+ * {@code node --check}.
+ */
+public final class SyntaxCheck {
+
+	private static final Set<String> SUPPORTED_EXTENSIONS = Set.of( "cfm", "cfc", "cfs", "bx", "bxs", "bxm" );
+
+	/**
+	 * The result of checking a single file
+	 *
+	 * @param file   the file that was checked
+	 * @param valid  whether the file parsed without any syntax issues
+	 * @param issues the list of syntax issues found (empty when valid)
+	 */
+	private record FileResult( Path file, boolean valid, List<Issue> issues ) {
+	}
+
+	/**
+	 * Prevents instantiation of this utility class.
+	 */
+	private SyntaxCheck() {
+	}
+
+	/**
+	 * Executes the syntax checker CLI and exits the JVM with the resulting status code.
+	 *
+	 * @param args command-line arguments
+	 */
+	public static void main( String[] args ) {
+		BoxRuntime runtime = BoxRuntime.getInstance();
+		try {
+			System.exit( run( args, System.out, System.err ) );
+		} finally {
+			runtime.shutdown();
+		}
+	}
+
+	/**
+	 * Runs the syntax checker against the provided arguments and streams.
+	 *
+	 * @param args command-line arguments
+	 * @param out  standard output stream for user-facing messages
+	 * @param err  standard error stream for error messages
+	 *
+	 * @return {@code 0} if every checked file is syntactically valid, otherwise {@code 1}
+	 */
+	static int run( String[] args, PrintStream out, PrintStream err ) {
+		String			source	= null;
+		List<String>	files	= new ArrayList<>();
+		boolean			quiet	= false;
+		String			format	= "text";
+
+		for ( int i = 0; i < args.length; i++ ) {
+			String arg = args[ i ];
+			if ( arg.equalsIgnoreCase( "--help" ) || arg.equalsIgnoreCase( "-h" ) ) {
+				printHelp( out );
+				return 0;
+			} else if ( arg.equalsIgnoreCase( "--source" ) ) {
+				if ( i + 1 >= args.length ) {
+					err.println( "Error: --source requires a path" );
+					return 1;
+				}
+				source = args[ ++i ];
+			} else if ( arg.equalsIgnoreCase( "--quiet" ) || arg.equalsIgnoreCase( "-q" ) ) {
+				quiet = true;
+			} else if ( arg.equalsIgnoreCase( "--format" ) ) {
+				if ( i + 1 >= args.length ) {
+					err.println( "Error: --format requires a value (text|json)" );
+					return 1;
+				}
+				format = args[ ++i ].toLowerCase();
+				if ( !format.equals( "text" ) && !format.equals( "json" ) ) {
+					err.println( "Error: --format must be 'text' or 'json'" );
+					return 1;
+				}
+			} else if ( arg.startsWith( "--" ) ) {
+				err.println( "Error: Unknown option: " + arg );
+				return 1;
+			} else {
+				files.add( arg );
+			}
+		}
+
+		Set<Path>				targets		= new LinkedHashSet<>();
+		Map<Path, FileResult>	resultMap	= new ConcurrentHashMap<>();
+		boolean					usageError	= false;
+
+		if ( source != null ) {
+			Path sourcePath = resolvePath( source );
+			if ( !Files.exists( sourcePath ) ) {
+				err.println( "Error: --source path does not exist: " + sourcePath );
+				return 1;
+			}
+			if ( Files.isDirectory( sourcePath ) ) {
+				try {
+					Files.walk( sourcePath, FileVisitOption.FOLLOW_LINKS )
+					    .filter( Files::isRegularFile )
+					    .filter( path -> SUPPORTED_EXTENSIONS.contains( extensionOf( path ) ) )
+					    .filter( path -> !DiskClassUtil.isJavaByteCode( path.toFile() ) )
+					    .forEach( targets::add );
+				} catch ( IOException e ) {
+					err.println( "Error walking source path: " + e.getMessage() );
+					return 1;
+				}
+			} else {
+				targets.add( sourcePath );
+			}
+		}
+
+		for ( String f : files ) {
+			Path filePath = resolvePath( f );
+			if ( !Files.exists( filePath ) ) {
+				err.println( "❌ File does not exist: " + filePath );
+				usageError = true;
+				continue;
+			}
+			if ( !SUPPORTED_EXTENSIONS.contains( extensionOf( filePath ) ) ) {
+				err.println( "⚠️  Skipping unsupported file type: " + filePath );
+				continue;
+			}
+			targets.add( filePath );
+		}
+
+		if ( targets.isEmpty() ) {
+			err.println( "Error: No files to check. Provide one or more file paths or --source <path>." );
+			return 1;
+		}
+
+		targets.parallelStream().forEach( path -> resultMap.put( path, checkFile( path ) ) );
+
+		int	validCount		= 0;
+		int	invalidCount	= 0;
+		for ( FileResult result : resultMap.values() ) {
+			if ( result.valid() ) {
+				validCount++;
+			} else {
+				invalidCount++;
+			}
+		}
+
+		if ( format.equals( "json" ) ) {
+			if ( !printJSON( out, err, targets, resultMap ) ) {
+				return 1;
+			}
+		} else {
+			printText( out, err, targets, resultMap, quiet, validCount, invalidCount );
+		}
+
+		return ( invalidCount > 0 || usageError ) ? 1 : 0;
+	}
+
+	/**
+	 * Parses a single file and reports whether it is syntactically valid.
+	 *
+	 * @param path the file to check
+	 *
+	 * @return the result of the check
+	 */
+	private static FileResult checkFile( Path path ) {
+		try {
+			if ( DiskClassUtil.isJavaByteCode( path.toFile() ) ) {
+				return new FileResult( path, false, List.of( new Issue( "Skipped: precompiled bytecode file", null ) ) );
+			}
+			ParsingResult result = new Parser().parse( path.toFile() );
+			return new FileResult( path, result.isCorrect(), result.getIssues() );
+		} catch ( Throwable t ) {
+			String message = t.getMessage() != null ? t.getMessage() : t.toString();
+			return new FileResult( path, false, List.of( new Issue( message, null ) ) );
+		}
+	}
+
+	/**
+	 * Prints human-readable check results: silent per-file success, an error block per invalid
+	 * file, and a final summary line.
+	 */
+	private static void printText( PrintStream out, PrintStream err, Set<Path> targets, Map<Path, FileResult> resultMap, boolean quiet, int validCount,
+	    int invalidCount ) {
+		for ( Path path : targets ) {
+			FileResult result = resultMap.get( path );
+			if ( result.valid() ) {
+				if ( !quiet ) {
+					out.println( "✅ " + path );
+				}
+			} else {
+				err.println( "❌ " + path );
+				for ( Issue issue : result.issues() ) {
+					err.println( "   " + issue.toString() );
+				}
+			}
+		}
+		if ( !quiet ) {
+			out.println();
+			out.println( "───────────────────────────────" );
+			out.println( String.format( "✅ %d valid   ❌ %d invalid   (%d files checked)", validCount, invalidCount, targets.size() ) );
+		}
+	}
+
+	/**
+	 * Prints check results as a JSON array of {@code {file, valid, issues}} records, for
+	 * CI/editor tooling integration.
+	 *
+	 * @return {@code true} if the JSON was written successfully, {@code false} on a serialization error
+	 */
+	private static boolean printJSON( PrintStream out, PrintStream err, Set<Path> targets, Map<Path, FileResult> resultMap ) {
+		List<Map<String, Object>> records = new ArrayList<>();
+		for ( Path path : targets ) {
+			FileResult			result	= resultMap.get( path );
+			Map<String, Object>	record	= new LinkedHashMap<>();
+			record.put( "file", path.toString() );
+			record.put( "valid", result.valid() );
+			List<Map<String, Object>> issues = new ArrayList<>();
+			for ( Issue issue : result.issues() ) {
+				Map<String, Object> issueMap = new LinkedHashMap<>();
+				issueMap.put( "message", issue.getMessage() );
+				if ( issue.getPosition() != null ) {
+					issueMap.put( "line", issue.getPosition().getStart().getLine() );
+					issueMap.put( "column", issue.getPosition().getStart().getColumn() );
+				} else {
+					issueMap.put( "line", null );
+					issueMap.put( "column", null );
+				}
+				issues.add( issueMap );
+			}
+			record.put( "issues", issues );
+			records.add( record );
+		}
+		try {
+			out.println( JSONUtil.getJSONBuilder( true ).asString( records ) );
+			return true;
+		} catch ( IOException e ) {
+			err.println( "Error: Failed to serialize results to JSON: " + e.getMessage() );
+			return false;
+		}
+	}
+
+	/**
+	 * Resolves a raw path argument to an absolute, normalized path against the current working
+	 * directory.
+	 */
+	private static Path resolvePath( String raw ) {
+		Path path = Paths.get( raw ).normalize();
+		if ( !path.isAbsolute() ) {
+			path = Paths.get( "" ).resolve( path ).normalize().toAbsolutePath().normalize();
+		}
+		return path;
+	}
+
+	/**
+	 * Returns the lower-cased file extension of a path, or an empty string if it has none.
+	 */
+	private static String extensionOf( Path path ) {
+		String	name	= path.getFileName().toString();
+		int		dot		= name.lastIndexOf( '.' );
+		return dot >= 0 ? name.substring( dot + 1 ).toLowerCase() : "";
+	}
+
+	/**
+	 * Prints the help message for the SyntaxCheck tool.
+	 */
+	private static void printHelp( PrintStream out ) {
+		out.println( "✅ BoxLang Check - A CLI tool for validating source file syntax without executing it" );
+		out.println();
+		out.println( "📋 USAGE:" );
+		out.println( "  boxlang check [OPTIONS] [FILE...]  # 🔧 Using OS binary" );
+		out.println( "  java -jar boxlang.jar ortus.boxlang.compiler.SyntaxCheck [OPTIONS] [FILE...] # 🐍 Using Java JAR" );
+		out.println();
+		out.println( "⚙️  OPTIONS:" );
+		out.println( "  -h, --help                  ❓ Show this help message and exit" );
+		out.println( "      --source <PATH>         📁 Path to a source directory or file to check" );
+		out.println( "      --format <text|json>    📄 Output format (default: text)" );
+		out.println( "  -q, --quiet                  🔇 Suppress success output; failures are still reported" );
+		out.println();
+		out.println( "🔧 SUPPORTED SOURCE FILES:" );
+		out.println( "  .cfm  .cfc  .cfs  .bx  .bxs  .bxm" );
+		out.println();
+		out.println( "💡 EXAMPLES:" );
+		out.println( "  # ✅ Check one or more files" );
+		out.println( "  boxlang check myapp.bx myComponent.cfc" );
+		out.println();
+		out.println( "  # ✅ Check an entire directory (e.g. in CI or a git hook)" );
+		out.println( "  boxlang check --source ./src" );
+		out.println();
+		out.println( "  # 📄 Machine-readable output for editor/CI tooling" );
+		out.println( "  boxlang check --source ./src --format json" );
+		out.println();
+		out.println( "🔚 EXIT CODES:" );
+		out.println( "  0  All checked files are syntactically valid" );
+		out.println( "  1  One or more files have syntax errors, or a usage error occurred" );
+		out.println();
+		out.println( "📖 More Information:" );
+		out.println( "  📖 Documentation: https://boxlang.ortusbooks.com/" );
+		out.println( "  💬 Community: https://community.ortussolutions.com/c/boxlang/42" );
+		out.println( "  💾 GitHub: https://github.com/ortus-boxlang" );
+		out.println();
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -40,6 +40,7 @@ import ortus.boxlang.compiler.BXCompiler;
 import ortus.boxlang.compiler.CFTranspiler;
 import ortus.boxlang.compiler.DiskClassUtil;
 import ortus.boxlang.compiler.FeatureAudit;
+import ortus.boxlang.compiler.SyntaxCheck;
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.compiler.prettyprint.PrettyPrint;
@@ -106,6 +107,7 @@ public class BoxRunner {
 	 * compile, cftranspile, featureAudit, format, generateSecret, schedule
 	 */
 	private static final List<String>	ACTION_COMMANDS				= List.of(
+	    "check",
 	    "compile",
 	    "cftranspile",
 	    "featureaudit",
@@ -336,6 +338,9 @@ public class BoxRunner {
 	 */
 	static int runActionCommand( CLIOptions options, BoxRuntime runtime ) {
 		switch ( options.actionCommand().toLowerCase() ) {
+			case "check" :
+				SyntaxCheck.main( options.cliArgs().toArray( new String[ 0 ] ) );
+				break;
 			case "compile" :
 				BXCompiler.main( options.cliArgs().toArray( new String[ 0 ] ) );
 				break;
@@ -978,6 +983,8 @@ public class BoxRunner {
 		System.out.println( "      --bx-transpile             🔄 Transpile BoxLang code to Java" );
 		System.out.println();
 		System.out.println( "🚀 ACTION COMMANDS:" );
+		System.out.println( "  check                            ✅ Check source files for syntax errors without executing them" );
+		System.out.println( "                                     Use: boxlang check --help" );
 		System.out.println( "  compile                         📦 Pre-compile BoxLang templates to class files" );
 		System.out.println( "                                     Use: boxlang compile --help" );
 		System.out.println( "  cftranspile                     🔄 Transpile ColdFusion code to BoxLang" );
@@ -1007,6 +1014,10 @@ public class BoxRunner {
 		System.out.println();
 		System.out.println( "  # 🐛 Execute with debug mode and custom config" );
 		System.out.println( "  boxlang --bx-debug --bx-config ./custom.json myapp.bx" );
+		System.out.println();
+		System.out.println( "  # ✅ Check files for syntax errors" );
+		System.out.println( "  boxlang check myapp.bx" );
+		System.out.println( "  boxlang check --source ./src" );
 		System.out.println();
 		System.out.println( "  # 📦 Pre-compile templates" );
 		System.out.println( "  boxlang compile --source ./src --target ./compiled" );

--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -104,7 +104,7 @@ public class BoxRunner {
 
 	/**
 	 * A list of action commands that can be executed by the BoxRunner:
-	 * compile, cftranspile, featureAudit, format, generateSecret, schedule
+	 * check, compile, cftranspile, featureaudit, format, generatesecret, schedule
 	 */
 	private static final List<String>	ACTION_COMMANDS				= List.of(
 	    "check",

--- a/src/test/java/ortus/boxlang/compiler/SyntaxCheckTest.java
+++ b/src/test/java/ortus/boxlang/compiler/SyntaxCheckTest.java
@@ -1,0 +1,279 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.compiler;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ortus.boxlang.runtime.BoxRuntime;
+
+@DisplayName( "SyntaxCheck CLI Tests" )
+public class SyntaxCheckTest {
+
+	static BoxRuntime				instance;
+
+	@TempDir
+	Path							tempDir;
+
+	private ByteArrayOutputStream	outBuffer;
+	private ByteArrayOutputStream	errBuffer;
+	private PrintStream				out;
+	private PrintStream				err;
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void resetStreams() {
+		this.outBuffer	= new ByteArrayOutputStream();
+		this.errBuffer	= new ByteArrayOutputStream();
+		this.out		= new PrintStream( this.outBuffer, true, StandardCharsets.UTF_8 );
+		this.err		= new PrintStream( this.errBuffer, true, StandardCharsets.UTF_8 );
+	}
+
+	private String out() {
+		return this.outBuffer.toString( StandardCharsets.UTF_8 );
+	}
+
+	private String err() {
+		return this.errBuffer.toString( StandardCharsets.UTF_8 );
+	}
+
+	private Path createSourceFile( String name, String content ) throws IOException {
+		Path file = this.tempDir.resolve( name );
+		Files.createDirectories( file.getParent() );
+		Files.write( file, content.getBytes( StandardCharsets.UTF_8 ) );
+		return file;
+	}
+
+	private Path createSourceDir( String dirName ) throws IOException {
+		Path dir = this.tempDir.resolve( dirName );
+		Files.createDirectories( dir );
+		return dir;
+	}
+
+	// ---------- Help flag ----------
+
+	@Test
+	@DisplayName( "--help returns exit code 0" )
+	void testHelpFlag() {
+		int exitCode = SyntaxCheck.run( new String[] { "--help" }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+		assertThat( out() ).contains( "USAGE" );
+	}
+
+	@Test
+	@DisplayName( "-h returns exit code 0" )
+	void testHelpFlagShort() {
+		int exitCode = SyntaxCheck.run( new String[] { "-h" }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+	}
+
+	// ---------- No files ----------
+
+	@Test
+	@DisplayName( "No files or --source returns exit code 1" )
+	void testNoFilesProvided() {
+		int exitCode = SyntaxCheck.run( new String[] {}, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+	}
+
+	// ---------- Non-existent source ----------
+
+	@Test
+	@DisplayName( "Non-existent --source returns exit code 1" )
+	void testNonExistentSource() {
+		int exitCode = SyntaxCheck.run( new String[] {
+		    "--source", this.tempDir.resolve( "doesnotexist" ).toString()
+		}, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+	}
+
+	@Test
+	@DisplayName( "Non-existent positional file returns exit code 1" )
+	void testNonExistentFile() {
+		int exitCode = SyntaxCheck.run( new String[] {
+		    this.tempDir.resolve( "doesnotexist.bxs" ).toString()
+		}, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+		assertThat( err() ).contains( "does not exist" );
+	}
+
+	// ---------- Valid files ----------
+
+	@Test
+	@DisplayName( "Valid .bx class file returns exit code 0 with no error output" )
+	void testValidBxFile() throws IOException {
+		Path	source		= createSourceFile( "Good.bx", "class { function init() { return this; } }" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+		assertThat( err() ).isEmpty();
+	}
+
+	@Test
+	@DisplayName( "Valid .bxs script file returns exit code 0" )
+	void testValidBxsFile() throws IOException {
+		Path	source		= createSourceFile( "good.bxs", "x = 1 + 2;" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+		assertThat( err() ).isEmpty();
+	}
+
+	@Test
+	@DisplayName( "Valid .cfc file returns exit code 0" )
+	void testValidCfcFile() throws IOException {
+		Path	source		= createSourceFile( "MyComponent.cfc", "component { function init() { return this; } }" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+	}
+
+	@Test
+	@DisplayName( "Valid .cfm file returns exit code 0" )
+	void testValidCfmFile() throws IOException {
+		Path	source		= createSourceFile( "page.cfm", "<cfoutput>Hello</cfoutput>" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+	}
+
+	@Test
+	@DisplayName( "Valid .cfs file returns exit code 0" )
+	void testValidCfsFile() throws IOException {
+		Path	source		= createSourceFile( "script.cfs", "x = 1;" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+	}
+
+	// ---------- Invalid files ----------
+
+	@Test
+	@DisplayName( "Invalid .bxs file returns exit code 1 with issue details" )
+	void testInvalidBxsFile() throws IOException {
+		Path	source		= createSourceFile( "bad.bxs", "if ( true {" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+		assertThat( err() ).contains( "bad.bxs" );
+		assertThat( err() ).contains( "Line:" );
+	}
+
+	@Test
+	@DisplayName( "Invalid .cfm file returns exit code 1" )
+	void testInvalidCfmFile() throws IOException {
+		Path	source		= createSourceFile( "bad.cfm", "<cfoutput><cfloop><cfif></cfoutput>" );
+		int		exitCode	= SyntaxCheck.run( new String[] { source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+	}
+
+	// ---------- Directory scanning ----------
+
+	@Test
+	@DisplayName( "Directory with mixed valid/invalid files returns exit code 1 and reports only the invalid one" )
+	void testDirectoryMixedFiles() throws IOException {
+		Path dir = createSourceDir( "mixed" );
+		createSourceFile( "mixed/good.bxs", "x = 1;" );
+		createSourceFile( "mixed/bad.bxs", "if ( true {" );
+		createSourceFile( "mixed/readme.txt", "not a source file" );
+
+		int exitCode = SyntaxCheck.run( new String[] { "--source", dir.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+		assertThat( out() ).contains( "good.bxs" );
+		assertThat( err() ).contains( "bad.bxs" );
+		assertThat( out() ).doesNotContain( "readme.txt" );
+	}
+
+	@Test
+	@DisplayName( "Directory with only valid files returns exit code 0" )
+	void testDirectoryAllValid() throws IOException {
+		Path dir = createSourceDir( "allgood" );
+		createSourceFile( "allgood/one.bxs", "x = 1;" );
+		createSourceFile( "allgood/two.bxs", "y = 2;" );
+
+		int exitCode = SyntaxCheck.run( new String[] { "--source", dir.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+		assertThat( out() ).contains( "2 valid" );
+	}
+
+	// ---------- Multiple positional files ----------
+
+	@Test
+	@DisplayName( "Multiple positional files, one invalid, returns exit code 1" )
+	void testMultipleFilesOneInvalid() throws IOException {
+		Path	good		= createSourceFile( "multi-good.bxs", "x = 1;" );
+		Path	bad			= createSourceFile( "multi-bad.bxs", "if ( true {" );
+
+		int		exitCode	= SyntaxCheck.run( new String[] { good.toString(), bad.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+	}
+
+	// ---------- --quiet flag ----------
+
+	@Test
+	@DisplayName( "--quiet suppresses success output but not failures" )
+	void testQuietFlag() throws IOException {
+		Path	good		= createSourceFile( "quiet-good.bxs", "x = 1;" );
+		Path	bad			= createSourceFile( "quiet-bad.bxs", "if ( true {" );
+
+		int		exitCode	= SyntaxCheck.run( new String[] { "--quiet", good.toString(), bad.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+		assertThat( out() ).isEmpty();
+		assertThat( err() ).contains( "quiet-bad.bxs" );
+	}
+
+	// ---------- --format json ----------
+
+	@Test
+	@DisplayName( "--format json produces a JSON array for a valid file" )
+	void testFormatJsonValid() throws IOException {
+		Path	source		= createSourceFile( "json-good.bxs", "x = 1;" );
+		int		exitCode	= SyntaxCheck.run( new String[] { "--format", "json", source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 0 );
+		assertThat( out() ).contains( "\"valid\" : true" );
+	}
+
+	@Test
+	@DisplayName( "--format json produces a JSON array for an invalid file" )
+	void testFormatJsonInvalid() throws IOException {
+		Path	source		= createSourceFile( "json-bad.bxs", "if ( true {" );
+		int		exitCode	= SyntaxCheck.run( new String[] { "--format", "json", source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+		assertThat( out() ).contains( "\"valid\" : false" );
+		assertThat( out() ).contains( "\"issues\"" );
+	}
+
+	@Test
+	@DisplayName( "Invalid --format value returns exit code 1" )
+	void testInvalidFormatValue() throws IOException {
+		Path	source		= createSourceFile( "format-bad.bxs", "x = 1;" );
+		int		exitCode	= SyntaxCheck.run( new String[] { "--format", "xml", source.toString() }, this.out, this.err );
+		assertThat( exitCode ).isEqualTo( 1 );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
@@ -316,7 +316,7 @@ public class BoxRunnerParseTest {
 	@DisplayName( "It recognizes all action commands" )
 	@Test
 	void testAllActionCommands() {
-		for ( String command : List.of( "compile", "cftranspile", "featureaudit", "format", "generatesecret", "schedule" ) ) {
+		for ( String command : List.of( "check", "compile", "cftranspile", "featureaudit", "format", "generatesecret", "schedule" ) ) {
 			CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { command, "arg1" } );
 			assertThat( options.actionCommand() ).isEqualTo( command );
 			assertThat( options.cliArgs() ).containsExactly( "arg1" ).inOrder();


### PR DESCRIPTION
**Jira:** [BL-2627](https://ortussolutions.atlassian.net/browse/BL-2627)

## Summary
- Adds a new `boxlang check` CLI action command, similar to `bash -n` or `node --check`: it parses one or more BoxLang/CFML source files and reports syntax errors without executing or compiling them to bytecode.
- Supports positional file arguments and directory scanning via `--source`, text or `--format json` output for CI/editor tooling, and a `--quiet` flag.
- Exits `0` when every checked file is syntactically valid, `1` when any file has syntax errors or a usage error occurred.

## Changes
- `src/main/java/ortus/boxlang/compiler/SyntaxCheck.java` (new) — the CLI tool, built on the existing `Parser.parse(file)` → `ParsingResult.isCorrect()`/`getIssues()` API (the same parse-only path already used by `FeatureAudit`/`CFTranspiler`).
- `src/main/java/ortus/boxlang/runtime/BoxRunner.java` — wires `check` into the action-command dispatch and help text (`ACTION COMMANDS`, `EXAMPLES`).
- `src/test/java/ortus/boxlang/compiler/SyntaxCheckTest.java` (new) — unit tests covering valid/invalid files across all supported extensions, directory scanning, JSON output, quiet mode, and error cases.
- `src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java` — added `check` to the existing action-command enumeration test.

## Test plan
- [x] `./gradlew test --tests "ortus.boxlang.compiler.SyntaxCheckTest"` — all tests pass
- [x] `./gradlew test --tests "ortus.boxlang.runtime.BoxRunner*"` — no regressions
- [x] `./gradlew spotlessApply` run before commit
- [x] Manual smoke test via `./gradlew run --args="check ..."`: valid file (exit 0), invalid file (exit 1 with file/line/col), directory scan, `--format json`, and `--help` output all verified


[BL-2627]: https://ortussolutions.atlassian.net/browse/BL-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ