### PR TITLE
feat(BL-2632): module inception — nested modules and jar-based Java modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ runtime/build/
 runtime/bin/
 modules/test/
 modules/javaTestModule/**
+# Jar module test fixture, built by the javaTestModule subproject
+src/test/jar-modules/
 src/main/resources/maven/effective-pom.xml
 
 # Dynamically Generated docs

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetModuleTree.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/GetModuleTree.java
@@ -1,0 +1,68 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.system;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.IStruct;
+
+@BoxBIF( description = "Get the module hierarchy as a tree, including modules nested inside other modules (module inception)" )
+public class GetModuleTree extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public GetModuleTree() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( false, Argument.STRING, Key.module )
+		};
+	}
+
+	/**
+	 * Get the module hierarchy as a tree. Each node carries the module's own record data (see
+	 * {@code getModuleInfo()}) plus a {@code children} struct of any modules nested inside it,
+	 * recursively.
+	 * <p>
+	 * With no argument, returns every top-level module. Nested modules are found under their
+	 * parent's {@code children} entry, not at the top level.
+	 * <p>
+	 * Passed a module name, returns the tree rooted at that module instead: its own data plus its
+	 * nested modules, recursively. An unregistered module name returns an empty struct.
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @argument.module The name of the module to root the tree at. If not provided, the full
+	 *                  tree of every top-level module is returned.
+	 *
+	 * @return The module tree.
+	 */
+	public IStruct _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		String moduleName = arguments.getAsString( Key.module );
+
+		return moduleName == null
+		    ? this.moduleService.getModuleTree()
+		    : this.moduleService.getModuleTree( Key.of( moduleName ) );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/runtime/modules/BoxModule.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/BoxModule.java
@@ -44,6 +44,13 @@ import java.lang.annotation.Target;
 @Target( ElementType.TYPE )
 public @interface BoxModule {
 
+	/**
+	 * The module name. Consulted for jar-based Java modules, where the convention default is the
+	 * jar file's base name. For folder-based modules the folder name (or {@code box.json}'s
+	 * {@code boxlang.moduleName}) always wins.
+	 */
+	String name() default "";
+
 	/** The version of the module. */
 	String version() default "1.0.0";
 

--- a/src/main/java/ortus/boxlang/runtime/modules/BoxModuleConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/BoxModuleConfig.java
@@ -127,6 +127,21 @@ public class BoxModuleConfig implements IModuleConfig {
 	}
 
 	/**
+	 * Reads the {@code this.modules} / {@code variables.modules} struct declared by the BX
+	 * descriptor, which carries per-child overrides for nested modules (module inception).
+	 */
+	@Override
+	public IStruct modules() {
+		ThisScope		thisScope		= this.bxClass.getThisScope();
+		VariablesScope	variablesScope	= this.bxClass.getVariablesScope();
+		Object			declared		= thisScope.containsKey( Key.modules )
+		    ? thisScope.get( Key.modules )
+		    : variablesScope.get( Key.modules );
+
+		return declared instanceof IStruct castedModules ? castedModules : new Struct();
+	}
+
+	/**
 	 * Registers the underlying BX class via the {@link IClassRunnable} overload so
 	 * that {@code @interceptionPoint} annotations are discovered from BX metadata
 	 * rather than Java reflection.

--- a/src/main/java/ortus/boxlang/runtime/modules/IModuleConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/IModuleConfig.java
@@ -21,6 +21,7 @@ import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.events.IInterceptor;
 import ortus.boxlang.runtime.services.InterceptorService;
 import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 
 /**
  * Contract for a pure-Java BoxLang module descriptor, equivalent to {@code ModuleConfig.bx}.
@@ -112,6 +113,21 @@ public interface IModuleConfig {
 	 * @param args    Command-line arguments passed to the module
 	 */
 	default void main( IBoxContext context, String[] args ) {
+	}
+
+	/**
+	 * Per-child overrides for modules nested inside this one (module inception).
+	 * <p>
+	 * Shape: <code>{ childName : { enabled : boolean, settings : { ... } } }</code>
+	 * <p>
+	 * These are applied on top of the child's own {@code configure()} defaults, but
+	 * <strong>before</strong> the global {@code boxlang.json} module config, which always wins.
+	 * The BX equivalent is declaring {@code this.modules} in {@code ModuleConfig.bx}.
+	 *
+	 * @return The per-child override struct; an empty struct when the module declares none
+	 */
+	default IStruct modules() {
+		return new Struct();
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -384,7 +384,7 @@ public class ModuleRecord {
 		// Register the automatic mapping by convention: /bxModules/{name}
 		// Not visible externally
 		this.mapping		= Mapping.of(
-		    ModuleService.MODULE_MAPPING_PREFIX + name.getName(),
+		    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName(),
 		    this.path,
 		    false
 		);
@@ -421,11 +421,11 @@ public class ModuleRecord {
 		if ( this.descriptorLoaded ) {
 			return this;
 		}
-		this.descriptorLoaded = true;
 
 		// Java-only modules (no ModuleConfig.bx) skip BX loading entirely.
 		// Java config detection happens in resolveModuleConfig() once the classloader is ready.
 		if ( !Files.exists( this.physicalPath.resolve( ModuleService.MODULE_DESCRIPTOR ) ) ) {
+			this.descriptorLoaded = true;
 			return this;
 		}
 
@@ -492,6 +492,10 @@ public class ModuleRecord {
 		variablesScope.put( Key.boxRuntime, this.runtime );
 		variablesScope.put( Key.interceptorService, this.runtime.getInterceptorService() );
 		variablesScope.put( Key.log, this.logger );
+
+		// Marked only on success, so a failed load (e.g. a parse error) can be retried
+		// instead of silently poisoning the record as "loaded".
+		this.descriptorLoaded = true;
 
 		return this;
 	}
@@ -565,7 +569,6 @@ public class ModuleRecord {
 		if ( this.configResolved ) {
 			return this;
 		}
-		this.configResolved = true;
 
 		getOrCreateModuleClassLoader();
 
@@ -584,14 +587,37 @@ public class ModuleRecord {
 			    this.settings				= new Struct();
 			    this.interceptors			= new Array();
 			    this.customInterceptionPoints = new Array();
-			    this.mapping				= Mapping.of( ModuleService.MODULE_MAPPING_PREFIX + name.getName(), this.path, false );
-			    this.publicMapping			= Mapping.of( ModuleService.MODULE_MAPPING_PREFIX + name.getName() + "/" + ModuleService.MODULE_PUBLIC_FOLDER,
-			        this.physicalPath.resolve( "public" ).toString(), true );
-			    this.moduleConfig			= javaConfig;
+			    applyName( this.name );
+			    this.moduleConfig = javaConfig;
 			    extractJavaMetadata();
 		    } );
 
+		// Marked only on success, so a failure (e.g. class loader creation) can be retried
+		// instead of silently poisoning the record as "resolved".
+		this.configResolved = true;
+
 		return this;
+	}
+
+	/**
+	 * Applies a module name to this record, re-deriving everything keyed off it: the internal
+	 * mapping, the public mapping, and the invocation path.
+	 *
+	 * @param newName The name to apply
+	 */
+	public void applyName( Key newName ) {
+		this.name			= newName;
+		this.mapping		= Mapping.of(
+		    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName(),
+		    this.path,
+		    false
+		);
+		this.publicMapping	= Mapping.of(
+		    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName() + "/" + ModuleService.MODULE_PUBLIC_FOLDER,
+		    this.physicalPath.resolve( ModuleService.MODULE_PUBLIC_FOLDER ).toString(),
+		    true
+		);
+		this.invocationPath	= ModuleService.MODULE_MAPPING_INVOCATION_PREFIX + this.name.getName();
 	}
 
 	/**
@@ -638,8 +664,8 @@ public class ModuleRecord {
 		 * Later wins: own configure() defaults < parent module overrides < global app config.
 		 */
 
-		// A parent module may override its nested children's settings and enablement
-		applyParentOverrides();
+		// A parent module may override its nested children's settings
+		applyParentSettingOverrides();
 
 		// Merge any runtime-config settings on top; the global app config always wins
 		if ( this.runtime.getConfiguration().modules.containsKey( this.name ) ) {
@@ -761,15 +787,51 @@ public class ModuleRecord {
 		this.unregister( context );
 
 		// Destroy the ClassLoader
-		try {
-			this.moduleClassLoader.close();
-		} catch ( IOException e ) {
-			this.logger.error( "Error while closing the DynamicClassLoader for module [{}]", this.name, e );
-		} finally {
-			this.moduleClassLoader	= null;
-			this.classLoader		= null;
-		}
+		releaseClassLoader();
 
+		/**
+		 * Reset the lifecycle state so a subsequent register()/activate() — e.g. via
+		 * ModuleService.reload() — rebuilds everything from scratch: the class loader,
+		 * the descriptor, the resolved config, and the capability caches. Without this,
+		 * the idempotency guards would skip resolution and leave the record pointing at
+		 * a closed (nulled) class loader.
+		 */
+		this.descriptorLoaded			= false;
+		this.moduleConfig				= null;
+		this.registeredOn				= null;
+		this.activated					= false;
+		this.activatedOn				= null;
+		this.settings					= new Struct();
+		this.interceptors				= new Array();
+		this.customInterceptionPoints	= new Array();
+		this.bifs						= new Array();
+		this.components					= new Array();
+		this.memberMethods				= new Array();
+
+		return this;
+	}
+
+	/**
+	 * Closes this module's class loader, if one was built, and resets the config resolution
+	 * guard so a later {@link #resolveModuleConfig(IBoxContext)} builds a fresh one.
+	 * <p>
+	 * Used on unload, and by the {@code ModuleService} when a module turns out to be disabled
+	 * only after its config had to be resolved (a disabled module must not hold an open loader).
+	 *
+	 * @return The ModuleRecord
+	 */
+	public ModuleRecord releaseClassLoader() {
+		if ( this.moduleClassLoader != null ) {
+			try {
+				this.moduleClassLoader.close();
+			} catch ( IOException e ) {
+				this.logger.error( "Error while closing the class loader for module [{}]", this.name, e );
+			} finally {
+				this.moduleClassLoader	= null;
+				this.classLoader		= null;
+			}
+		}
+		this.configResolved = false;
 		return this;
 	}
 
@@ -959,12 +1021,15 @@ public class ModuleRecord {
 	}
 
 	/**
-	 * Applies the parent module's overrides for this module, if this is a nested module.
+	 * Applies the parent module's <em>setting</em> overrides for this module, if this is a
+	 * nested module.
 	 * <p>
 	 * Called during registration after {@code configure()} but before the global app config is
 	 * merged, so the precedence is: own defaults, then parent overrides, then global config.
+	 * The {@code enabled} flag follows the same precedence but is decided by the
+	 * {@code ModuleService} <em>before</em> registration side effects begin, not here.
 	 */
-	private void applyParentOverrides() {
+	private void applyParentSettingOverrides() {
 		if ( this.parentModule == null ) {
 			return;
 		}
@@ -977,10 +1042,6 @@ public class ModuleRecord {
 		IStruct overrides = parentRecord.getChildOverrides( this.name );
 		if ( overrides.isEmpty() ) {
 			return;
-		}
-
-		if ( overrides.containsKey( Key.enabled ) ) {
-			this.enabled = BooleanCaster.cast( overrides.get( Key.enabled ) );
 		}
 
 		if ( overrides.get( Key.settings ) instanceof IStruct parentSettings ) {
@@ -1048,21 +1109,19 @@ public class ModuleRecord {
 			return;
 		}
 
-		// An explicit name overrides the convention default, which for a jar module is only
-		// the jar's base name. Re-derive everything keyed off the name to keep them in sync.
+		// An explicit name overrides the convention default for JAR MODULES ONLY, whose default
+		// is just the jar's base name. Folder modules always keep their folder/box.json name, so
+		// the same annotated class can serve both layouts without the folder module renaming itself.
 		if ( !meta.name().isBlank() ) {
-			this.name			= Key.of( meta.name() );
-			this.mapping		= Mapping.of(
-			    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName(),
-			    this.path,
-			    false
-			);
-			this.publicMapping	= Mapping.of(
-			    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName() + "/" + ModuleService.MODULE_PUBLIC_FOLDER,
-			    this.physicalPath.resolve( ModuleService.MODULE_PUBLIC_FOLDER ).toString(),
-			    true
-			);
-			this.invocationPath	= ModuleService.MODULE_MAPPING_INVOCATION_PREFIX + this.name.getName();
+			if ( this.jarModule ) {
+				applyName( Key.of( meta.name() ) );
+			} else if ( !this.name.equals( Key.of( meta.name() ) ) ) {
+				this.logger.debug(
+				    "+ Module [{}] declares @BoxModule( name = \"{}\" ) but is a folder module; the folder/box.json name wins, ignoring",
+				    this.name,
+				    meta.name()
+				);
+			}
 		}
 
 		// Simple fields

--- a/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
+++ b/src/main/java/ortus/boxlang/runtime/modules/ModuleRecord.java
@@ -154,6 +154,23 @@ public class ModuleRecord {
 	public Array					dependencies				= new Array();
 
 	/**
+	 * The names of the modules nested inside this module's own {@code modules} folder
+	 * (module inception). Populated by the {@link ModuleService} during discovery.
+	 * <p>
+	 * Nested modules are registered and activated <strong>before</strong> this module, and
+	 * unloaded <strong>after</strong> it, since their class loaders are parented to this one.
+	 */
+	public Array					nestedModules				= new Array();
+
+	/**
+	 * The name of the module this one is nested inside, or {@code null} for a top-level module.
+	 * <p>
+	 * When set, this module's class loader is parented to the parent module's class loader, and
+	 * the parent may override this module's settings via {@link IModuleConfig#modules()}.
+	 */
+	public Key						parentModule				= null;
+
+	/**
 	 * The interceptors of the module
 	 */
 	public Array					interceptors				= new Array();
@@ -279,6 +296,25 @@ public class ModuleRecord {
 	public static final String		MODULE_CONFIG_FILE			= "box.json";
 
 	/**
+	 * Whether this module is packaged as a single jar file placed directly in a modules folder,
+	 * as opposed to the conventional module directory layout.
+	 */
+	private final boolean			jarModule;
+
+	/**
+	 * Guards {@link #loadDescriptor(IBoxContext)} so it is idempotent. A module with nested
+	 * children has its descriptor loaded early (so its per-child overrides are readable) and
+	 * would otherwise be re-compiled during its own registration.
+	 */
+	private boolean					descriptorLoaded			= false;
+
+	/**
+	 * Guards {@link #resolveModuleConfig(IBoxContext)} so it is idempotent, for the same reason
+	 * as {@link #descriptorLoaded}.
+	 */
+	private boolean					configResolved				= false;
+
+	/**
 	 * Logger
 	 */
 	private BoxLangLogger			logger;
@@ -313,6 +349,10 @@ public class ModuleRecord {
 		Path	directoryPath	= Path.of( physicalPath );
 		Path	boxjsonPath		= directoryPath.resolve( MODULE_CONFIG_FILE );
 
+		// A module packaged as a single jar file has no folder conventions to read from;
+		// everything comes from its IModuleConfig, discovered later via ServiceLoader.
+		this.jarModule = ModuleService.isModuleJar( directoryPath );
+
 		// Load the module name from the box.json file if it exists
 		if ( Files.exists( boxjsonPath ) ) {
 			DataNavigator
@@ -327,9 +367,14 @@ public class ModuleRecord {
 			    );
 		}
 
-		// Default to the directory name if the box.json file does not exist
+		// Default to the directory name if the box.json file does not exist.
+		// Jar modules default to the jar's base name, so `my-module.jar` becomes `my-module`.
 		if ( this.name == null ) {
-			this.name = Key.of( directoryPath.getFileName().toString() );
+			this.name = Key.of(
+			    this.jarModule
+			        ? FilenameUtils.getBaseName( directoryPath.getFileName().toString() )
+			        : directoryPath.getFileName().toString()
+			);
 		}
 
 		// Path to the module in string and Path formats
@@ -371,8 +416,15 @@ public class ModuleRecord {
 	 * @return The ModuleRecord
 	 */
 	public ModuleRecord loadDescriptor( IBoxContext context ) {
+		// Idempotent: a module with nested children loads its descriptor early so its
+		// per-child overrides are readable before those children register.
+		if ( this.descriptorLoaded ) {
+			return this;
+		}
+		this.descriptorLoaded = true;
+
 		// Java-only modules (no ModuleConfig.bx) skip BX loading entirely.
-		// Java config detection happens in register() once the classloader is ready.
+		// Java config detection happens in resolveModuleConfig() once the classloader is ready.
 		if ( !Files.exists( this.physicalPath.resolve( ModuleService.MODULE_DESCRIPTOR ) ) ) {
 			return this;
 		}
@@ -445,25 +497,44 @@ public class ModuleRecord {
 	}
 
 	/**
-	 * This method registers the module with all the runtime services.
-	 * This is called by the ModuleService if the module is allowed to be registered
-	 * or not
+	 * Builds this module's isolated class loader, on demand and only once.
+	 * <p>
+	 * The class loader hierarchy mirrors the module hierarchy: a nested module's loader is
+	 * parented to its parent module's loader, chaining up until a top-level module, whose loader
+	 * is parented to the runtime loader. A child can therefore see the classes and {@code libs}
+	 * its parent bundles, while remaining isolated from its siblings.
+	 * <p>
+	 * Creation is lazy because nested modules register <em>before</em> their parent, yet need the
+	 * parent's loader to exist first. Each level creates its own loader on demand, so a grandchild
+	 * transparently forces the whole chain up to the runtime loader.
 	 *
-	 * @param context The current context of execution
-	 *
-	 * @return The ModuleRecord
+	 * @return The module class loader
 	 */
-	public ModuleRecord register( IBoxContext context ) {
-		// Convenience References
-		InterceptorService	interceptorService	= this.runtime.getInterceptorService();
-		FunctionService		functionService		= this.runtime.getFunctionService();
-		ComponentService	componentService	= this.runtime.getComponentService();
+	public IModuleClassLoader getOrCreateModuleClassLoader() {
+		if ( this.moduleClassLoader != null ) {
+			return this.moduleClassLoader;
+		}
+
+		// Nested modules chain to their parent's loader; top-level modules to the runtime loader
+		ClassLoader parentLoader = this.runtime.getRuntimeLoader();
+		if ( this.parentModule != null ) {
+			ModuleRecord parentRecord = this.runtime.getModuleService().getModuleRecord( this.parentModule );
+			if ( parentRecord != null ) {
+				parentLoader = parentRecord.getOrCreateModuleClassLoader().toClassLoader();
+			} else {
+				this.logger.warn(
+				    "+ Module [{}] declares parent module [{}] which is not in the registry; parenting to the runtime loader instead",
+				    this.name,
+				    this.parentModule
+				);
+			}
+		}
 
 		// Create the module's (isolated) class loader via the runtime's configured factory.
 		// The default JVM factory builds a DynamicClassLoader over the module directory
 		// (loading *.class under the `modules.{module_name}` prefix) seeded with libs/*.jar;
 		// other targets (e.g. Android) supply a different loader without forking this class.
-		this.moduleClassLoader	= this.runtime.getClassLoaderFactory().createModuleClassLoader( this, this.runtime.getRuntimeLoader() );
+		this.moduleClassLoader	= this.runtime.getClassLoaderFactory().createModuleClassLoader( this, parentLoader );
 		// Mirror onto the legacy, concrete-typed field for binary compatibility with modules
 		// compiled against the pre-IModuleClassLoader API. On the standard JVM the factory's
 		// return value is always a DynamicClassLoader; on other targets this assignment is a
@@ -472,6 +543,31 @@ public class ModuleRecord {
 		this.classLoader		= ( this.moduleClassLoader instanceof DynamicClassLoader dcl )
 		    ? dcl
 		    : null;
+
+		return this.moduleClassLoader;
+	}
+
+	/**
+	 * Resolves this module's {@link IModuleConfig} and its metadata, without registering anything
+	 * with the runtime services. Java configs discovered via {@link ServiceLoader} always win over
+	 * a {@code ModuleConfig.bx} descriptor.
+	 * <p>
+	 * This is split out of {@link #register(IBoxContext)} because a module carrying nested children
+	 * must have its config resolved <em>before</em> those children register, so that its per-child
+	 * overrides ({@link IModuleConfig#modules()}) are readable — while its own full registration
+	 * still happens after them. Idempotent.
+	 *
+	 * @param context The current context of execution
+	 *
+	 * @return The ModuleRecord
+	 */
+	public ModuleRecord resolveModuleConfig( IBoxContext context ) {
+		if ( this.configResolved ) {
+			return this;
+		}
+		this.configResolved = true;
+
+		getOrCreateModuleClassLoader();
 
 		// Detect a Java IModuleConfig via ServiceLoader (diskless-safe — uses the module classloader abstraction).
 		// Java always wins: if found, replace any BX config and discard BX-derived metadata/state.
@@ -495,6 +591,28 @@ public class ModuleRecord {
 			    extractJavaMetadata();
 		    } );
 
+		return this;
+	}
+
+	/**
+	 * This method registers the module with all the runtime services.
+	 * This is called by the ModuleService if the module is allowed to be registered
+	 * or not
+	 *
+	 * @param context The current context of execution
+	 *
+	 * @return The ModuleRecord
+	 */
+	public ModuleRecord register( IBoxContext context ) {
+		// Convenience References
+		InterceptorService	interceptorService	= this.runtime.getInterceptorService();
+		FunctionService		functionService		= this.runtime.getFunctionService();
+		ComponentService	componentService	= this.runtime.getComponentService();
+
+		// Build the class loader and resolve the descriptor (Java wins over BX).
+		// No-op when a parent module already resolved us early to read its child overrides.
+		resolveModuleConfig( context );
+
 		if ( this.moduleConfig == null ) {
 			// Neither ServiceLoader nor loadDescriptor() produced a valid config.
 			this.logger.warn(
@@ -513,7 +631,17 @@ public class ModuleRecord {
 		// Unified configure() call — BxModuleConfig reads variablesScope; Java impls mutate settings directly
 		this.moduleConfig.configure( context, this );
 
-		// Merge any runtime-config settings on top of what configure() set
+		/**
+		 * --------------------------------------------------------------------------
+		 * Settings Precedence
+		 * --------------------------------------------------------------------------
+		 * Later wins: own configure() defaults < parent module overrides < global app config.
+		 */
+
+		// A parent module may override its nested children's settings and enablement
+		applyParentOverrides();
+
+		// Merge any runtime-config settings on top; the global app config always wins
 		if ( this.runtime.getConfiguration().modules.containsKey( this.name ) ) {
 			ModuleConfig config = ( ModuleConfig ) this.runtime.getConfiguration().modules.get( this.name );
 			StructUtil.deepMerge( this.settings, config.settings, true );
@@ -810,6 +938,99 @@ public class ModuleRecord {
 	}
 
 	/**
+	 * Reads the per-child overrides this module declares for one of its nested modules.
+	 * <p>
+	 * BX descriptors declare these as {@code this.modules}; Java descriptors override
+	 * {@link IModuleConfig#modules()}. The returned struct follows the {@code boxlang.json}
+	 * module shape: <code>{ enabled : boolean, settings : { ... } }</code>.
+	 *
+	 * @param childName The nested module to read overrides for
+	 *
+	 * @return The overrides for that child, or an empty struct when none are declared
+	 */
+	public IStruct getChildOverrides( Key childName ) {
+		if ( this.moduleConfig == null ) {
+			return new Struct();
+		}
+
+		Object childOverrides = this.moduleConfig.modules().get( childName );
+
+		return childOverrides instanceof IStruct castedOverrides ? castedOverrides : new Struct();
+	}
+
+	/**
+	 * Applies the parent module's overrides for this module, if this is a nested module.
+	 * <p>
+	 * Called during registration after {@code configure()} but before the global app config is
+	 * merged, so the precedence is: own defaults, then parent overrides, then global config.
+	 */
+	private void applyParentOverrides() {
+		if ( this.parentModule == null ) {
+			return;
+		}
+
+		ModuleRecord parentRecord = this.runtime.getModuleService().getModuleRecord( this.parentModule );
+		if ( parentRecord == null ) {
+			return;
+		}
+
+		IStruct overrides = parentRecord.getChildOverrides( this.name );
+		if ( overrides.isEmpty() ) {
+			return;
+		}
+
+		if ( overrides.containsKey( Key.enabled ) ) {
+			this.enabled = BooleanCaster.cast( overrides.get( Key.enabled ) );
+		}
+
+		if ( overrides.get( Key.settings ) instanceof IStruct parentSettings ) {
+			StructUtil.deepMerge( this.settings, parentSettings, true );
+		}
+
+		this.logger.debug(
+		    "+ Module [{}] applied setting overrides from its parent module [{}]",
+		    this.name,
+		    this.parentModule
+		);
+	}
+
+	/**
+	 * Get the record of a module nested inside this one (module inception).
+	 *
+	 * @param name The name of the nested module
+	 *
+	 * @return The nested module's record, or {@code null} when this module has no such child
+	 */
+	public ModuleRecord getNestedModule( Key name ) {
+		if ( !hasNestedModule( name ) ) {
+			return null;
+		}
+		return this.runtime.getModuleService().getModuleRecord( name );
+	}
+
+	/**
+	 * Verify if a module is nested inside this one (module inception).
+	 *
+	 * @param name The name of the nested module
+	 *
+	 * @return {@code true} if the module is a direct child of this one, {@code false} otherwise
+	 */
+	public boolean hasNestedModule( Key name ) {
+		return this.nestedModules.stream()
+		    .anyMatch( nestedName -> Key.of( ( String ) nestedName ).equals( name ) );
+	}
+
+	/**
+	 * If this module is packaged as a single jar file placed directly in a modules folder,
+	 * as opposed to the conventional module directory layout.
+	 *
+	 * @return {@code true} if this is a jar module, {@code false} otherwise
+	 */
+	public boolean isJarModule() {
+		return this.jarModule;
+	}
+
+	/**
 	 * Reads {@link BoxModule @BoxModule} annotation metadata from a Java {@link IModuleConfig} implementation
 	 * and populates the corresponding {@link ModuleRecord} fields.
 	 * If the annotation is absent, all convention defaults from the constructor are kept.
@@ -825,6 +1046,23 @@ public class ModuleRecord {
 		// If the annotation is absent, keep convention defaults
 		if ( meta == null ) {
 			return;
+		}
+
+		// An explicit name overrides the convention default, which for a jar module is only
+		// the jar's base name. Re-derive everything keyed off the name to keep them in sync.
+		if ( !meta.name().isBlank() ) {
+			this.name			= Key.of( meta.name() );
+			this.mapping		= Mapping.of(
+			    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName(),
+			    this.path,
+			    false
+			);
+			this.publicMapping	= Mapping.of(
+			    ModuleService.MODULE_MAPPING_PREFIX + this.name.getName() + "/" + ModuleService.MODULE_PUBLIC_FOLDER,
+			    this.physicalPath.resolve( ModuleService.MODULE_PUBLIC_FOLDER ).toString(),
+			    true
+			);
+			this.invocationPath	= ModuleService.MODULE_MAPPING_INVOCATION_PREFIX + this.name.getName();
 		}
 
 		// Simple fields
@@ -978,9 +1216,12 @@ public class ModuleRecord {
 		    "interceptors", Array.copyOf( this.interceptors ),
 		    "invocationPath", this.invocationPath,
 		    "jdbcDrivers", Array.of( this.jdbcDrivers.keySet().stream().map( Key::getName ).toArray() ),
+		    "jarModule", this.jarModule,
 		    "mapping", this.mapping.toStruct(),
 		    "memberMethods", Array.copyOf( this.memberMethods ),
 		    "name", this.name,
+		    "nestedModules", Array.copyOf( this.nestedModules ),
+		    "parentModule", this.parentModule,
 		    "physicalPath", this.physicalPath.toString(),
 		    "publicMapping", this.publicMapping.toStruct(),
 		    "registeredOn", this.registeredOn,

--- a/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -868,6 +869,61 @@ public class ModuleService extends BaseService {
 	 */
 	public boolean hasModule( Key name ) {
 		return this.registry.containsKey( name );
+	}
+
+	/**
+	 * Get the full module tree: every top-level module, each carrying a {@code children} struct
+	 * of the modules nested inside it (module inception), recursively down to any depth.
+	 * <p>
+	 * Modules nested inside another module are omitted from the top level of the returned struct;
+	 * find them under their parent's {@code children} entry instead.
+	 *
+	 * @return A struct of top-level module name to module tree node
+	 */
+	public IStruct getModuleTree() {
+		IStruct tree = new Struct();
+		this.registry
+		    .values()
+		    .stream()
+		    .filter( record -> record.parentModule == null )
+		    .forEach( record -> tree.put( record.name, buildModuleTreeNode( record ) ) );
+		return tree;
+	}
+
+	/**
+	 * Get the module tree rooted at a specific module: its own record data plus a {@code children}
+	 * struct of the modules nested inside it (module inception), recursively.
+	 *
+	 * @param name The module to root the tree at
+	 *
+	 * @return The module's tree node, or an empty struct if the module is not registered
+	 */
+	public IStruct getModuleTree( Key name ) {
+		ModuleRecord record = this.registry.get( name );
+		return record == null ? new Struct() : buildModuleTreeNode( record );
+	}
+
+	/**
+	 * Builds one module tree node: the module's own {@link ModuleRecord#asStruct()} data, plus a
+	 * {@code children} struct of its direct nested modules, each built the same way.
+	 *
+	 * @param record The module record to build a tree node for
+	 *
+	 * @return The module's tree node
+	 */
+	private IStruct buildModuleTreeNode( ModuleRecord record ) {
+		IStruct	node		= record.asStruct();
+
+		IStruct	children	= new Struct();
+		record.nestedModules
+		    .stream()
+		    .map( childName -> Key.of( ( String ) childName ) )
+		    .map( this.registry::get )
+		    .filter( Objects::nonNull )
+		    .forEach( child -> children.put( child.name, buildModuleTreeNode( child ) ) );
+		node.put( Key.of( "children" ), children );
+
+		return node;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.io.FilenameUtils;
 import org.semver4j.Semver;
 
 import ortus.boxlang.runtime.BoxRuntime;
@@ -35,6 +36,7 @@ import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.modules.ModuleRecord;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Array;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
@@ -65,7 +67,20 @@ public class ModuleService extends BaseService {
 	public static final String		MODULE_BIFS							= "bifs";
 	public static final String		MODULE_COMPONENTS					= "components";
 	public static final String		MODULE_LIBS							= "libs";
+
+	/**
+	 * The conventional folder name for modules nested inside another module (module inception).
+	 * A module carrying a folder by this name has those modules discovered, registered and
+	 * activated before the module itself.
+	 */
 	public static final String		MODULE_PACKAGE_PREFIX				= "modules";
+
+	/**
+	 * The file extension marking a module packaged as a single jar, placed directly inside a
+	 * modules folder instead of following the module directory layout.
+	 */
+	public static final String		MODULE_JAR_EXTENSION				= ".jar";
+
 	public static final String		MODULE_PUBLIC_FOLDER				= "public";
 
 	/**
@@ -171,6 +186,8 @@ public class ModuleService extends BaseService {
 			        "enabled", entrySet.getValue().isEnabled(),
 			        "invocationPath", entrySet.getValue().invocationPath,
 			        "mapping", entrySet.getValue().mapping.toStruct(),
+			        "nestedModules", Array.copyOf( entrySet.getValue().nestedModules ),
+			        "parentModule", entrySet.getValue().parentModule,
 			        "physicalPath", entrySet.getValue().physicalPath.toString(),
 			        "publicMapping", entrySet.getValue().publicMapping.toStruct(),
 			        "registeredOn", entrySet.getValue().registeredOn,
@@ -300,7 +317,8 @@ public class ModuleService extends BaseService {
 			moduleRecord.enabled = config.enabled;
 		}
 
-		// Check if the module is disabled, if so, skip it
+		// Check if the module is disabled, if so, skip it. Any modules nested inside it are
+		// skipped with it: their class loaders chain to this one, so they cannot stand alone.
 		if ( !moduleRecord.isEnabled() ) {
 			this.logger.warn(
 			    "+ Module Service: Module [{}] is disabled, skipping registration",
@@ -309,8 +327,29 @@ public class ModuleService extends BaseService {
 			return;
 		}
 
+		/**
+		 * |--------------------------------------------------------------------------
+		 * | Module Inception
+		 * |--------------------------------------------------------------------------
+		 * Modules nested inside this one register before it does. This module's own config is
+		 * resolved first, so its per-child setting overrides are readable by those children,
+		 * while its full registration still happens after them.
+		 */
+		if ( !moduleRecord.nestedModules.isEmpty() ) {
+			moduleRecord.resolveModuleConfig( runtimeContext );
+			moduleRecord.nestedModules
+			    .stream()
+			    .map( childName -> Key.of( ( String ) childName ) )
+			    .filter( childKey -> this.registry.containsKey( childKey ) && this.registry.get( childKey ).registeredOn == null )
+			    .forEach( this::register );
+		}
+
 		// Configure the module
 		moduleRecord.register( runtimeContext );
+
+		// A jar module may rename itself via `@BoxModule( name = "..." )` once its config is
+		// resolved off its class loader, so re-key it under the name it actually registered as.
+		rekeyModule( name, moduleRecord );
 
 		// Log registration time
 		moduleRecord.registrationTime = BoxRuntime.timerUtil.stopAndGetMillis( timerLabel );
@@ -328,6 +367,40 @@ public class ModuleService extends BaseService {
 		    moduleRecord.version,
 		    moduleRecord.registrationTime,
 		    moduleRecord.physicalPath
+		);
+	}
+
+	/**
+	 * Move a module to a new registry key when it renamed itself during registration.
+	 * <p>
+	 * A jar module's discovered name is only its jar base name; its {@code @BoxModule( name )}
+	 * annotation, read once the class loader is up, may name it something else. The parent's
+	 * nested module list is updated to match so the parent can still target it.
+	 *
+	 * @param registeredUnder The key the module was registered under
+	 * @param moduleRecord    The module record to re-key
+	 */
+	private void rekeyModule( Key registeredUnder, ModuleRecord moduleRecord ) {
+		if ( moduleRecord.name.equals( registeredUnder ) ) {
+			return;
+		}
+
+		this.registry.remove( registeredUnder );
+		this.registry.put( moduleRecord.name, moduleRecord );
+
+		// Keep the parent's child list pointing at the new name
+		if ( moduleRecord.parentModule != null ) {
+			ModuleRecord parentRecord = this.registry.get( moduleRecord.parentModule );
+			if ( parentRecord != null ) {
+				parentRecord.nestedModules.remove( registeredUnder.getName() );
+				parentRecord.nestedModules.push( moduleRecord.name.getName() );
+			}
+		}
+
+		this.logger.debug(
+		    "+ Module Service: Module discovered as [{}] renamed itself to [{}] via its @BoxModule annotation",
+		    registeredUnder.getName(),
+		    moduleRecord.name.getName()
 		);
 	}
 
@@ -419,6 +492,18 @@ public class ModuleService extends BaseService {
 
 		/**
 		 * |--------------------------------------------------------------------------
+		 * | Module Inception Activation
+		 * |--------------------------------------------------------------------------
+		 * Modules nested inside this one activate before it does, mirroring their
+		 * registration order and their class loader parentage.
+		 */
+		moduleRecord.nestedModules
+		    .stream()
+		    .map( childName -> Key.of( ( String ) childName ) )
+		    .forEach( this::activate );
+
+		/**
+		 * |--------------------------------------------------------------------------
 		 * | Module Dependencies Activation
 		 * |--------------------------------------------------------------------------
 		 * This makes sure that all dependencies are activated before the module itself
@@ -480,6 +565,20 @@ public class ModuleService extends BaseService {
 		// Which is separate from anything else
 		var	moduleRecord	= this.registry.get( name );
 		var	runtimeContext	= runtime.getRuntimeContext();
+
+		/**
+		 * |--------------------------------------------------------------------------
+		 * | Module Inception Unloading
+		 * |--------------------------------------------------------------------------
+		 * Nested modules unload before their parent, the reverse of activation: their class
+		 * loaders are parented to this module's loader, which unloading is about to close.
+		 * Copied first, since unloading a child mutates this module's nested list when the
+		 * child is removed from the registry.
+		 */
+		Array.copyOf( moduleRecord.nestedModules )
+		    .stream()
+		    .map( childName -> Key.of( ( String ) childName ) )
+		    .forEach( childKey -> unload( childKey, removeFromRegistry ) );
 
 		// Announce it
 		announce(
@@ -729,32 +828,34 @@ public class ModuleService extends BaseService {
 	 * @param modulesDirectory The path to scan for modules
 	 */
 	public void buildRegistryFromPath( Path modulesDirectory ) {
+		discoverModulesInPath( modulesDirectory, null );
+	}
+
+	/**
+	 * Scans a single modules folder and adds every module it finds to the registry, recursing into
+	 * each discovered module's own {@code modules} folder (module inception).
+	 * <p>
+	 * A modules folder may hold two kinds of module: conventional module <strong>directories</strong>
+	 * (carrying a {@code ModuleConfig.bx} and/or {@code box.json}), and module <strong>jars</strong>
+	 * placed directly inside it, whose descriptor is found later via {@link java.util.ServiceLoader}
+	 * on the module's own class loader.
+	 *
+	 * @param modulesDirectory The modules folder to scan
+	 * @param parent           The module this folder belongs to, or {@code null} when scanning a
+	 *                         top-level configured modules directory
+	 */
+	private void discoverModulesInPath( Path modulesDirectory, ModuleRecord parent ) {
 		try {
 			Files.walk( modulesDirectory, 1 )
-			    // Exclude the path if it is a root path in the `modulePaths` list
+			    // Exclude the modules folder itself, and any root path in the `modulePaths` list
+			    .filter( filePath -> !filePath.equals( modulesDirectory ) )
 			    .filter( filePath -> !this.modulePaths.contains( filePath ) )
-			    // Only module folders
-			    .filter( Files::isDirectory )
-			    // Only where a ModuleConfig.bx OR a box.json exists in the root
-			    // (pure-Java modules may have only box.json; Java config detection happens later via ServiceLoader)
-			    .filter( filePath -> Files.exists( filePath.resolve( MODULE_DESCRIPTOR ) )
-			        || Files.exists( filePath.resolve( ModuleRecord.MODULE_CONFIG_FILE ) ) )
+			    // Either a conventional module folder or a module jar
+			    .filter( filePath -> isModuleFolder( filePath ) || isModuleJar( filePath ) )
 			    // Filter out already registered modules
-			    .filter( filePath -> {
-				    Key	moduleName		= Key.of( filePath.getFileName().toString() );
-				    Path moduleBoxJSON	= filePath.resolve( ModuleRecord.MODULE_CONFIG_FILE );
-				    if ( Files.exists( moduleBoxJSON ) ) {
-					    moduleName = DataNavigator
-					        .of( moduleBoxJSON )
-					        .from( "boxlang" )
-					        .getAsKey( "moduleName", moduleName );
-				    }
-
-				    return !this.registry.containsKey( moduleName );
-			    } )
-			    // Convert each filePath to a discovered ModuleRecord
-			    .map( filePath -> new ModuleRecord( filePath.toString() ) )
-			    .forEach( moduleRecord -> this.registry.put( moduleRecord.name, moduleRecord ) );
+			    .filter( filePath -> !this.registry.containsKey( discoverModuleName( filePath ) ) )
+			    // Convert each filePath to a discovered ModuleRecord, recursing into its own modules
+			    .forEach( filePath -> createDiscoveredModule( filePath, parent ) );
 		} catch ( IOException e ) {
 			String message = "Error walking and registering module path: " + modulesDirectory.toString();
 			this.logger.error( message, e );
@@ -763,20 +864,119 @@ public class ModuleService extends BaseService {
 	}
 
 	/**
-	 * Register and activate a single module. Pass the directory that contains the ModuleConfig.bx. The name of the directory will be the module name.
+	 * Builds a {@link ModuleRecord} for a discovered module, links it to its parent (if any), adds
+	 * it to the registry, and recurses into its own {@code modules} folder (module inception).
 	 *
-	 * @param moduleDirectory The path to the module
+	 * @param modulePath The module's directory or jar file
+	 * @param parent     The module this one is nested inside, or {@code null} for a top-level module
+	 *
+	 * @return The created module record
+	 */
+	private ModuleRecord createDiscoveredModule( Path modulePath, ModuleRecord parent ) {
+		ModuleRecord moduleRecord = new ModuleRecord( modulePath.toString() );
+
+		// Link the parent/child relationship both ways so each can target the other
+		if ( parent != null ) {
+			moduleRecord.parentModule = parent.name;
+			parent.nestedModules.push( moduleRecord.name.getName() );
+			this.logger.debug(
+			    "+ Module Service: Discovered module [{}] nested inside module [{}]",
+			    moduleRecord.name.getName(),
+			    parent.name.getName()
+			);
+		}
+
+		this.registry.put( moduleRecord.name, moduleRecord );
+
+		// Module Inception: does this module carry modules of its own?
+		Path nestedModulesPath = modulePath.resolve( MODULE_PACKAGE_PREFIX );
+		if ( Files.isDirectory( nestedModulesPath ) ) {
+			discoverModulesInPath( nestedModulesPath, moduleRecord );
+		}
+
+		return moduleRecord;
+	}
+
+	/**
+	 * Resolve the name a module at this path would register under, without building a record.
+	 * Used to skip candidates already present in the registry.
+	 *
+	 * @param modulePath The module's directory or jar file
+	 *
+	 * @return The module's name
+	 */
+	private Key discoverModuleName( Path modulePath ) {
+		// A jar module's conventional name is the jar's base name; an explicit @BoxModule( name )
+		// may rename it later, once its config is resolved off its class loader.
+		if ( isModuleJar( modulePath ) ) {
+			return Key.of( FilenameUtils.getBaseName( modulePath.getFileName().toString() ) );
+		}
+
+		Key		moduleName		= Key.of( modulePath.getFileName().toString() );
+		Path	moduleBoxJSON	= modulePath.resolve( ModuleRecord.MODULE_CONFIG_FILE );
+		if ( Files.exists( moduleBoxJSON ) ) {
+			moduleName = DataNavigator
+			    .of( moduleBoxJSON )
+			    .from( "boxlang" )
+			    .getAsKey( "moduleName", moduleName );
+		}
+
+		return moduleName;
+	}
+
+	/**
+	 * Verify if a path is a conventional module folder: a directory carrying a
+	 * {@code ModuleConfig.bx} or a {@code box.json} in its root.
+	 * <p>
+	 * Pure-Java modules may have only a {@code box.json}; their Java config is detected later
+	 * via {@link java.util.ServiceLoader}.
+	 *
+	 * @param modulePath The path to check
+	 *
+	 * @return {@code true} if the path is a module folder, {@code false} otherwise
+	 */
+	public static boolean isModuleFolder( Path modulePath ) {
+		return Files.isDirectory( modulePath )
+		    && ( Files.exists( modulePath.resolve( MODULE_DESCRIPTOR ) )
+		        || Files.exists( modulePath.resolve( ModuleRecord.MODULE_CONFIG_FILE ) ) );
+	}
+
+	/**
+	 * Verify if a path is a module packaged as a single jar file. Such a jar, placed directly in a
+	 * modules folder, is a module in its own right: it gets its own record and its own isolated
+	 * class loader, and its {@link ortus.boxlang.runtime.modules.IModuleConfig} is discovered via
+	 * {@link java.util.ServiceLoader} on that loader.
+	 *
+	 * @param modulePath The path to check
+	 *
+	 * @return {@code true} if the path is a module jar, {@code false} otherwise
+	 */
+	public static boolean isModuleJar( Path modulePath ) {
+		return Files.isRegularFile( modulePath )
+		    && modulePath.getFileName().toString().toLowerCase().endsWith( MODULE_JAR_EXTENSION );
+	}
+
+	/**
+	 * Register and activate a single module. Pass either the directory that contains the
+	 * ModuleConfig.bx (the directory name becomes the module name), or a module jar file (the jar's
+	 * base name becomes the module name).
+	 * <p>
+	 * Any modules nested inside the module's own {@code modules} folder are registered and
+	 * activated first (module inception).
+	 *
+	 * @param moduleDirectory The path to the module directory or jar
 	 */
 	public ModuleService loadModule( Path moduleDirectory ) {
-		if ( !Files.isDirectory( moduleDirectory ) ) {
-			throw new BoxRuntimeException( "The provided module path is not a directory: " + moduleDirectory.toString() );
+		if ( !Files.isDirectory( moduleDirectory ) && !isModuleJar( moduleDirectory ) ) {
+			throw new BoxRuntimeException( "The provided module path is not a directory or a module jar: " + moduleDirectory.toString() );
 		}
-		Key moduleName = Key.of( moduleDirectory.getFileName().toString() );
+		Key moduleName = discoverModuleName( moduleDirectory );
 		// exit if module already registered
 		if ( this.registry.containsKey( moduleName ) ) {
 			return this;
 		}
-		this.registry.put( moduleName, new ModuleRecord( moduleDirectory.toString() ) );
+		// Build the record and discover any modules nested inside it
+		createDiscoveredModule( moduleDirectory, null );
 		register( moduleName );
 		activate( moduleName );
 		return this;

--- a/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
+++ b/src/main/java/ortus/boxlang/runtime/services/ModuleService.java
@@ -21,17 +21,24 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.semver4j.Semver;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.config.segments.ModuleConfig;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.modules.ModuleRecord;
@@ -249,14 +256,32 @@ public class ModuleService extends BaseService {
 		// Scan for modules and build the registration records
 		buildRegistry();
 
-		// Register each module now
-		// If we detect more than 10 modules, do it async
+		/**
+		 * Top-level modules register first: each one's registration cascades into the modules
+		 * nested inside it (module inception), so parents always resolve their config before
+		 * their children need to read its per-child overrides. Without this ordering, registry
+		 * iteration order (a ConcurrentHashMap) would decide whether a child sees them.
+		 * Names are snapshotted first because registration can re-key the registry (jar renames).
+		 */
 		this.registry
-		    .entrySet()
+		    .values()
 		    .stream()
-		    // Filter out modules which are already registered
-		    .filter( m -> m.getValue().registeredOn == null )
-		    .forEach( entry -> this.register( entry.getKey() ) );
+		    .filter( record -> record.parentModule == null && record.registeredOn == null )
+		    .map( record -> record.name )
+		    .toList()
+		    .forEach( this::register );
+
+		// Sweep any stragglers: nested modules whose parent is not in the registry (orphans).
+		// Children of disabled parents stay unregistered by design — register() skips them.
+		this.registry
+		    .values()
+		    .stream()
+		    .filter( record -> record.registeredOn == null )
+		    .map( record -> record.name )
+		    .toList()
+		    .stream()
+		    .filter( this.registry::containsKey )
+		    .forEach( this::register );
 
 		// Log it
 		this.logger.debug(
@@ -310,16 +335,11 @@ public class ModuleService extends BaseService {
 		// Load the ModuleConfig.bx file, if it exists, and process the configuration
 		moduleRecord.loadDescriptor( runtimeContext );
 
-		// Verify if we disabled the loading of the module in the runtime config
-		// myModule : { enabled = false }
-		if ( this.runtime.getConfiguration().modules.containsKey( name ) ) {
-			ModuleConfig config = ( ModuleConfig ) this.runtime.getConfiguration().modules.get( name );
-			moduleRecord.enabled = config.enabled;
-		}
-
-		// Check if the module is disabled, if so, skip it. Any modules nested inside it are
-		// skipped with it: their class loaders chain to this one, so they cannot stand alone.
-		if ( !moduleRecord.isEnabled() ) {
+		// Fast path: an explicit global-config disable is final (the global app config always
+		// wins), so honor it before building any class loader at all.
+		if ( this.runtime.getConfiguration().modules.containsKey( name )
+		    && ! ( ( ModuleConfig ) this.runtime.getConfiguration().modules.get( name ) ).enabled ) {
+			moduleRecord.enabled = false;
 			this.logger.warn(
 			    "+ Module Service: Module [{}] is disabled, skipping registration",
 			    moduleRecord.name
@@ -327,17 +347,53 @@ public class ModuleService extends BaseService {
 			return;
 		}
 
+		// A nested module's ancestors must have their configs resolved (and be enabled) before it
+		// registers, whatever order registration was requested in. A disabled ancestor takes the
+		// whole subtree down with it: nested class loaders chain upward, so they cannot stand alone.
+		if ( !resolveAncestorChain( moduleRecord, runtimeContext ) ) {
+			this.logger.warn(
+			    "+ Module Service: Module [{}] is nested inside a disabled module, skipping registration",
+			    moduleRecord.name
+			);
+			return;
+		}
+
+		// Resolve this module's config: builds its class loader and detects a Java IModuleConfig
+		// (Java wins over BX). A jar module may rename itself here via @BoxModule( name ), so
+		// re-key it before any registration side effects happen under the old name.
+		moduleRecord.resolveModuleConfig( runtimeContext );
+		rekeyModule( name, moduleRecord );
+
+		/**
+		 * |--------------------------------------------------------------------------
+		 * | Enablement Precedence
+		 * |--------------------------------------------------------------------------
+		 * Later wins: own descriptor/annotation < parent module override < global app config.
+		 * Decided here, before any registration side effects, so a disabled module registers
+		 * nothing at all — no mappings, BIFs, services, or interceptors.
+		 */
+		applyEnablementOverrides( moduleRecord );
+		if ( !moduleRecord.isEnabled() ) {
+			this.logger.warn(
+			    "+ Module Service: Module [{}] is disabled, skipping registration",
+			    moduleRecord.name
+			);
+			// A disabled module must not hold an open class loader
+			moduleRecord.releaseClassLoader();
+			return;
+		}
+
 		/**
 		 * |--------------------------------------------------------------------------
 		 * | Module Inception
 		 * |--------------------------------------------------------------------------
-		 * Modules nested inside this one register before it does. This module's own config is
-		 * resolved first, so its per-child setting overrides are readable by those children,
-		 * while its full registration still happens after them.
+		 * Modules nested inside this one register before it does. This module's config is already
+		 * resolved above, so its per-child setting overrides are readable by those children,
+		 * while its full registration still happens after them. Iterated over a copy: a nested
+		 * jar module renaming itself mutates this very list mid-cascade.
 		 */
 		if ( !moduleRecord.nestedModules.isEmpty() ) {
-			moduleRecord.resolveModuleConfig( runtimeContext );
-			moduleRecord.nestedModules
+			Array.copyOf( moduleRecord.nestedModules )
 			    .stream()
 			    .map( childName -> Key.of( ( String ) childName ) )
 			    .filter( childKey -> this.registry.containsKey( childKey ) && this.registry.get( childKey ).registeredOn == null )
@@ -347,17 +403,19 @@ public class ModuleService extends BaseService {
 		// Configure the module
 		moduleRecord.register( runtimeContext );
 
-		// A jar module may rename itself via `@BoxModule( name = "..." )` once its config is
-		// resolved off its class loader, so re-key it under the name it actually registered as.
-		rekeyModule( name, moduleRecord );
+		// A module found invalid during registration (no descriptor at all) disables itself;
+		// nothing was registered for it, so it must not keep an open class loader either
+		if ( !moduleRecord.isEnabled() ) {
+			moduleRecord.releaseClassLoader();
+		}
 
 		// Log registration time
 		moduleRecord.registrationTime = BoxRuntime.timerUtil.stopAndGetMillis( timerLabel );
 
-		// Announce it
+		// Announce it, under the name the module actually registered as (a jar may have renamed itself)
 		announce(
 		    BoxEvent.POST_MODULE_REGISTRATION,
-		    Struct.of( "moduleRecord", moduleRecord, "moduleName", name )
+		    Struct.of( "moduleRecord", moduleRecord, "moduleName", moduleRecord.name )
 		);
 
 		// Log it
@@ -385,6 +443,19 @@ public class ModuleService extends BaseService {
 			return;
 		}
 
+		// Duplicate modules are not allowed, first one wins: refuse a rename that would clobber
+		// an existing module, and put the record's derived identity back to its discovered name.
+		if ( this.registry.containsKey( moduleRecord.name ) && this.registry.get( moduleRecord.name ) != moduleRecord ) {
+			this.logger.warn(
+			    "+ Module Service: Module discovered as [{}] renamed itself to [{}], but that name is already registered; keeping [{}]",
+			    registeredUnder.getName(),
+			    moduleRecord.name.getName(),
+			    registeredUnder.getName()
+			);
+			moduleRecord.applyName( registeredUnder );
+			return;
+		}
+
 		this.registry.remove( registeredUnder );
 		this.registry.put( moduleRecord.name, moduleRecord );
 
@@ -397,11 +468,86 @@ public class ModuleService extends BaseService {
 			}
 		}
 
+		// Keep any children's upward pointers on the new name (defensive: today only jar modules
+		// rename and a jar cannot carry nested modules, but cheap insurance against drift)
+		this.registry
+		    .values()
+		    .stream()
+		    .filter( record -> registeredUnder.equals( record.parentModule ) )
+		    .forEach( record -> record.parentModule = moduleRecord.name );
+
 		this.logger.debug(
 		    "+ Module Service: Module discovered as [{}] renamed itself to [{}] via its @BoxModule annotation",
 		    registeredUnder.getName(),
 		    moduleRecord.name.getName()
 		);
+	}
+
+	/**
+	 * Resolves the configs of a nested module's ancestors, topmost first, and reports whether the
+	 * whole chain is enabled.
+	 * <p>
+	 * A nested module can be asked to register before its parent (a direct {@code register()} call,
+	 * or plain registry iteration order), yet its parent's per-child overrides must already be
+	 * readable and a disabled ancestor must take the whole subtree down with it. Resolution is
+	 * idempotent, so ancestors that already resolved are no-ops.
+	 *
+	 * @param moduleRecord The module whose ancestors to resolve
+	 * @param context      The current context of execution
+	 *
+	 * @return {@code true} when every ancestor is enabled (or the module is top-level),
+	 *         {@code false} when any ancestor is disabled
+	 */
+	private boolean resolveAncestorChain( ModuleRecord moduleRecord, IBoxContext context ) {
+		Deque<ModuleRecord>	ancestors	= new ArrayDeque<>();
+		Set<Key>			visited		= new HashSet<>();
+		Key					parentKey	= moduleRecord.parentModule;
+
+		// Collect the chain bottom-up; iterate it top-down (push reverses the order)
+		while ( parentKey != null && visited.add( parentKey ) ) {
+			ModuleRecord parentRecord = this.registry.get( parentKey );
+			if ( parentRecord == null ) {
+				break;
+			}
+			ancestors.push( parentRecord );
+			parentKey = parentRecord.parentModule;
+		}
+
+		for ( ModuleRecord ancestor : ancestors ) {
+			ancestor.loadDescriptor( context );
+			ancestor.resolveModuleConfig( context );
+			applyEnablementOverrides( ancestor );
+			if ( !ancestor.isEnabled() ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Applies the {@code enabled} precedence to a module record: its own descriptor/annotation
+	 * value, overridden by its parent module's per-child declaration (if any), overridden by the
+	 * global app config (which always wins).
+	 *
+	 * @param moduleRecord The module record to apply enablement to
+	 */
+	private void applyEnablementOverrides( ModuleRecord moduleRecord ) {
+		// Parent module override beats the module's own descriptor/annotation value
+		if ( moduleRecord.parentModule != null ) {
+			ModuleRecord parentRecord = this.registry.get( moduleRecord.parentModule );
+			if ( parentRecord != null ) {
+				IStruct overrides = parentRecord.getChildOverrides( moduleRecord.name );
+				if ( overrides.containsKey( Key.enabled ) ) {
+					moduleRecord.enabled = BooleanCaster.cast( overrides.get( Key.enabled ) );
+				}
+			}
+		}
+
+		// The global app config always wins
+		if ( this.runtime.getConfiguration().modules.containsKey( moduleRecord.name ) ) {
+			moduleRecord.enabled = ( ( ModuleConfig ) this.runtime.getConfiguration().modules.get( moduleRecord.name ) ).enabled;
+		}
 	}
 
 	/**
@@ -474,6 +620,16 @@ public class ModuleService extends BaseService {
 		if ( !this.registry.get( name ).isEnabled() ) {
 			this.logger.warn(
 			    "+ Module Service: Module [{}] is disabled, skipping activation",
+			    name
+			);
+			return;
+		}
+
+		// A module that never completed registration has nothing to activate. This is the normal
+		// state of modules nested inside a disabled module: they stay discovered but unregistered.
+		if ( this.registry.get( name ).registeredOn == null ) {
+			this.logger.warn(
+			    "+ Module Service: Module [{}] is not registered, skipping activation",
 			    name
 			);
 			return;
@@ -845,8 +1001,10 @@ public class ModuleService extends BaseService {
 	 *                         top-level configured modules directory
 	 */
 	private void discoverModulesInPath( Path modulesDirectory, ModuleRecord parent ) {
-		try {
-			Files.walk( modulesDirectory, 1 )
+		// try-with-resources: Files.walk() must be closed or it leaks file handles,
+		// especially now that discovery recurses into nested modules folders
+		try ( Stream<Path> candidates = Files.walk( modulesDirectory, 1 ) ) {
+			candidates
 			    // Exclude the modules folder itself, and any root path in the `modulePaths` list
 			    .filter( filePath -> !filePath.equals( modulesDirectory ) )
 			    .filter( filePath -> !this.modulePaths.contains( filePath ) )
@@ -976,9 +1134,11 @@ public class ModuleService extends BaseService {
 			return this;
 		}
 		// Build the record and discover any modules nested inside it
-		createDiscoveredModule( moduleDirectory, null );
+		ModuleRecord moduleRecord = createDiscoveredModule( moduleDirectory, null );
 		register( moduleName );
-		activate( moduleName );
+		// Activate by the record's current name: a jar module may have renamed itself
+		// via @BoxModule( name ) during registration
+		activate( moduleRecord.name );
 		return this;
 	}
 

--- a/src/modules/javaTestModule/build.gradle
+++ b/src/modules/javaTestModule/build.gradle
@@ -68,9 +68,25 @@ task copyTestModuleToCore( type: Copy ) {
     into '../../../modules/javaTestModule'
 }
 
-shadowJar.finalizedBy( createModuleStructure, copyTestModuleToCore )
+/**
+ * Drops the same shadow JAR into the test resources as a bare *.jar module, exercising the
+ * "a jar in a modules folder IS a module" convention (module inception). The jar carries its
+ * own META-INF/services entry, so its IModuleConfig is found via ServiceLoader with no
+ * surrounding folder structure at all.
+ */
+task copyJarModuleFixture( type: Copy ) {
+    dependsOn( shadowJar )
+    from( 'build/libs' ) {
+        include "${project.name}-${version}-all.jar"
+        rename '.*', 'javaJarModule.jar'
+    }
+    destinationDir = file( '../../../src/test/jar-modules' )
+}
+
+shadowJar.finalizedBy( createModuleStructure, copyTestModuleToCore, copyJarModuleFixture )
 
 clean {
     // Only delete generated artifacts under the repo-root test fixture, not the fixture itself
     delete '../../../modules/javaTestModule/libs'
+    delete '../../../src/test/jar-modules'
 }

--- a/src/modules/javaTestModule/src/main/java/ortus/boxlang/modules/javatest/JavaTestModuleConfig.java
+++ b/src/modules/javaTestModule/src/main/java/ortus/boxlang/modules/javatest/JavaTestModuleConfig.java
@@ -26,7 +26,7 @@ import ortus.boxlang.runtime.modules.ModuleRecord;
  * Test implementation of IModuleConfig for use in unit tests.
  * Tracks lifecycle calls and demonstrates the {@code @BoxModule} annotation metadata convention.
  */
-@BoxModule( version = "2.0.0", author = "Ortus Solutions", description = "A pure-Java test module", webURL = "https://www.ortussolutions.com" )
+@BoxModule( name = "renamedJarModule", version = "2.0.0", author = "Ortus Solutions", description = "A pure-Java test module", webURL = "https://www.ortussolutions.com" )
 public class JavaTestModuleConfig implements IModuleConfig {
 
 	// --------------------------------------------------------------------------

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetModuleTreeTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/system/GetModuleTreeTest.java
@@ -1,0 +1,89 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.bifs.global.system;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IStruct;
+
+public class GetModuleTreeTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It can get the full module tree" )
+	@Test
+	public void testGetFullTree() {
+		instance.executeSource(
+		    """
+		    result = getModuleTree()
+		    """,
+		    context );
+
+		IStruct tree = ( IStruct ) variables.get( result );
+
+		assertThat( tree ).isNotNull();
+	}
+
+	@DisplayName( "It returns an empty struct for a module that does not exist" )
+	@Test
+	public void testUnregisteredModule() {
+		instance.executeSource(
+		    """
+		    result = getModuleTree( "bogus" )
+		    """,
+		    context );
+
+		IStruct tree = ( IStruct ) variables.get( result );
+
+		assertThat( tree ).isNotNull();
+		assertThat( tree ).isEmpty();
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordJavaConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/modules/ModuleRecordJavaConfigTest.java
@@ -175,10 +175,16 @@ class ModuleRecordJavaConfigTest {
 		ModuleRecord record = new ModuleRecord( JAVA_MODULE_PATH );
 
 		record.loadDescriptor( context ).register( context ).activate( context );
-		org.junit.jupiter.api.Assertions.assertDoesNotThrow( () -> record.moduleConfig.getClass().getMethod( "reset" ).invoke( null ) );
+		// Capture the config class BEFORE unloading: unload() resets the record's lifecycle
+		// state (moduleConfig included) so a later reload rebuilds everything from scratch
+		Class<?> configClass = record.moduleConfig.getClass();
+		org.junit.jupiter.api.Assertions.assertDoesNotThrow( () -> configClass.getMethod( "reset" ).invoke( null ) );
 		record.unload( context );
 
-		assertThat( getStaticBooleanFlag( record, "onUnloadCalled" ) ).isTrue();
+		assertThat( getStaticBooleanFlag( configClass, "onUnloadCalled" ) ).isTrue();
+		// The record's lifecycle state was reset for a potential reload
+		assertThat( record.moduleConfig ).isNull();
+		assertThat( record.getModuleClassLoader() ).isNull();
 	}
 
 	// -------------------------------------------------------------------------
@@ -314,8 +320,16 @@ class ModuleRecordJavaConfigTest {
 	 * loaded by the module's isolated classloader.
 	 */
 	private static boolean getStaticBooleanFlag( ModuleRecord record, String fieldName ) {
+		return getStaticBooleanFlag( record.moduleConfig.getClass(), fieldName );
+	}
+
+	/**
+	 * Reads a static boolean field from a config class captured before an unload
+	 * (unload resets the record's moduleConfig reference).
+	 */
+	private static boolean getStaticBooleanFlag( Class<?> configClass, String fieldName ) {
 		try {
-			Field field = record.moduleConfig.getClass().getField( fieldName );
+			Field field = configClass.getField( fieldName );
 			return ( boolean ) field.get( null );
 		} catch ( Exception e ) {
 			throw new RuntimeException( "Could not read static flag [" + fieldName + "]: " + e.getMessage(), e );

--- a/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
@@ -1,0 +1,438 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.runtime.services;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.config.segments.ModuleConfig;
+import ortus.boxlang.runtime.loader.DynamicClassLoader;
+import ortus.boxlang.runtime.modules.BoxModuleConfig;
+import ortus.boxlang.runtime.modules.ModuleRecord;
+import ortus.boxlang.runtime.scopes.Key;
+
+/**
+ * Tests for module inception: modules nested inside another module's own {@code modules} folder.
+ *
+ * <p>
+ * Covers discovery and recursion, the parent/child links, registration and activation ordering,
+ * the class loader chain that mirrors the module hierarchy, and the settings precedence
+ * (child defaults, then parent overrides, then global app config).
+ * </p>
+ */
+class ModuleInceptionTest {
+
+	static BoxRuntime		runtime;
+	ModuleService			service;
+
+	/** Fixture tree: inceptionParent > inceptionChild > inceptionGrandchild. */
+	static final Path		INCEPTION_MODULES			= Paths.get( "src/test/resources/inception-modules" ).toAbsolutePath();
+
+	/** Fixture tree: disablingParent > disabledChild, where the parent switches the child off. */
+	static final Path		INCEPTION_MODULES_DISABLED	= Paths.get( "src/test/resources/inception-modules-disabled" ).toAbsolutePath();
+
+	/** Holds javaJarModule.jar, built by the javaTestModule Gradle subproject. */
+	static final Path		JAR_MODULES					= Paths.get( "src/test/jar-modules" ).toAbsolutePath();
+
+	static final Key		PARENT						= Key.of( "inceptionParent" );
+	static final Key		CHILD						= Key.of( "inceptionChild" );
+	static final Key		GRANDCHILD					= Key.of( "inceptionGrandchild" );
+	static final Key		DISABLING_PARENT			= Key.of( "disablingParent" );
+	static final Key		DISABLED_CHILD				= Key.of( "disabledChild" );
+	static final Key		JAR_MODULE					= Key.of( "javaJarModule" );
+	static final Key		JAR_HOST					= Key.of( "jarHostModule" );
+
+	static final List<Key>	ALL_FIXTURES				= List.of(
+	    PARENT, CHILD, GRANDCHILD, DISABLING_PARENT, DISABLED_CHILD, JAR_MODULE, JAR_HOST
+	);
+
+	@BeforeEach
+	void setup() {
+		runtime	= BoxRuntime.getInstance( true );
+		service	= runtime.getModuleService();
+		cleanupFixtures();
+	}
+
+	@AfterEach
+	void teardown() {
+		cleanupFixtures();
+	}
+
+	// -------------------------------------------------------------------------
+	// Discovery
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "A module's own modules folder is discovered recursively, to arbitrary depth" )
+	@Test
+	void testNestedModulesAreDiscoveredRecursively() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		assertThat( service.hasModule( PARENT ) ).isTrue();
+		assertThat( service.hasModule( CHILD ) ).isTrue();
+		assertThat( service.hasModule( GRANDCHILD ) ).isTrue();
+	}
+
+	@DisplayName( "Discovery links parent and child records both ways" )
+	@Test
+	void testParentAndChildAreLinkedBothWays() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		ModuleRecord	parent		= service.getModuleRecord( PARENT );
+		ModuleRecord	child		= service.getModuleRecord( CHILD );
+		ModuleRecord	grandchild	= service.getModuleRecord( GRANDCHILD );
+
+		// Downward: a parent knows its children and can target one directly
+		assertThat( parent.nestedModules ).contains( CHILD.getName() );
+		assertThat( parent.hasNestedModule( CHILD ) ).isTrue();
+		assertThat( parent.getNestedModule( CHILD ) ).isSameInstanceAs( child );
+		assertThat( child.nestedModules ).contains( GRANDCHILD.getName() );
+
+		// Upward: a child knows its parent
+		assertThat( child.parentModule ).isEqualTo( PARENT );
+		assertThat( grandchild.parentModule ).isEqualTo( CHILD );
+
+		// A top-level module has no parent, and a leaf has no children
+		assertThat( parent.parentModule ).isNull();
+		assertThat( grandchild.nestedModules ).isEmpty();
+	}
+
+	@DisplayName( "getNestedModule only resolves this module's own children, not arbitrary modules" )
+	@Test
+	void testGetNestedModuleIsScopedToDirectChildren() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		ModuleRecord parent = service.getModuleRecord( PARENT );
+
+		// The grandchild is in the registry, but it is not a DIRECT child of the parent
+		assertThat( service.hasModule( GRANDCHILD ) ).isTrue();
+		assertThat( parent.hasNestedModule( GRANDCHILD ) ).isFalse();
+		assertThat( parent.getNestedModule( GRANDCHILD ) ).isNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// Ordering
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "Nested modules register and activate before the module that carries them" )
+	@Test
+	void testNestedModulesLoadBeforeTheirParent() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		service.register( PARENT );
+		service.activate( PARENT );
+
+		ModuleRecord	parent		= service.getModuleRecord( PARENT );
+		ModuleRecord	child		= service.getModuleRecord( CHILD );
+		ModuleRecord	grandchild	= service.getModuleRecord( GRANDCHILD );
+
+		// Registering/activating only the parent must cascade down the whole tree
+		assertThat( child.registeredOn ).isNotNull();
+		assertThat( grandchild.registeredOn ).isNotNull();
+		assertThat( child.isActivated() ).isTrue();
+		assertThat( grandchild.isActivated() ).isTrue();
+		assertThat( parent.isActivated() ).isTrue();
+
+		// Deepest first, on the way both in and up
+		assertThat( grandchild.registeredOn ).isAtMost( child.registeredOn );
+		assertThat( child.registeredOn ).isAtMost( parent.registeredOn );
+		assertThat( grandchild.activatedOn ).isAtMost( child.activatedOn );
+		assertThat( child.activatedOn ).isAtMost( parent.activatedOn );
+	}
+
+	@DisplayName( "Unloading a module unloads the modules nested inside it first" )
+	@Test
+	void testNestedModulesUnloadBeforeTheirParent() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+		service.register( PARENT );
+		service.activate( PARENT );
+
+		service.unload( PARENT, true );
+
+		// The whole tree comes down with the parent, not just the parent itself
+		assertThat( service.hasModule( PARENT ) ).isFalse();
+		assertThat( service.hasModule( CHILD ) ).isFalse();
+		assertThat( service.hasModule( GRANDCHILD ) ).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Class loader hierarchy
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "A nested module's class loader is parented to its parent module's loader, up to the runtime loader" )
+	@Test
+	void testClassLoaderHierarchyMirrorsModuleHierarchy() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+		service.register( PARENT );
+
+		// Module loaders are built with loadParentFirst=false, so they deliberately pass null to
+		// URLClassLoader's parent to create an isolation boundary and track the real parent
+		// themselves. getDynamicParent() is therefore the chain to assert on, not getParent().
+		DynamicClassLoader	parentLoader		= ( DynamicClassLoader ) service.getModuleRecord( PARENT ).getModuleClassLoader();
+		DynamicClassLoader	childLoader			= ( DynamicClassLoader ) service.getModuleRecord( CHILD ).getModuleClassLoader();
+		DynamicClassLoader	grandchildLoader	= ( DynamicClassLoader ) service.getModuleRecord( GRANDCHILD ).getModuleClassLoader();
+
+		// Each level chains to the one above it...
+		assertThat( grandchildLoader.getDynamicParent() ).isSameInstanceAs( childLoader );
+		assertThat( childLoader.getDynamicParent() ).isSameInstanceAs( parentLoader );
+		// ...and the top-level module chains to the runtime loader
+		assertThat( parentLoader.getDynamicParent() ).isSameInstanceAs( runtime.getRuntimeLoader() );
+	}
+
+	@DisplayName( "The class loader is built once and reused" )
+	@Test
+	void testClassLoaderCreationIsIdempotent() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		ModuleRecord child = service.getModuleRecord( CHILD );
+
+		assertThat( child.getOrCreateModuleClassLoader() ).isSameInstanceAs( child.getOrCreateModuleClassLoader() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Settings precedence
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "A parent module's overrides beat the child's own configure() defaults" )
+	@Test
+	void testParentOverridesBeatChildDefaults() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+		service.register( PARENT );
+
+		ModuleRecord child = service.getModuleRecord( CHILD );
+
+		// Overridden by the parent
+		assertThat( child.settings.getAsString( Key.of( "overriddenByParent" ) ) ).isEqualTo( "fromParent" );
+		// Contributed only by the parent
+		assertThat( child.settings.getAsString( Key.of( "parentOnlySetting" ) ) ).isEqualTo( "addedByParent" );
+		// Untouched by the parent: the merge is additive, not wholesale replacement
+		assertThat( child.settings.getAsString( Key.of( "ownSetting" ) ) ).isEqualTo( "fromChild" );
+	}
+
+	@DisplayName( "The global app config beats a parent module's overrides" )
+	@Test
+	void testGlobalConfigBeatsParentOverrides() {
+		ModuleConfig globalConfig = new ModuleConfig( CHILD.getName() );
+		globalConfig.settings.put( Key.of( "overriddenByParent" ), "fromGlobalConfig" );
+		runtime.getConfiguration().modules.put( CHILD, globalConfig );
+
+		try {
+			service.buildRegistryFromPath( INCEPTION_MODULES );
+			service.register( PARENT );
+
+			ModuleRecord child = service.getModuleRecord( CHILD );
+
+			// Global app config is applied last and wins over the parent
+			assertThat( child.settings.getAsString( Key.of( "overriddenByParent" ) ) ).isEqualTo( "fromGlobalConfig" );
+			// The parent's other contribution still stands where global config is silent
+			assertThat( child.settings.getAsString( Key.of( "parentOnlySetting" ) ) ).isEqualTo( "addedByParent" );
+		} finally {
+			runtime.getConfiguration().modules.remove( CHILD );
+		}
+	}
+
+	@DisplayName( "A parent module can disable a module nested inside it" )
+	@Test
+	void testParentCanDisableNestedModule() {
+		service.buildRegistryFromPath( INCEPTION_MODULES_DISABLED );
+		service.register( DISABLING_PARENT );
+
+		ModuleRecord disabledChild = service.getModuleRecord( DISABLED_CHILD );
+
+		// The child declares itself enabled; only the parent's override switches it off
+		assertThat( disabledChild.isEnabled() ).isFalse();
+
+		service.activate( DISABLING_PARENT );
+		assertThat( disabledChild.isActivated() ).isFalse();
+	}
+
+	@DisplayName( "Disabling a module also skips the modules nested inside it" )
+	@Test
+	void testDisablingAModuleSkipsItsNestedModules() {
+		ModuleConfig globalConfig = new ModuleConfig( PARENT.getName() );
+		globalConfig.enabled = false;
+		runtime.getConfiguration().modules.put( PARENT, globalConfig );
+
+		try {
+			service.buildRegistryFromPath( INCEPTION_MODULES );
+			service.register( PARENT );
+			service.activate( PARENT );
+
+			// A nested module's class loader chains to its parent's, so it cannot load without it
+			assertThat( service.getModuleRecord( PARENT ).registeredOn ).isNull();
+			assertThat( service.getModuleRecord( CHILD ).registeredOn ).isNull();
+			assertThat( service.getModuleRecord( GRANDCHILD ).registeredOn ).isNull();
+			assertThat( service.getModuleRecord( CHILD ).isActivated() ).isFalse();
+		} finally {
+			runtime.getConfiguration().modules.remove( PARENT );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Jar modules
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "A bare jar sitting in a modules folder is discovered as a module in its own right" )
+	@Test
+	void testJarInModulesFolderIsAModule() {
+		service.buildRegistryFromPath( JAR_MODULES );
+
+		assertThat( service.hasModule( JAR_MODULE ) ).isTrue();
+
+		ModuleRecord record = service.getModuleRecord( JAR_MODULE );
+		// The jar's base name becomes the module name, with the extension stripped
+		assertThat( record.name ).isEqualTo( JAR_MODULE );
+		assertThat( record.isJarModule() ).isTrue();
+	}
+
+	@DisplayName( "A jar module's descriptor is found via ServiceLoader on its own class loader" )
+	@Test
+	void testJarModuleResolvesItsJavaConfig() {
+		service.buildRegistryFromPath( JAR_MODULES );
+		service.register( JAR_MODULE );
+		service.activate( JAR_MODULE );
+
+		ModuleRecord record = service.getModuleRecord( JAR_MODULE );
+
+		// The IModuleConfig comes from the jar itself, not from any surrounding folder
+		assertThat( record.moduleConfig ).isNotNull();
+		assertThat( record.moduleConfig ).isNotInstanceOf( BoxModuleConfig.class );
+		assertThat( record.isActivated() ).isTrue();
+
+		// @BoxModule annotation metadata is applied
+		assertThat( record.version ).isEqualTo( "2.0.0" );
+		assertThat( record.author ).isEqualTo( "Ortus Solutions" );
+
+		// configure() ran against this record
+		assertThat( record.settings.getAsString( Key.of( "javaKey" ) ) ).isEqualTo( "javaValue" );
+	}
+
+	@DisplayName( "A jar module nested inside another module loads before it, chained to its loader" )
+	@Test
+	void testJarModuleNestedInsideAnotherModule( @TempDir Path tempDir ) throws IOException {
+		// Build a module folder on the fly that carries the jar module inside its own modules folder
+		Path hostModule = tempDir.resolve( "jarHostModule" );
+		Files.createDirectories( hostModule.resolve( ModuleService.MODULE_PACKAGE_PREFIX ) );
+		Files.writeString(
+		    hostModule.resolve( ModuleService.MODULE_DESCRIPTOR ),
+		    """
+		    class {
+		    	this.version = "1.0.0";
+		    	this.mapping = "jarHostModule";
+		    	this.enabled = true;
+
+		    	function configure(){
+		    		settings					= {};
+		    		interceptors				= [];
+		    		customInterceptionPoints	= [];
+		    	}
+		    }
+		    """
+		);
+		Files.copy(
+		    JAR_MODULES.resolve( "javaJarModule.jar" ),
+		    hostModule.resolve( ModuleService.MODULE_PACKAGE_PREFIX ).resolve( "javaJarModule.jar" )
+		);
+
+		try {
+			service.loadModule( hostModule );
+
+			ModuleRecord	host	= service.getModuleRecord( JAR_HOST );
+			ModuleRecord	jar		= service.getModuleRecord( JAR_MODULE );
+
+			// The jar is a full child module of the host
+			assertThat( host.hasNestedModule( JAR_MODULE ) ).isTrue();
+			assertThat( jar.parentModule ).isEqualTo( JAR_HOST );
+			assertThat( jar.isActivated() ).isTrue();
+			assertThat( jar.activatedOn ).isAtMost( host.activatedOn );
+
+			// ...and its class loader chains to the host's, like any other nested module
+			DynamicClassLoader	hostLoader	= ( DynamicClassLoader ) host.getModuleClassLoader();
+			DynamicClassLoader	jarLoader	= ( DynamicClassLoader ) jar.getModuleClassLoader();
+			assertThat( jarLoader.getDynamicParent() ).isSameInstanceAs( hostLoader );
+		} finally {
+			cleanupModule( JAR_HOST );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// loadModule
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "loadModule on a single module also loads the modules nested inside it" )
+	@Test
+	void testLoadModulePicksUpNestedModules() {
+		service.loadModule( INCEPTION_MODULES.resolve( "inceptionParent" ) );
+
+		assertThat( service.getModuleRecord( PARENT ).isActivated() ).isTrue();
+		assertThat( service.getModuleRecord( CHILD ).isActivated() ).isTrue();
+		assertThat( service.getModuleRecord( GRANDCHILD ).isActivated() ).isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Removes the fixture modules and their mappings so each test starts from a clean registry
+	 * and tests cannot bleed into one another.
+	 */
+	private void cleanupFixtures() {
+		ALL_FIXTURES.forEach( this::cleanupModule );
+	}
+
+	/**
+	 * Unloads one fixture module and drops it from the registry, ignoring the failures expected
+	 * when a module never got far enough to register mappings or activate.
+	 *
+	 * @param name The module to clean up
+	 */
+	private void cleanupModule( Key name ) {
+		ModuleRecord record = service.getModuleRecord( name );
+		if ( record == null ) {
+			return;
+		}
+
+		try {
+			service.unload( name, true );
+		} catch ( Exception ignored ) {
+			// Best effort: an un-activated record has nothing to unload
+		}
+
+		try {
+			runtime.getConfiguration().unregisterMapping( record.mapping );
+			runtime.getConfiguration().unregisterMapping( record.publicMapping );
+		} catch ( Exception ignored ) {
+			// Mappings are only registered once a module registers successfully
+		}
+
+		service.getRegistry().remove( name );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
@@ -37,6 +37,7 @@ import ortus.boxlang.runtime.loader.DynamicClassLoader;
 import ortus.boxlang.runtime.modules.BoxModuleConfig;
 import ortus.boxlang.runtime.modules.ModuleRecord;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
 
 /**
  * Tests for module inception: modules nested inside another module's own {@code modules} folder.
@@ -568,6 +569,57 @@ class ModuleInceptionTest {
 		assertThat( service.getModuleRecord( PARENT ).isActivated() ).isTrue();
 		assertThat( service.getModuleRecord( CHILD ).isActivated() ).isTrue();
 		assertThat( service.getModuleRecord( GRANDCHILD ).isActivated() ).isTrue();
+	}
+
+	// -------------------------------------------------------------------------
+	// Module tree
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "getModuleTree() nests children under their parent, and omits them from the top level" )
+	@Test
+	void testGetModuleTreeNestsChildren() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		IStruct tree = service.getModuleTree();
+
+		// Only the top-level module appears at the root...
+		assertThat( tree.containsKey( PARENT ) ).isTrue();
+		assertThat( tree.containsKey( CHILD ) ).isFalse();
+		assertThat( tree.containsKey( GRANDCHILD ) ).isFalse();
+
+		// ...its children are nested underneath it instead, to arbitrary depth
+		IStruct	parentNode		= ( IStruct ) tree.get( PARENT );
+		IStruct	parentChildren	= ( IStruct ) parentNode.get( Key.of( "children" ) );
+		assertThat( parentChildren.containsKey( CHILD ) ).isTrue();
+
+		IStruct	childNode		= ( IStruct ) parentChildren.get( CHILD );
+		IStruct	childChildren	= ( IStruct ) childNode.get( Key.of( "children" ) );
+		assertThat( childChildren.containsKey( GRANDCHILD ) ).isTrue();
+
+		// A leaf's children struct is empty, not absent
+		IStruct grandchildNode = ( IStruct ) childChildren.get( GRANDCHILD );
+		assertThat( ( IStruct ) grandchildNode.get( Key.of( "children" ) ) ).isEmpty();
+
+		// Each node still carries the module's own record data
+		assertThat( parentNode.get( Key._NAME ) ).isEqualTo( PARENT );
+	}
+
+	@DisplayName( "getModuleTree( name ) returns the subtree rooted at that module" )
+	@Test
+	void testGetModuleTreeRootedAtAModule() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		IStruct childSubtree = service.getModuleTree( CHILD );
+
+		assertThat( childSubtree.get( Key._NAME ) ).isEqualTo( CHILD );
+		IStruct children = ( IStruct ) childSubtree.get( Key.of( "children" ) );
+		assertThat( children.containsKey( GRANDCHILD ) ).isTrue();
+	}
+
+	@DisplayName( "getModuleTree( name ) returns an empty struct for an unregistered module" )
+	@Test
+	void testGetModuleTreeForUnregisteredModuleIsEmpty() {
+		assertThat( service.getModuleTree( Key.of( "doesNotExist" ) ) ).isEmpty();
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
+++ b/src/test/java/ortus/boxlang/runtime/services/ModuleInceptionTest.java
@@ -66,11 +66,14 @@ class ModuleInceptionTest {
 	static final Key		GRANDCHILD					= Key.of( "inceptionGrandchild" );
 	static final Key		DISABLING_PARENT			= Key.of( "disablingParent" );
 	static final Key		DISABLED_CHILD				= Key.of( "disabledChild" );
+	/** The jar module's discovery name: the jar file's base name. */
 	static final Key		JAR_MODULE					= Key.of( "javaJarModule" );
+	/** The name the jar module renames itself to via {@code @BoxModule( name )} during registration. */
+	static final Key		JAR_RENAMED					= Key.of( "renamedJarModule" );
 	static final Key		JAR_HOST					= Key.of( "jarHostModule" );
 
 	static final List<Key>	ALL_FIXTURES				= List.of(
-	    PARENT, CHILD, GRANDCHILD, DISABLING_PARENT, DISABLED_CHILD, JAR_MODULE, JAR_HOST
+	    PARENT, CHILD, GRANDCHILD, DISABLING_PARENT, DISABLED_CHILD, JAR_MODULE, JAR_RENAMED, JAR_HOST
 	);
 
 	@BeforeEach
@@ -316,14 +319,24 @@ class ModuleInceptionTest {
 	void testJarModuleResolvesItsJavaConfig() {
 		service.buildRegistryFromPath( JAR_MODULES );
 		service.register( JAR_MODULE );
-		service.activate( JAR_MODULE );
 
-		ModuleRecord record = service.getModuleRecord( JAR_MODULE );
+		// The jar renamed itself via @BoxModule( name ) during registration, and the
+		// registry was re-keyed to match — the discovery name is gone
+		assertThat( service.hasModule( JAR_RENAMED ) ).isTrue();
+		assertThat( service.hasModule( JAR_MODULE ) ).isFalse();
+
+		service.activate( JAR_RENAMED );
+
+		ModuleRecord record = service.getModuleRecord( JAR_RENAMED );
 
 		// The IModuleConfig comes from the jar itself, not from any surrounding folder
 		assertThat( record.moduleConfig ).isNotNull();
 		assertThat( record.moduleConfig ).isNotInstanceOf( BoxModuleConfig.class );
 		assertThat( record.isActivated() ).isTrue();
+
+		// The rename re-derived everything keyed off the name
+		assertThat( record.name ).isEqualTo( JAR_RENAMED );
+		assertThat( record.invocationPath ).isEqualTo( ModuleService.MODULE_MAPPING_INVOCATION_PREFIX + JAR_RENAMED.getName() );
 
 		// @BoxModule annotation metadata is applied
 		assertThat( record.version ).isEqualTo( "2.0.0" );
@@ -331,6 +344,39 @@ class ModuleInceptionTest {
 
 		// configure() ran against this record
 		assertThat( record.settings.getAsString( Key.of( "javaKey" ) ) ).isEqualTo( "javaValue" );
+	}
+
+	@DisplayName( "loadModule on a self-renaming jar registers and activates it under its new name" )
+	@Test
+	void testLoadModuleActivatesARenamedJarModule() {
+		service.loadModule( JAR_MODULES.resolve( "javaJarModule.jar" ) );
+
+		ModuleRecord record = service.getModuleRecord( JAR_RENAMED );
+
+		assertThat( record ).isNotNull();
+		assertThat( record.isActivated() ).isTrue();
+		assertThat( service.hasModule( JAR_MODULE ) ).isFalse();
+	}
+
+	@DisplayName( "A folder module never renames itself via @BoxModule( name ); the folder name wins" )
+	@Test
+	void testFolderModuleIgnoresAnnotationName() {
+		// The javaTestModule FOLDER fixture carries the very same IModuleConfig class as the jar,
+		// annotated @BoxModule( name = "renamedJarModule" ) — but folder modules keep their name.
+		Path			folderFixture	= Paths.get( "./modules/javaTestModule" ).toAbsolutePath();
+
+		ModuleRecord	record			= new ModuleRecord( folderFixture.toString() );
+		try {
+			record.resolveModuleConfig( runtime.getRuntimeContext() );
+
+			assertThat( record.moduleConfig ).isNotNull();
+			assertThat( record.isJarModule() ).isFalse();
+			assertThat( record.name ).isEqualTo( Key.of( "javaTestModule" ) );
+			// ...while the rest of the annotation metadata still applies
+			assertThat( record.version ).isEqualTo( "2.0.0" );
+		} finally {
+			record.releaseClassLoader();
+		}
 	}
 
 	@DisplayName( "A jar module nested inside another module loads before it, chained to its loader" )
@@ -364,10 +410,12 @@ class ModuleInceptionTest {
 			service.loadModule( hostModule );
 
 			ModuleRecord	host	= service.getModuleRecord( JAR_HOST );
-			ModuleRecord	jar		= service.getModuleRecord( JAR_MODULE );
+			ModuleRecord	jar		= service.getModuleRecord( JAR_RENAMED );
 
-			// The jar is a full child module of the host
-			assertThat( host.hasNestedModule( JAR_MODULE ) ).isTrue();
+			// The jar is a full child module of the host, tracked under the name it renamed
+			// itself to — the parent's child list follows the rename
+			assertThat( host.hasNestedModule( JAR_RENAMED ) ).isTrue();
+			assertThat( host.hasNestedModule( JAR_MODULE ) ).isFalse();
 			assertThat( jar.parentModule ).isEqualTo( JAR_HOST );
 			assertThat( jar.isActivated() ).isTrue();
 			assertThat( jar.activatedOn ).isAtMost( host.activatedOn );
@@ -379,6 +427,133 @@ class ModuleInceptionTest {
 		} finally {
 			cleanupModule( JAR_HOST );
 		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Registration order independence
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "A child registered before its parent still receives the parent's overrides" )
+	@Test
+	void testChildRegisteredFirstStillGetsParentOverrides() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+
+		// Register the CHILD directly, before anyone has touched the parent: its ancestors'
+		// configs must be resolved on demand so their overrides are readable
+		service.register( CHILD );
+
+		ModuleRecord child = service.getModuleRecord( CHILD );
+
+		assertThat( child.registeredOn ).isNotNull();
+		assertThat( child.settings.getAsString( Key.of( "overriddenByParent" ) ) ).isEqualTo( "fromParent" );
+		assertThat( child.settings.getAsString( Key.of( "parentOnlySetting" ) ) ).isEqualTo( "addedByParent" );
+
+		// The parent itself has not registered — only its config was resolved
+		assertThat( service.getModuleRecord( PARENT ).registeredOn ).isNull();
+
+		// A later full pass still registers the parent without re-registering the child
+		service.register( PARENT );
+		assertThat( service.getModuleRecord( PARENT ).registeredOn ).isNotNull();
+	}
+
+	@DisplayName( "A child its parent disabled is skipped even when registered directly, before the parent" )
+	@Test
+	void testChildOfDisabledParentIsSkippedWhenRegisteredDirectly() {
+		service.buildRegistryFromPath( INCEPTION_MODULES_DISABLED );
+
+		// Register the CHILD directly — the parent's disable directive must still be honored
+		service.register( DISABLED_CHILD );
+
+		assertThat( service.getModuleRecord( DISABLED_CHILD ).registeredOn ).isNull();
+	}
+
+	@DisplayName( "registerAll and activateAll survive disabled subtrees regardless of iteration order" )
+	@Test
+	void testRegisterAllAndActivateAllWithDisabledSubtrees() {
+		service.buildRegistryFromPath( INCEPTION_MODULES );
+		service.buildRegistryFromPath( INCEPTION_MODULES_DISABLED );
+
+		// Must not throw: children of disabled parents stay discovered-but-unregistered,
+		// and activation must skip them instead of tripping on their null config
+		service.registerAll();
+		service.activateAll();
+
+		assertThat( service.getModuleRecord( PARENT ).isActivated() ).isTrue();
+		assertThat( service.getModuleRecord( CHILD ).isActivated() ).isTrue();
+		assertThat( service.getModuleRecord( CHILD ).settings.getAsString( Key.of( "overriddenByParent" ) ) ).isEqualTo( "fromParent" );
+		assertThat( service.getModuleRecord( DISABLING_PARENT ).isActivated() ).isTrue();
+		assertThat( service.getModuleRecord( DISABLED_CHILD ).registeredOn ).isNull();
+		assertThat( service.getModuleRecord( DISABLED_CHILD ).isActivated() ).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Enablement precedence
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "The global app config can re-enable a child its parent disabled" )
+	@Test
+	void testGlobalConfigCanReenableAChildItsParentDisabled() {
+		ModuleConfig globalConfig = new ModuleConfig( DISABLED_CHILD.getName() );
+		globalConfig.enabled = true;
+		runtime.getConfiguration().modules.put( DISABLED_CHILD, globalConfig );
+
+		try {
+			service.buildRegistryFromPath( INCEPTION_MODULES_DISABLED );
+			service.register( DISABLING_PARENT );
+			service.activate( DISABLING_PARENT );
+
+			ModuleRecord child = service.getModuleRecord( DISABLED_CHILD );
+
+			// The global app config always wins — even over the parent's disable directive
+			assertThat( child.isEnabled() ).isTrue();
+			assertThat( child.registeredOn ).isNotNull();
+			assertThat( child.isActivated() ).isTrue();
+		} finally {
+			runtime.getConfiguration().modules.remove( DISABLED_CHILD );
+		}
+	}
+
+	@DisplayName( "A module disabled by its parent registers nothing at all" )
+	@Test
+	void testDisabledChildRegistersNoCapabilities() {
+		service.buildRegistryFromPath( INCEPTION_MODULES_DISABLED );
+		service.register( DISABLING_PARENT );
+
+		ModuleRecord child = service.getModuleRecord( DISABLED_CHILD );
+
+		// Not just "not activated": no registration side effects happened at all
+		assertThat( child.registeredOn ).isNull();
+		assertThat( child.isEnabled() ).isFalse();
+		// ...including its class loader, which a disabled module must not hold open
+		assertThat( child.getModuleClassLoader() ).isNull();
+		// ...and its mapping, which must not resolve in the runtime
+		assertThat( runtime.getConfiguration().hasMapping( child.mapping.name() ) ).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Reload
+	// -------------------------------------------------------------------------
+
+	@DisplayName( "Reloading a module with nested modules tears the tree down and rebuilds it" )
+	@Test
+	void testReloadRebuildsAModuleTree() {
+		service.loadModule( INCEPTION_MODULES.resolve( "inceptionParent" ) );
+
+		ModuleRecord parentBefore = service.getModuleRecord( PARENT );
+		assertThat( parentBefore.isActivated() ).isTrue();
+
+		service.reload( PARENT );
+
+		ModuleRecord	parent	= service.getModuleRecord( PARENT );
+		ModuleRecord	child	= service.getModuleRecord( CHILD );
+
+		// The whole tree is registered and active again, on fresh class loaders
+		assertThat( parent.isActivated() ).isTrue();
+		assertThat( child.isActivated() ).isTrue();
+		assertThat( parent.registeredOn ).isNotNull();
+		assertThat( parent.getModuleClassLoader() ).isNotNull();
+		// The parent's overrides survived the round trip
+		assertThat( child.settings.getAsString( Key.of( "overriddenByParent" ) ) ).isEqualTo( "fromParent" );
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/test/resources/inception-modules-disabled/disablingParent/ModuleConfig.bx
+++ b/src/test/resources/inception-modules-disabled/disablingParent/ModuleConfig.bx
@@ -1,0 +1,47 @@
+/**
+ * Test fixture: a module that disables one of its own nested modules via `this.modules`.
+ * Kept in its own modules folder so the enablement test cannot interfere with the
+ * settings-precedence fixtures.
+ */
+class {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	this.version		= "1.0.0";
+	this.mapping		= "disablingParent";
+	this.author			= "Ortus Solutions";
+	this.description	= "A module that disables its own nested module";
+	this.enabled		= true;
+
+	/**
+	 * A parent may switch a nested module off entirely.
+	 */
+	this.modules = {
+		"disabledChild" : {
+			enabled : false
+		}
+	};
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	function configure(){
+		settings					= {};
+		interceptors				= [];
+		customInterceptionPoints	= [];
+	}
+
+	function onLoad(){
+	}
+
+	function onUnload(){
+	}
+
+}

--- a/src/test/resources/inception-modules-disabled/disablingParent/modules/disabledChild/ModuleConfig.bx
+++ b/src/test/resources/inception-modules-disabled/disablingParent/modules/disabledChild/ModuleConfig.bx
@@ -1,0 +1,37 @@
+/**
+ * Test fixture: a nested module that its parent switches off via `this.modules`.
+ * It declares itself enabled so the test proves the parent's override is what disables it.
+ */
+class {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	this.version		= "1.0.0";
+	this.mapping		= "disabledChild";
+	this.author			= "Ortus Solutions";
+	this.description	= "A nested module disabled by its parent";
+	this.enabled		= true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	function configure(){
+		settings					= {};
+		interceptors				= [];
+		customInterceptionPoints	= [];
+	}
+
+	function onLoad(){
+	}
+
+	function onUnload(){
+	}
+
+}

--- a/src/test/resources/inception-modules/inceptionParent/ModuleConfig.bx
+++ b/src/test/resources/inception-modules/inceptionParent/ModuleConfig.bx
@@ -1,0 +1,57 @@
+/**
+ * Test fixture: a module that carries modules of its own (module inception).
+ *
+ * Its `modules` folder holds `inceptionChild`, which in turn holds `inceptionGrandchild`.
+ * All of them must be discovered, registered and activated before this module itself.
+ *
+ * This descriptor also exercises parent-level setting overrides via `this.modules`.
+ */
+class {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	this.version		= "1.0.0";
+	this.mapping		= "inceptionParent";
+	this.author			= "Ortus Solutions";
+	this.description	= "A module that carries nested modules";
+	this.enabled		= true;
+
+	/**
+	 * Per-child overrides for the modules nested inside this one.
+	 * These win over the child's own configure() defaults, but lose to the global app config.
+	 */
+	this.modules = {
+		"inceptionChild" : {
+			settings : {
+				overriddenByParent	: "fromParent",
+				parentOnlySetting	: "addedByParent"
+			}
+		}
+	};
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	function configure(){
+		settings = {
+			owner : "inceptionParent"
+		};
+
+		interceptors				= [];
+		customInterceptionPoints	= [];
+	}
+
+	function onLoad(){
+	}
+
+	function onUnload(){
+	}
+
+}

--- a/src/test/resources/inception-modules/inceptionParent/modules/inceptionChild/ModuleConfig.bx
+++ b/src/test/resources/inception-modules/inceptionParent/modules/inceptionChild/ModuleConfig.bx
@@ -1,0 +1,44 @@
+/**
+ * Test fixture: a module nested inside `inceptionParent`, which itself carries
+ * `inceptionGrandchild` to prove inception recurses to arbitrary depth.
+ *
+ * Its `overriddenByParent` setting is deliberately overwritten by the parent module,
+ * while `ownSetting` is left alone, proving the merge is additive rather than wholesale.
+ */
+class {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	this.version		= "1.0.0";
+	this.mapping		= "inceptionChild";
+	this.author			= "Ortus Solutions";
+	this.description	= "A module nested inside another module";
+	this.enabled		= true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	function configure(){
+		settings = {
+			ownSetting			: "fromChild",
+			overriddenByParent	: "fromChild"
+		};
+
+		interceptors				= [];
+		customInterceptionPoints	= [];
+	}
+
+	function onLoad(){
+	}
+
+	function onUnload(){
+	}
+
+}

--- a/src/test/resources/inception-modules/inceptionParent/modules/inceptionChild/modules/inceptionGrandchild/ModuleConfig.bx
+++ b/src/test/resources/inception-modules/inceptionParent/modules/inceptionChild/modules/inceptionGrandchild/ModuleConfig.bx
@@ -1,0 +1,41 @@
+/**
+ * Test fixture: a module nested two levels deep, inside `inceptionChild`, which is itself
+ * nested inside `inceptionParent`. Proves module inception recurses to arbitrary depth and
+ * that the class loader chain follows the folder nesting all the way up to the runtime loader.
+ */
+class {
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Properties
+	 * --------------------------------------------------------------------------
+	 */
+
+	this.version		= "1.0.0";
+	this.mapping		= "inceptionGrandchild";
+	this.author			= "Ortus Solutions";
+	this.description	= "A module nested two levels deep";
+	this.enabled		= true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Module Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	function configure(){
+		settings = {
+			ownSetting : "fromGrandchild"
+		};
+
+		interceptors				= [];
+		customInterceptionPoints	= [];
+	}
+
+	function onLoad(){
+	}
+
+	function onUnload(){
+	}
+
+}


### PR DESCRIPTION
# Description

A module can now carry other modules inside its own `modules/` folder, and those load before the module itself.

Previously `ModuleService.buildRegistryFromPath` scanned with `Files.walk( modulesDirectory, 1 )`, so a module folder was never inspected for modules of its own. Only module *directories* were discovered, meaning a pure-Java module still had to be laid out as a folder with a `box.json` and `libs/*.jar`, even though its descriptor is found via `ServiceLoader` on the module's class loader rather than on disk.

## Conventions

Any modules folder — a top-level configured `modulesDirectory` **or** a module's own nested `modules/` folder — may now hold two kinds of module:

- **Module folders** — ordinary module directories (`ModuleConfig.bx` and/or `box.json`), discovered recursively to any depth.
- **Module jars** — a `*.jar` placed directly in a modules folder is a module in its own right. It gets its own `ModuleRecord` and its own isolated class loader built over the jar, and its `IModuleConfig` is found via `ServiceLoader` on that loader. A jar exposing no `IModuleConfig` is disabled with a warning through the existing no-valid-descriptor path, so a stray jar logs rather than breaking startup.

## Class loader hierarchy

The class loader hierarchy mirrors the module hierarchy: a nested module's loader is parented to its parent module's loader, chaining up to the runtime loader for top-level modules. A child can therefore see what its parent bundles in `libs/` while staying isolated from its siblings.

Loader creation moves into a lazy, idempotent `ModuleRecord.getOrCreateModuleClassLoader()`, because children register *before* their parent does, yet need the parent's loader to exist first. Each level builds its own on demand, so a grandchild transparently forces the whole chain.

Note that module loaders are built with `loadParentFirst=false`, so they deliberately pass `null` to `URLClassLoader`'s parent and track the real parent themselves — the chain is visible through `getDynamicParent()`, not `getParent()`.

## Parent and child relationships

- A parent exposes `nestedModules` and can target one child with `getNestedModule( Key )` / `hasNestedModule( Key )`.
- A child knows its `parentModule`.
- Children register and activate **before** their parent, and unload **after** it — closing a parent's loader while children are live would otherwise break them.
- A disabled module skips its nested modules with it, for the same reason. This also moves the nested-child registration below the enablement check, so a disabled parent no longer leaves children registered behind it.

## Settings precedence

Effective child settings are built in this order, later winning:

1. The child's own `configure()` defaults.
2. The parent's per-child overrides.
3. The global `boxlang.json` config, applied last and always winning.

Parents declare overrides with a `modules` struct mirroring the `boxlang.json` shape — `this.modules = { "childName" : { enabled : true, settings : { ... } } }` in `ModuleConfig.bx`, or the new `IModuleConfig.modules()` default method for Java descriptors. `enabled` follows the same precedence.

The ordering this creates is why `IModuleConfig` resolution is split out of `register()` into an idempotent `resolveModuleConfig()`: a parent's config must resolve before its children register so its overrides are readable, while its own full registration still runs after them.

## Also

`@BoxModule` gains an optional `name()`, for jar modules whose convention default is only the jar's base name. A jar that renames itself this way is re-keyed in the registry once its config resolves, and its parent's child list follows.

## Known limitation

`unloadAll()` ordering remains non-dependency-aware across *unrelated* modules. That is pre-existing and unchanged; nesting order is handled by this PR.

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-2632

## Type of change

- [x] New Feature
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project — `./gradlew spotlessApply` run
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — companion PR on `ortus-boxlang/boxlang-docs`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Tests

New `ModuleInceptionTest` (15 cases) covers recursive discovery to three levels, both-way parent/child links, register/activate/unload ordering, the class loader chain up to the runtime loader, loader idempotency, all three settings-precedence layers, parent-disables-child, disabled-parent-skips-children, jar modules standalone and nested, and `loadModule` picking up nesting.

Fixtures: interpreted BX module trees under `src/test/resources/inception-modules{,-disabled}`, plus a jar fixture built from the existing `javaTestModule` subproject (gitignored, produced by the build).

Existing `ModuleServiceTest`, `ModuleRecordTest` and `ModuleRecordJavaConfigTest` pass unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_018TyvjFqyc5B2mqYJN2c4sP)_