### PR TITLE
dump(): split maxRows (row limiting) from depth (recursion limiting)

### DIFF
--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -657,6 +657,21 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 			}
 		}
 
+		// CF's writeDump()/cfdump "top" attribute limits the number of rows/items shown per level. BoxLang's dump()
+		// separates that concept from recursion depth, so a CF "top" value maps onto BoxLang's "depth" argument
+		// (recursion levels), decremented by one to account for the differing 1-based semantics.
+		// writeDump( var=data, top=value ) -> writeDump( var=data, depth=value-1 )
+		if ( name.equals( "writedump" ) && node.isNamedArgs() ) {
+			node.getArguments().stream()
+			    .filter( arg -> arg.getName().getAsSimpleValue().toString().equalsIgnoreCase( "top" ) )
+			    .forEach( arg -> {
+				    if ( arg.getName() instanceof BoxStringLiteral bsl ) {
+					    bsl.setValue( "depth" );
+				    }
+				    arg.setValue( transpileDumpTopToDepth( arg.getValue() ) );
+			    } );
+		}
+
 		// look for "params" named arg, or 2nd positional arg, and if it's a struct literal, any of the values which are also a struct literal,
 		// rename any keys from cfsqltype to sqltype and remove "cf_sql_" from the values of any sqltype
 		if ( name.equals( "queryexecute" ) && node.getArguments().size() >= 2 ) {
@@ -806,6 +821,18 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 			}
 		}
 		return super.visit( node );
+	}
+
+	/**
+	 * Wraps a CF cfdump/writeDump "top" attribute/argument value expression as {@code value - 1}, for use as the
+	 * BoxLang dump "depth" argument.
+	 *
+	 * @param value The original "top" value expression
+	 *
+	 * @return A new expression representing {@code value - 1}
+	 */
+	private BoxExpression transpileDumpTopToDepth( BoxExpression value ) {
+		return new BoxBinaryOperation( value, BoxBinaryOperator.Minus, new BoxIntegerLiteral( "1", null, "1" ), null, null );
 	}
 
 	private BoxNode transpileListAppend( BoxFunctionInvocation node ) {
@@ -1537,6 +1564,19 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 				    } else if ( !bsl.getValue().equalsIgnoreCase( "readonly" ) ) {
 					    bsl.setValue( "readonly" );
 				    }
+			    } );
+		}
+
+		// cfdump's "top" attribute limits the number of rows/items shown per level. BoxLang's dump component separates
+		// that concept from recursion depth, so a CF "top" value maps onto BoxLang's "depth" attribute (recursion
+		// levels), decremented by one to account for the differing 1-based semantics.
+		// <cfdump var="data" top="#value#"> -> <bx:dump var="data" depth="#value-1#">
+		if ( componentName.equals( "dump" ) ) {
+			node.getAttributes().stream()
+			    .filter( a -> a.getKey().getValue().equalsIgnoreCase( "top" ) )
+			    .forEach( a -> {
+				    a.getKey().setValue( "depth" );
+				    a.setValue( transpileDumpTopToDepth( a.getValue() ) );
 			    } );
 		}
 

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -657,9 +657,9 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 			}
 		}
 
-		// CF's writeDump()/cfdump "top" attribute limits the number of rows/items shown per level. BoxLang's dump()
-		// separates that concept from recursion depth, so a CF "top" value maps onto BoxLang's "depth" argument
-		// (recursion levels), decremented by one to account for the differing 1-based semantics.
+		// CF's writeDump()/cfdump "top" attribute limits how many levels of recursion are shown. BoxLang's dump()
+		// separates that concept from row/item limiting (its "maxRows" argument), so a CF "top" value maps onto
+		// BoxLang's "depth" argument (recursion levels), decremented by one to account for the differing 1-based semantics.
 		// writeDump( var=data, top=value ) -> writeDump( var=data, depth=value-1 )
 		if ( name.equals( "writedump" ) && node.isNamedArgs() ) {
 			node.getArguments().stream()
@@ -1567,9 +1567,9 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 			    } );
 		}
 
-		// cfdump's "top" attribute limits the number of rows/items shown per level. BoxLang's dump component separates
-		// that concept from recursion depth, so a CF "top" value maps onto BoxLang's "depth" attribute (recursion
-		// levels), decremented by one to account for the differing 1-based semantics.
+		// cfdump's "top" attribute limits how many levels of recursion are shown. BoxLang's dump component separates
+		// that concept from row/item limiting (its "maxRows" attribute), so a CF "top" value maps onto BoxLang's
+		// "depth" attribute (recursion levels), decremented by one to account for the differing 1-based semantics.
 		// <cfdump var="data" top="#value#"> -> <bx:dump var="data" depth="#value-1#">
 		if ( componentName.equals( "dump" ) ) {
 			node.getAttributes().stream()

--- a/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
+++ b/src/main/java/ortus/boxlang/compiler/ast/visitor/CFTranspilerVisitor.java
@@ -222,6 +222,14 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 	private static Map<String, Map<String, String>>	BIFArgMap					= new HashMap<>();
 
 	/**
+	 * Names used when transpiling the CF writeDump()/cfdump "top" attribute/argument to BoxLang's "depth" argument
+	 */
+	private static final String						WRITEDUMP_FUNCTION_NAME		= "writedump";
+	private static final String						DUMP_COMPONENT_NAME			= "dump";
+	private static final String						DUMP_TOP_ATTRIBUTE_NAME		= "top";
+	private static final String						DUMP_DEPTH_ATTRIBUTE_NAME	= "depth";
+
+	/**
 	 * Configuration keys for transpiler settings
 	 */
 	private static Key								transpilerKey				= Key.of( "transpiler" );
@@ -661,12 +669,12 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		// separates that concept from row/item limiting (its "maxRows" argument), so a CF "top" value maps onto
 		// BoxLang's "depth" argument (recursion levels), decremented by one to account for the differing 1-based semantics.
 		// writeDump( var=data, top=value ) -> writeDump( var=data, depth=value-1 )
-		if ( name.equals( "writedump" ) && node.isNamedArgs() ) {
+		if ( name.equals( WRITEDUMP_FUNCTION_NAME ) && node.isNamedArgs() ) {
 			node.getArguments().stream()
-			    .filter( arg -> arg.getName().getAsSimpleValue().toString().equalsIgnoreCase( "top" ) )
+			    .filter( arg -> arg.getName().getAsSimpleValue().toString().equalsIgnoreCase( DUMP_TOP_ATTRIBUTE_NAME ) )
 			    .forEach( arg -> {
 				    if ( arg.getName() instanceof BoxStringLiteral bsl ) {
-					    bsl.setValue( "depth" );
+					    bsl.setValue( DUMP_DEPTH_ATTRIBUTE_NAME );
 				    }
 				    arg.setValue( transpileDumpTopToDepth( arg.getValue() ) );
 			    } );
@@ -1571,11 +1579,11 @@ public class CFTranspilerVisitor extends ReplacingBoxVisitor {
 		// that concept from row/item limiting (its "maxRows" attribute), so a CF "top" value maps onto BoxLang's
 		// "depth" attribute (recursion levels), decremented by one to account for the differing 1-based semantics.
 		// <cfdump var="data" top="#value#"> -> <bx:dump var="data" depth="#value-1#">
-		if ( componentName.equals( "dump" ) ) {
+		if ( componentName.equals( DUMP_COMPONENT_NAME ) ) {
 			node.getAttributes().stream()
-			    .filter( a -> a.getKey().getValue().equalsIgnoreCase( "top" ) )
+			    .filter( a -> a.getKey().getValue().equalsIgnoreCase( DUMP_TOP_ATTRIBUTE_NAME ) )
 			    .forEach( a -> {
-				    a.getKey().setValue( "depth" );
+				    a.getKey().setValue( DUMP_DEPTH_ATTRIBUTE_NAME );
 				    a.setValue( transpileDumpTopToDepth( a.getValue() ) );
 			    } );
 		}

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
@@ -63,8 +63,12 @@ public class Dump extends BIF {
 		    new Argument( false, "any", Key.var ),
 		    // A custom label to display above the dump (Only in HTML output)
 		    new Argument( false, Argument.STRING, Key.label, "" ),
-		    // The number of levels to display when dumping collections. Great to avoid dumping the entire world!
-		    new Argument( false, Argument.NUMERIC, Key.top ),
+		    // The recursion depth to display when dumping nested collections. Great to avoid dumping the entire world!
+		    // 1-based: -1 (default) is unlimited, 0 shows nothing, 1 shows the top level with no recursion, 2 recurses once, etc.
+		    new Argument( false, Argument.NUMERIC, Key.depth, Set.of( Validator.min( -1 ) ) ),
+		    // The maximum number of keys/rows/items to display per level of a collection.
+		    // 1-based: -1 (default) is unlimited, 0 shows nothing, 1 shows a single row, etc.
+		    new Argument( false, Argument.NUMERIC, Key.maxRows, Set.of( Validator.min( -1 ) ) ),
 		    // Whether to expand the dump. By default, the dump is expanded on the first level only
 		    new Argument( false, Argument.BOOLEAN, Key.expand, true ),
 		    // Whether to do a hard abort the request after dumping
@@ -99,7 +103,11 @@ public class Dump extends BIF {
 	 *
 	 * @argument.label A custom label to display above the dump (Only in HTML output)
 	 *
-	 * @argument.top The number of levels to display when dumping collections. Great to avoid dumping the entire world! Default is inifinity. (Only in HTML output)
+	 * @argument.depth The recursion depth to display when dumping nested collections. 1-based: -1 (default) is unlimited, 0 shows nothing,
+	 *                 1 shows the top level with no recursion, 2 recurses once, etc. (Only in HTML output)
+	 *
+	 * @argument.maxRows The maximum number of keys/rows/items to display per level of a collection, array, or query. 1-based: -1 (default)
+	 *                   is unlimited, 0 shows nothing, 1 shows a single row, etc. (Only in HTML output)
 	 *
 	 * @argument.expand Whether to expand the dump. Be default, we try to expand as much as possible. (Only in HTML output)
 	 *
@@ -118,14 +126,16 @@ public class Dump extends BIF {
 			arguments.put( Key.abort, true );
 		}
 
-		Object top = arguments.get( Key.top );
+		Object	depth	= arguments.get( Key.depth );
+		Object	maxRows	= arguments.get( Key.maxRows );
 
 		// Dump the object
 		DumpUtil.dump(
 		    context,
 		    DynamicObject.unWrap( arguments.get( Key.var ) ),
 		    arguments.getAsString( Key.label ),
-		    top == null ? null : IntegerCaster.cast( top ),
+		    depth == null ? null : IntegerCaster.cast( depth ),
+		    maxRows == null ? null : IntegerCaster.cast( maxRows ),
 		    arguments.getAsBoolean( Key.expand ),
 		    BooleanCaster.cast( arguments.get( Key.abort ) ),
 		    arguments.getAsString( Key.output ),

--- a/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/bifs/global/system/Dump.java
@@ -69,6 +69,8 @@ public class Dump extends BIF {
 		    // The maximum number of keys/rows/items to display per level of a collection.
 		    // 1-based: -1 (default) is unlimited, 0 shows nothing, 1 shows a single row, etc.
 		    new Argument( false, Argument.NUMERIC, Key.maxRows, Set.of( Validator.min( -1 ) ) ),
+		    // Deprecated: use maxRows instead. Kept for backwards compatibility with existing BoxLang code.
+		    new Argument( false, Argument.NUMERIC, Key.top, Set.of( Validator.min( -1 ) ) ),
 		    // Whether to expand the dump. By default, the dump is expanded on the first level only
 		    new Argument( false, Argument.BOOLEAN, Key.expand, true ),
 		    // Whether to do a hard abort the request after dumping
@@ -109,6 +111,9 @@ public class Dump extends BIF {
 	 * @argument.maxRows The maximum number of keys/rows/items to display per level of a collection, array, or query. 1-based: -1 (default)
 	 *                   is unlimited, 0 shows nothing, 1 shows a single row, etc. (Only in HTML output)
 	 *
+	 * @argument.top Deprecated: use maxRows instead. When maxRows is not also passed, top's value is used as maxRows.
+	 *               Kept for backwards compatibility with existing BoxLang code. (Only in HTML output)
+	 *
 	 * @argument.expand Whether to expand the dump. Be default, we try to expand as much as possible. (Only in HTML output)
 	 *
 	 * @argument.abort Whether to do a hard abort the request after dumping. Default is false
@@ -127,7 +132,7 @@ public class Dump extends BIF {
 		}
 
 		Object	depth	= arguments.get( Key.depth );
-		Object	maxRows	= arguments.get( Key.maxRows );
+		Object	maxRows	= DumpUtil.resolveDeprecatedTop( arguments.get( Key.maxRows ), arguments.get( Key.top ) );
 
 		// Dump the object
 		DumpUtil.dump(

--- a/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
@@ -45,7 +45,8 @@ public class Dump extends Component {
 		declaredAttributes = new Attribute[] {
 		    new Attribute( Key.var, "any" ),
 		    new Attribute( Key.label, "string", "" ),
-		    new Attribute( Key.top, "numeric" ),
+		    new Attribute( Key.depth, "numeric", Set.of( Validator.min( -1 ) ) ),
+		    new Attribute( Key.maxRows, "numeric", Set.of( Validator.min( -1 ) ) ),
 		    new Attribute( Key.expand, "boolean" ),
 		    new Attribute( Key.abort, "any", false ),
 		    new Attribute( Key.output, "string", Set.of( Validator.NON_EMPTY ) ),
@@ -69,7 +70,11 @@ public class Dump extends Component {
 	 *
 	 * @attributes.label A custom label to display above the dump (Only in HTML output)
 	 *
-	 * @attributes.top The number of levels to display when dumping collections. Great to avoid dumping the entire world! Default is inifinity. (Only in HTML output)
+	 * @attributes.depth The recursion depth to display when dumping nested collections. 1-based: -1 (default) is unlimited, 0 shows nothing,
+	 *                   1 shows the top level with no recursion, 2 recurses once, etc. (Only in HTML output)
+	 *
+	 * @attributes.maxRows The maximum number of keys/rows/items to display per level of a collection, array, or query. 1-based: -1 (default)
+	 *                     is unlimited, 0 shows nothing, 1 shows a single row, etc. (Only in HTML output)
 	 *
 	 * @attributes.expand Whether to expand the dump. Be default, we try to expand as much as possible. (Only in HTML output)
 	 *
@@ -94,13 +99,15 @@ public class Dump extends Component {
 			attributes.put( Key.abort, true );
 		}
 
-		Object top = attributes.get( Key.top );
+		Object	depth	= attributes.get( Key.depth );
+		Object	maxRows	= attributes.get( Key.maxRows );
 
 		DumpUtil.dump(
 		    context,
 		    DynamicObject.unWrap( attributes.get( Key.var ) ),
 		    attributes.getAsString( Key.label ),
-		    top == null ? null : IntegerCaster.cast( top ),
+		    depth == null ? null : IntegerCaster.cast( depth ),
+		    maxRows == null ? null : IntegerCaster.cast( maxRows ),
 		    attributes.getAsBoolean( Key.expand ),
 		    BooleanCaster.cast( attributes.get( Key.abort ) ),
 		    attributes.getAsString( Key.output ),

--- a/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
+++ b/src/main/java/ortus/boxlang/runtime/components/system/Dump.java
@@ -47,6 +47,8 @@ public class Dump extends Component {
 		    new Attribute( Key.label, "string", "" ),
 		    new Attribute( Key.depth, "numeric", Set.of( Validator.min( -1 ) ) ),
 		    new Attribute( Key.maxRows, "numeric", Set.of( Validator.min( -1 ) ) ),
+		    // Deprecated: use maxRows instead. Kept for backwards compatibility with existing BoxLang code.
+		    new Attribute( Key.top, "numeric", Set.of( Validator.min( -1 ) ) ),
 		    new Attribute( Key.expand, "boolean" ),
 		    new Attribute( Key.abort, "any", false ),
 		    new Attribute( Key.output, "string", Set.of( Validator.NON_EMPTY ) ),
@@ -76,6 +78,9 @@ public class Dump extends Component {
 	 * @attributes.maxRows The maximum number of keys/rows/items to display per level of a collection, array, or query. 1-based: -1 (default)
 	 *                     is unlimited, 0 shows nothing, 1 shows a single row, etc. (Only in HTML output)
 	 *
+	 * @attributes.top Deprecated: use maxRows instead. When maxRows is not also passed, top's value is used as maxRows.
+	 *                 Kept for backwards compatibility with existing BoxLang code. (Only in HTML output)
+	 *
 	 * @attributes.expand Whether to expand the dump. Be default, we try to expand as much as possible. (Only in HTML output)
 	 *
 	 * @attributes.abort Whether to do a hard abort the request after dumping. Default is false
@@ -100,7 +105,7 @@ public class Dump extends Component {
 		}
 
 		Object	depth	= attributes.get( Key.depth );
-		Object	maxRows	= attributes.get( Key.maxRows );
+		Object	maxRows	= DumpUtil.resolveDeprecatedTop( attributes.get( Key.maxRows ), attributes.get( Key.top ) );
 
 		DumpUtil.dump(
 		    context,

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -99,16 +99,24 @@ public class DumpUtil {
 	private static final String									DEFAULT_DUMP_TEMPLATE	= "Class.bxm";
 
 	/**
+	 * Dump the given target object to the configured output location, in either HTML or plain-text
+	 * format. This is the main entry point used by the {@code dump()}/{@code writeDump()} BIF and the
+	 * {@code <bx:dump>} component.
 	 *
-	 * @param target
-	 * @param label
-	 * @param depth
-	 * @param maxRows
-	 * @param expand
-	 * @param abort
-	 * @param output
-	 * @param format
-	 * @param showUDFs
+	 * @param context  The context in which the dump is being executed
+	 * @param target   The object to dump; can be any BoxLang or Java type, including {@code null}
+	 * @param label    An optional custom label to display above the dump (HTML output only)
+	 * @param depth    The recursion depth to display when dumping nested collections. 1-based:
+	 *                 {@code null} or {@code -1} is unlimited, {@code 0} shows nothing, {@code 1}
+	 *                 shows the top level with no recursion, {@code 2} recurses once, etc. Only
+	 *                 container/complex values are gated by this; scalar values always render fully
+	 * @param maxRows  The maximum number of keys/rows/items to display per level of a collection.
+	 *                 Same 1-based/{@code -1}/{@code 0} semantics as {@code depth}, but independent of it
+	 * @param expand   Whether to expand the dump by default (HTML output only)
+	 * @param abort    Whether to hard-abort the request after dumping
+	 * @param output   The output location: {@code "buffer"}, {@code "console"}, or an absolute file path
+	 * @param format   The output format: {@code "html"} or {@code "text"}; defaults based on the output location
+	 * @param showUDFs Whether to show UDFs/methods when dumping classes (HTML output only)
 	 */
 	public static void dump(
 	    IBoxContext context,

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.runtime.bifs.global.decision.IsSimpleValue;
 import ortus.boxlang.runtime.components.jdbc.Query;
 import ortus.boxlang.runtime.context.ContainerBoxContext;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -393,8 +394,11 @@ public class DumpUtil {
 			return null;
 		}
 
-		// Reached the depth limit, so return to prevent dumping the entire world
-		if ( depth != null && depth <= 0 ) {
+		// Reached the depth limit, so return to prevent dumping the entire world.
+		// Simple/scalar values (strings, numbers, booleans, dates, etc.) never recurse further, so
+		// there's nothing for "depth" to limit about them - only gate actual container/complex values.
+		boolean isContainerValue = target != null && ! ( target instanceof NullValue ) && !IsSimpleValue.isSimpleValue( target );
+		if ( isContainerValue && depth != null && depth <= 0 ) {
 			context.writeToBuffer( "<div><em>Depth Limit reached (Skipping dump)</em></div>", true );
 			// We added thisHashCode above but are bailing out before the try/finally that would
 			// normally clean it up, so do it here to avoid leaking thread-local state across calls.

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -49,6 +49,7 @@ import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.ArrayCaster;
 import ortus.boxlang.runtime.dynamic.casters.DateTimeCaster;
 import ortus.boxlang.runtime.events.BoxEvent;
+import ortus.boxlang.runtime.logging.LoggingService;
 import ortus.boxlang.runtime.runnables.IClassRunnable;
 import ortus.boxlang.runtime.runnables.ITemplateRunnable;
 import ortus.boxlang.runtime.scopes.IScope;
@@ -291,6 +292,30 @@ public class DumpUtil {
 	 */
 	private static Integer normalizeLimit( @Nullable Integer value ) {
 		return ( value == null || value <= -1 ) ? null : value;
+	}
+
+	/**
+	 * Resolves the {@code maxRows} argument for the {@code dump()}/{@code writeDump()}/{@code <bx:dump>}
+	 * calls, folding in the deprecated {@code top} argument when {@code maxRows} wasn't explicitly
+	 * provided. {@code top} used to control both row limiting and recursion depth at once; now that
+	 * those are split into {@code maxRows} and {@code depth}, {@code top} is kept working - mapped onto
+	 * {@code maxRows} - purely for backwards compatibility with existing BoxLang code, and logs a
+	 * deprecation warning when used.
+	 *
+	 * @param maxRows The {@code maxRows} argument value, or {@code null} if not provided
+	 * @param top     The deprecated {@code top} argument value, or {@code null} if not provided
+	 *
+	 * @return The value to use for {@code maxRows}, or {@code null} if neither was provided
+	 */
+	public static Object resolveDeprecatedTop( @Nullable Object maxRows, @Nullable Object top ) {
+		if ( top != null ) {
+			LoggingService.getInstance().RUNTIME_LOGGER.warn(
+			    "The [top] argument to dump()/writeDump()/<bx:dump> is deprecated and will be removed in a future release. Use [maxRows] instead." );
+			if ( maxRows == null ) {
+				return top;
+			}
+		}
+		return maxRows;
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/util/DumpUtil.java
@@ -100,7 +100,8 @@ public class DumpUtil {
 	 *
 	 * @param target
 	 * @param label
-	 * @param top
+	 * @param depth
+	 * @param maxRows
 	 * @param expand
 	 * @param abort
 	 * @param output
@@ -111,14 +112,19 @@ public class DumpUtil {
 	    IBoxContext context,
 	    Object target,
 	    String label,
-	    @Nullable Integer top,
+	    @Nullable Integer depth,
+	    @Nullable Integer maxRows,
 	    Boolean expand,
 	    Boolean abort,
 	    String output,
 	    String format,
 	    Boolean showUDFs ) {
 
-		boolean isScriptContext = context.getRequestContext() instanceof ScriptingRequestBoxContext;
+		// Normalize the -1 sentinel (and any other negative value) to "unlimited"
+		final Integer	depthFinal		= normalizeLimit( depth );
+		final Integer	maxRowsFinal	= normalizeLimit( maxRows );
+
+		boolean			isScriptContext	= context.getRequestContext() instanceof ScriptingRequestBoxContext;
 
 		// Default output param
 		if ( output == null ) {
@@ -182,7 +188,8 @@ public class DumpUtil {
 		            Key.context, context,
 		            Key.target, target,
 		            Key.label, label,
-		            Key.top, top,
+		            Key.depth, depthFinal,
+		            Key.maxRows, maxRowsFinal,
 		            Key.expand, expand,
 		            Key.abort, abort,
 		            Key.output, outputFinal,
@@ -192,7 +199,7 @@ public class DumpUtil {
 
 		String dumpOutput;
 		if ( format.equals( "html" ) ) {
-			dumpOutput = generateDumpHTML( context, target, label, top, expand, abort, output, format, showUDFs );
+			dumpOutput = generateDumpHTML( context, target, label, depthFinal, maxRowsFinal, expand, abort, output, format, showUDFs );
 		} else {
 			dumpOutput = generateDumpText( context, target, label );
 		}
@@ -255,7 +262,8 @@ public class DumpUtil {
 					            Key.context, context,
 					            Key.target, target,
 					            Key.label, label,
-					            Key.top, top,
+					            Key.depth, depthFinal,
+					            Key.maxRows, maxRowsFinal,
 					            Key.expand, expand,
 					            Key.abort, abort,
 					            Key.output, outputFinal,
@@ -267,6 +275,21 @@ public class DumpUtil {
 			}
 
 		}
+	}
+
+	/**
+	 * Normalizes a "depth" or "maxRows" limit value.
+	 * <p>
+	 * {@code null} and {@code -1} (and anything more negative) mean "unlimited", which we
+	 * represent internally as {@code null} so the rest of the dump logic only has one case
+	 * to worry about.
+	 *
+	 * @param value The limit value passed by the caller
+	 *
+	 * @return The normalized limit, or {@code null} if unlimited
+	 */
+	private static Integer normalizeLimit( @Nullable Integer value ) {
+		return ( value == null || value <= -1 ) ? null : value;
 	}
 
 	/**
@@ -338,7 +361,8 @@ public class DumpUtil {
 	 * @param context  The context
 	 * @param target   The target object
 	 * @param label    The label for the object
-	 * @param top      The number of levels to dump
+	 * @param depth    The recursion depth to dump
+	 * @param maxRows  The maximum number of rows/items to dump per level
 	 * @param expand   Whether to expand the object
 	 * @param abort    Whether to abort on error
 	 * @param output   The output location
@@ -349,7 +373,8 @@ public class DumpUtil {
 	    IBoxContext context,
 	    Object target,
 	    String label,
-	    @Nullable Integer top,
+	    @Nullable Integer depth,
+	    @Nullable Integer maxRows,
 	    Boolean expand,
 	    Boolean abort,
 	    String output,
@@ -364,12 +389,19 @@ public class DumpUtil {
 		// prevent recursion
 		if ( !dumped.add( thisHashCode ) ) {
 			context.writeToBuffer( "<div><em>Recursive Reference (Skipping dump)</em></div>", true );
+			// Not our entry to clean up: dumped.add() failed, so we never added thisHashCode.
 			return null;
 		}
 
-		// Reached the top limit, so return to prevent dumping the entire world
-		if ( top != null && top <= 0 ) {
-			context.writeToBuffer( "<div><em>Top Limit reached (Skipping dump)</em></div>", true );
+		// Reached the depth limit, so return to prevent dumping the entire world
+		if ( depth != null && depth <= 0 ) {
+			context.writeToBuffer( "<div><em>Depth Limit reached (Skipping dump)</em></div>", true );
+			// We added thisHashCode above but are bailing out before the try/finally that would
+			// normally clean it up, so do it here to avoid leaking thread-local state across calls.
+			dumped.remove( thisHashCode );
+			if ( outerDump ) {
+				dumpedObjects.remove();
+			}
 			return null;
 		}
 
@@ -407,7 +439,8 @@ public class DumpUtil {
 			        Key.posInCode, posInCode,
 			        Key.var, target,
 			        Key.label, label,
-			        Key.top, top,
+			        Key.depth, depth,
+			        Key.maxRows, maxRows,
 			        Key.expand, expand,
 			        Key.abort, abort,
 			        Key.showUDFs, showUDFs,

--- a/src/main/resources/dump/html/Array.bxm
+++ b/src/main/resources/dump/html/Array.bxm
@@ -14,7 +14,7 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						Array:
-						<bx:if !isNull( top ) && top lt var.len()>#top#/</bx:if>#var.len()#
+						<bx:if !isNull( maxRows ) && maxRows lt var.len()>#maxRows#/</bx:if>#var.len()#
 					</strong>
 				</caption>
 			<bx:else>
@@ -28,11 +28,9 @@
 			<tbody
 				<bx:if !expandRoot>class="d-none"</bx:if>
 			>
-				<bx:loop array="#var#" index="i" item="value">
-						<!--- Top limit only if > 0 --->
-						<bx:if  !isNull( top ) and i GT top >
-							<bx:break>
-						</bx:if>
+				<bx:set maxItems = isNull( maxRows ) ? var.len() : min( maxRows, var.len() )>
+				<bx:loop from="1" to="#maxItems#" index="i">
+						<bx:set value = var[i]>
 						<tr>
 							<th
 								aria-expanded="true"
@@ -47,8 +45,11 @@
 								<div class="bx-onoff">
 									<bx:set dump(
 										var : value ?: null,
-										top : isNull( top ) ? null : top - 1,
-										expand : expand ?: null
+										depth : isNull( depth ) ? null : depth - 1,
+										maxRows : maxRows,
+										expand : expand ?: null,
+										output : "buffer",
+										format : format
 									)>
 								</div>
 							</td>

--- a/src/main/resources/dump/html/BoxClass.bxm
+++ b/src/main/resources/dump/html/BoxClass.bxm
@@ -132,7 +132,7 @@
 												<strong>#encodeForHTML( thisAnnotation )#</strong>
 											</td>
 											<td>
-												#writeDump( var : annotations[ thisAnnotation ], output : "buffer", format : format )#
+												#writeDump( var : annotations[ thisAnnotation ], depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, output : "buffer", format : format )#
 											</td>
 										</tr>
 									</bx:loop>
@@ -164,7 +164,9 @@
 										<th>Name</th>
 										<th>Value</th>
 									</tr>
-									<bx:loop array="#sortedProperties#" index="prop">
+									<bx:set maxItems = isNull( maxRows ) ? sortedProperties.len() : min( maxRows, sortedProperties.len() )>
+									<bx:loop from="1" to="#maxItems#" index="idx">
+										<bx:set prop = sortedProperties[idx]>
 										<tr>
 											<td
 												valign="top"
@@ -176,12 +178,13 @@
 												<strong>#encodeForHTML( prop.name )#</strong>
 											</td>
 											<td>
-												#writeDump(
-													var : variablesScope[ prop.name ] ?: null,
-													top : isNull( top ) ? null : top - 1,
-													expand : variables?.expand,
-													showUDFs : variables?.showUDFs
-												)#
+											#writeDump(
+												var : variablesScope[ prop.name ] ?: null,
+												depth : isNull( depth ) ? null : depth - 1,
+												maxRows : maxRows,
+												expand : variables?.expand,
+												showUDFs : variables?.showUDFs
+											)#
 											</td>
 										</tr>
 									</bx:loop>
@@ -208,39 +211,45 @@
 							<bx:if thisScope.valueArray().filter( ( v ) => !isNull( v ) && !(v instanceOf "ortus.boxlang.runtime.types.Function") ).len() == 0 >
 								<p><em>None</em></p>
 							<bx:else>
-								<table class="bx-table-default">
+							<table class="bx-table-default">
+								<tr>
+									<th>Name</th>
+									<th>Value</th>
+								</tr>
+								<bx:set shown = 0>
+								<bx:loop collection="#thisScope#" item="dataProperty">
+									<bx:script>
+										thisData = thisScope[ dataProperty ] ?: null;
+										if( !isNull( thisData ) && (thisData instanceOf "ortus.boxlang.runtime.types.Function") ){
+											continue;
+										}
+										if( !isNull( maxRows ) && shown >= maxRows ){
+											break;
+										}
+										shown++;
+									</bx:script>
 									<tr>
-										<th>Name</th>
-										<th>Value</th>
+										<td
+											valign="top"
+											onclick="
+												this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none';
+												this.style.fontStyle = this.nextElementSibling.style.display === 'none' ? 'italic' : 'normal'
+											"
+											>
+											<strong>#encodeForHTML( dataProperty )#</strong>
+										</td>
+										<td>
+										#writeDump(
+											var : thisData ?: null,
+											depth : isNull( depth ) ? null : depth - 1,
+											maxRows : maxRows,
+											expand : variables?.expand,
+											showUDFs : variables?.showUDFs
+										)#
+										</td>
 									</tr>
-									<bx:loop collection="#thisScope#" item="dataProperty">
-										<bx:script>
-											thisData = thisScope[ dataProperty ] ?: null;
-											if( !isNull( thisData ) && (thisData instanceOf "ortus.boxlang.runtime.types.Function") ){
-												continue;
-											}
-										</bx:script>
-										<tr>
-											<td
-												valign="top"
-												onclick="
-													this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none';
-													this.style.fontStyle = this.nextElementSibling.style.display === 'none' ? 'italic' : 'normal'
-												"
-												>
-												<strong>#encodeForHTML( dataProperty )#</strong>
-											</td>
-											<td>
-												#writeDump(
-													var : thisData ?: null,
-													top : isNull( top ) ? null : top - 1,
-													expand : variables?.expand,
-													showUDFs : variables?.showUDFs
-												)#
-											</td>
-										</tr>
-									</bx:loop>
-								</table>
+								</bx:loop>
+							</table>
 							</bx:if>
 						</div>
 					</td>
@@ -248,29 +257,34 @@
 
 				<!--- Static METHODS  --->
 				<bx:if staticScope && showUDFs>
-				<tr>
-					<th
-						aria-expanded="true"
-						data-bx-toggle="onoff"
-						scope="row"
-						valign="top"
-						tabindex="0"
-					>
-						Static Methods
-					</th>
-					<td>
-						<div class="bx-onoff">
+					<tr>
+						<th
+							aria-expanded="true"
+							data-bx-toggle="onoff"
+							scope="row"
+							valign="top"
+							tabindex="0"
+						>
+							Static Methods
+						</th>
+						<td>
+							<div class="bx-onoff">
 							<table class="bx-table-default">
 								<tr>
 									<th>Name</th>
 									<th>Signature</th>
 								</tr>
+								<bx:set shown = 0>
 								<bx:loop collection="#staticScope#" item="methodName">
 									<bx:script>
 										thisMethod = staticScope[ methodName ] ?: null;
 										if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
 											continue;
 										}
+										if( !isNull( maxRows ) && shown >= maxRows ){
+											break;
+										}
+										shown++;
 									</bx:script>
 									<tr>
 										<td
@@ -283,20 +297,21 @@
 											<strong>#encodeForHTML( methodName )#</strong>
 										</td>
 										<td>
-											#writeDump( 
-												var : thisMethod ?: null,
-												top : isNull( top ) ? null : top - 1,
-												expand : variables?.expand,
-												output : "buffer",
-												format : format
-											)#
+										#writeDump(
+											var : thisMethod ?: null,
+											depth : isNull( depth ) ? null : depth - 1,
+											maxRows : maxRows,
+											expand : variables?.expand,
+											output : "buffer",
+											format : format
+										)#
 										</td>
 									</tr>
 								</bx:loop>
 							</table>
-						</div>
-					</td>
-				</tr>
+							</div>
+						</td>
+					</tr>
 				</bx:if>
 
 				<!--- PUBLIC METHODS  --->
@@ -316,46 +331,52 @@
 								<bx:if thisScope.valueArray().filter( ( v ) => !isNull( v ) && v instanceOf "ortus.boxlang.runtime.types.Function" ).len() == 0 >
 									<p><em>None</em></p>
 								<bx:else>
-									<table class="bx-table-default">
+								<table class="bx-table-default">
+									<tr>
+										<th>Name</th>
+										<th>Signature</th>
+									</tr>
+									<bx:set shown = 0>
+									<bx:loop collection="#thisScope#" item="methodName">
+										<bx:script>
+											thisMethod = thisScope[ methodName ] ?: null;
+											if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
+												continue;
+											}
+											if( !isNull( maxRows ) && shown >= maxRows ){
+												break;
+											}
+											shown++;
+										</bx:script>
 										<tr>
-											<th>Name</th>
-											<th>Signature</th>
-										</tr>
-										<bx:loop collection="#thisScope#" item="methodName">
-											<bx:script>
-												thisMethod = thisScope[ methodName ] ?: null;
-												if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
-													continue;
-												}
-											</bx:script>
-											<tr>
-												<td
-													valign="top"
-													onclick="
-														this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none';
-														this.style.fontStyle = this.nextElementSibling.style.display === 'none' ? 'italic' : 'normal'
-													"
-													>
-													<strong>#encodeForHTML( methodName )#</strong>
-												</td>
-												<td>
-													#writeDump(
-														var : thisMethod ?: null,
-														top : isNull( top ) ? null : top - 1,
-														expand : variables?.expand
-													)#
-												</td>
-											</tr>
-										</bx:loop>
-									</table>
-								</bx:if>
-							</div>
-						</td>
-					</tr>
-				</bx:if>
+											<td
+												valign="top"
+												onclick="
+													this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none';
+													this.style.fontStyle = this.nextElementSibling.style.display === 'none' ? 'italic' : 'normal'
+												"
+										>
+											<strong>#encodeForHTML( methodName )#</strong>
+										</td>
+										<td>
+											#writeDump(
+												var : thisMethod ?: null,
+												depth : isNull( depth ) ? null : depth - 1,
+												maxRows : maxRows,
+												expand : variables?.expand
+											)#
+										</td>
+									</tr>
+								</bx:loop>
+							</table>
+							</bx:if>
+						</div>
+					</td>
+				</tr>
+			</bx:if>
 
-				<!--- PRIVATE METHODS  --->
-				<bx:if showUDFs>
+			<!--- PRIVATE METHODS  --->
+			<bx:if showUDFs>
 					<tr>
 						<th
 							aria-expanded="true"
@@ -371,44 +392,50 @@
 								<bx:if variablesScope.valueArray().filter( ( v ) => !isNull( v ) && v instanceOf "ortus.boxlang.runtime.types.Function" ).len() == 0 >
 									<p><em>None</em></p>
 								<bx:else>
-									<table class="bx-table-default">
+								<table class="bx-table-default">
+									<tr>
+										<th>Name</th>
+										<th>Signature</th>
+									</tr>
+									<bx:set shown = 0>
+									<bx:loop collection="#variablesScope#" item="methodName">
+										<bx:script>
+											thisMethod = variablesScope[ methodName ] ?: null;
+											if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
+												continue;
+											}
+											if( thisMethod.getAccess().toString() == "public" ){
+												continue;
+											}
+											if( !isNull( maxRows ) && shown >= maxRows ){
+												break;
+											}
+											shown++;
+										</bx:script>
 										<tr>
-											<th>Name</th>
-											<th>Signature</th>
-										</tr>
-										<bx:loop collection="#variablesScope#" item="methodName">
-											<bx:script>
-												thisMethod = variablesScope[ methodName ] ?: null;
-												if( isNull( thisMethod ) || !(thisMethod instanceOf "ortus.boxlang.runtime.types.Function") ){
-													continue;
-												}
-												if( thisMethod.getAccess().toString() == "public" ){
-													continue;
-												}
-											</bx:script>
-											<tr>
-												<td
-													valign="top"
-													onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
-													>
-													<strong>#encodeForHTML( methodName )#</strong>
-												</td>
-												<td>
-													#writeDump(
-														var : thisMethod ?: null,
-														top : isNull( top ) ? null : top - 1,
-														expand : variables?.expand
-													)#
-												</td>
-											</tr>
-										</bx:loop>
-									</table>
-								</bx:if>
-							</div>
-						</td>
-					</tr>
-				</bx:if>
-			</tbody>
-		</table>
-	</div>
+											<td
+												valign="top"
+												onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'"
+										>
+											<strong>#encodeForHTML( methodName )#</strong>
+										</td>
+										<td>
+											#writeDump(
+												var : thisMethod ?: null,
+												depth : isNull( depth ) ? null : depth - 1,
+												maxRows : maxRows,
+												expand : variables?.expand
+											)#
+										</td>
+									</tr>
+								</bx:loop>
+							</table>
+							</bx:if>
+						</div>
+					</td>
+				</tr>
+			</bx:if>
+		</tbody>
+	</table>
+</div>
 </bx:output>

--- a/src/main/resources/dump/html/BoxSet.bxm
+++ b/src/main/resources/dump/html/BoxSet.bxm
@@ -16,7 +16,7 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						Set (#setType#):
-						<bx:if !isNull( top ) && top lt var.size()>#top#/</bx:if>#var.size()#
+						<bx:if !isNull( maxRows ) && maxRows lt var.size()>#maxRows#/</bx:if>#var.size()#
 					</strong>
 					<bx:if isBoxSet>
 					<span class="bx-meta">
@@ -40,13 +40,10 @@
 			<tbody
 				<bx:if !expandRoot>class="d-none"</bx:if>
 			>
-				<bx:set i = 0>
-				<bx:loop array="#var.toArray()#" item="value">
-						<bx:set i++>
-						<!--- Top limit only if > 0 --->
-						<bx:if !isNull( top ) and i GT top >
-							<bx:break>
-						</bx:if>
+				<bx:set setItems = var.toArray()>
+				<bx:set maxItems = isNull( maxRows ) ? setItems.len() : min( maxRows, setItems.len() )>
+				<bx:loop from="1" to="#maxItems#" index="i">
+						<bx:set value = setItems[i]>
 						<tr>
 							<th
 								aria-expanded="true"
@@ -61,8 +58,11 @@
 								<div class="bx-onoff">
 									<bx:set dump(
 										var : value ?: null,
-										top : isNull( top ) ? null : top - 1,
-										expand : expand ?: null
+										depth : isNull( depth ) ? null : depth - 1,
+										maxRows : maxRows,
+										expand : expand ?: null,
+										output : "buffer",
+										format : format
 									)>
 								</div>
 							</td>

--- a/src/main/resources/dump/html/Function.bxm
+++ b/src/main/resources/dump/html/Function.bxm
@@ -82,7 +82,7 @@
 													#encodeForHTML( thisArg.name() )#
 												</td>
 												<td>
-													#writedump( var: thisArg.defaultValue(), top: isNull( top ) ? null : top - 1, expand: expand ?: null, output : "buffer", format : format )#
+													#writedump( var: thisArg.defaultValue(), depth: isNull( depth ) ? null : depth - 1, maxRows: maxRows, expand: expand ?: null, output : "buffer", format : format )#
 												</td>
 												<td>
 													#encodeForHTML( argHint )#
@@ -127,7 +127,7 @@
 												<strong>#encodeForHTML( thisAnnotation )#</strong>
 											</td>
 											<td>
-												#writeDump( var : annotations[ thisAnnotation ], output : "buffer", format : format )#
+												#writeDump( var : annotations[ thisAnnotation ], depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, output : "buffer", format : format )#
 											</td>
 										</tr>
 									</bx:loop>

--- a/src/main/resources/dump/html/List.bxm
+++ b/src/main/resources/dump/html/List.bxm
@@ -14,7 +14,7 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						#var.getClass().getName()#
-						<bx:if !isNull( top ) && top lt var.size()>#top#/</bx:if>#var.size()#
+						<bx:if !isNull( maxRows ) && maxRows lt var.size()>#maxRows#/</bx:if>#var.size()#
 					</strong>
 				</caption>
 			<bx:else>
@@ -28,11 +28,9 @@
 			<tbody
 				<bx:if !expandRoot>class="d-none"</bx:if>
 			>
-					<bx:loop array="#var#" index="i" item="value">
-						<!--- Top limit only if > 0 --->
-						<bx:if !isNull( top ) and i GT top >
-							<bx:break>
-						</bx:if>
+					<bx:set maxItems = isNull( maxRows ) ? var.size() : min( maxRows, var.size() )>
+					<bx:loop from="1" to="#maxItems#" index="i">
+							<bx:set value = var[i-1]>
 							<tr>
 								<th
 									aria-expanded="true"
@@ -45,7 +43,7 @@
 								</th>
 								<td>
 									<div class="bx-onoff">
-										<bx:set dump( var : value, top : isNull( top ) ? null : top - 1, expand : expand ?: null, output : "buffer", format : format )>
+										<bx:set dump( var : value, depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, expand : expand ?: null, output : "buffer", format : format )>
 									</div>
 								</td>
 							</tr>

--- a/src/main/resources/dump/html/List.bxm
+++ b/src/main/resources/dump/html/List.bxm
@@ -30,7 +30,7 @@
 			>
 					<bx:set maxItems = isNull( maxRows ) ? var.size() : min( maxRows, var.size() )>
 					<bx:loop from="1" to="#maxItems#" index="i">
-							<bx:set value = var[i-1]>
+							<bx:set value = var[i]>
 							<tr>
 								<th
 									aria-expanded="true"

--- a/src/main/resources/dump/html/Map.bxm
+++ b/src/main/resources/dump/html/Map.bxm
@@ -14,7 +14,7 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						#var.getClass().getName()#:
-						<bx:if !isNull( top ) && top lt var.size()>#top#/</bx:if>#var.size()# item(s)
+						<bx:if !isNull( maxRows ) && maxRows lt var.size()>#maxRows#/</bx:if>#var.size()# item(s)
 					</strong>
 				</caption>
 			<bx:else>
@@ -22,18 +22,17 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						#var.getClass().getName()#:
-						<bx:if !isNull( top ) && top lt var.size()>#top#/</bx:if>#var.size()# item(s)
+						<bx:if !isNull( maxRows ) && maxRows lt var.size()>#maxRows#/</bx:if>#var.size()# item(s)
 					</strong>
 				</caption>
 			</bx:if>
 			<tbody
 				<bx:if !expandRoot>class="d-none"</bx:if>
 			>
-				<bx:set index = 1>
-				<bx:loop collection="#var#" item="key">
-					<bx:if  !isNull( top ) and index++ GT top >
-						<bx:break>
-					</bx:if>
+				<bx:set keys = var.keySet().toArray()>
+				<bx:set maxItems = isNull( maxRows ) ? keys.len() : min( maxRows, keys.len() )>
+				<bx:loop from="1" to="#maxItems#" index="idx">
+					<bx:set key = keys[idx]>
 						<bx:if NOT isCustomFunction( var[ key ] ) >
 							<tr>
 								<th
@@ -47,7 +46,7 @@
 								</th>
 								<td>
 									<div class="bx-onoff">
-										<bx:set dump( var : var[ key ], top : isNull( top ) ? null : top - 1, expand : expand ?: null, output : "buffer", format : format ) >
+										<bx:set dump( var : var[ key ], depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, expand : expand ?: null, output : "buffer", format : format ) >
 									</div>
 								</td>
 							</tr>

--- a/src/main/resources/dump/html/Query.bxm
+++ b/src/main/resources/dump/html/Query.bxm
@@ -13,7 +13,7 @@
 					<strong>
 						<bx:if label.len() >#label# - </bx:if>
 						Query:
-						<bx:if !isNull( top ) && top lt var.recordcount>#top#/</bx:if>#var.recordcount# rows
+						<bx:if !isNull( maxRows ) && maxRows lt var.recordcount>#maxRows#/</bx:if>#var.recordcount# rows
 					</strong>
 				</caption>
 				<thead
@@ -28,8 +28,9 @@
 				<tbody
 					<bx:if !expandRoot>class="d-none"</bx:if>
 				>
-					<bx:loop query="#var#" item="row" index="index">
-						<bx:if !isNull( top ) and var.currentRow gt top >
+					<bx:set maxItems = isNull( maxRows ) ? var.recordcount : min( maxRows, var.recordcount )>
+					<bx:loop query="#var#" item="row">
+						<bx:if var.currentRow gt maxItems>
 							<bx:break/>
 						</bx:if>
 						<tr>
@@ -38,7 +39,7 @@
 									<bx:if isSimpleValue( var[ column ] )>
 										#encodeForHTML( var[ column ] )#
 									<bx:else>
-										<bx:dump var="#var[ column ]#"/>
+										#writeDump( var : var[ column ], depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, output : "buffer", format : format )#
 									</bx:if>
 								</td>
 							</bx:loop>

--- a/src/main/resources/dump/html/Struct.bxm
+++ b/src/main/resources/dump/html/Struct.bxm
@@ -21,7 +21,7 @@
 						<strong>
 							<bx:if label.len() >#label# - </bx:if>
 							#dumpTitle#
-							<bx:if !isNull( top ) && top lt var.len()>#top#/</bx:if>#var.len()#
+							<bx:if !isNull( maxRows ) && maxRows lt var.len()>#maxRows#/</bx:if>#var.len()#
 						</strong>
 					</caption>
 				<bx:else>
@@ -29,7 +29,7 @@
 						<strong>
 							<bx:if label.len() >#label# - </bx:if>
 							#dumpTitle#
-							<bx:if !isNull( top ) && top lt var.len()>#top#/</bx:if>#var.len()#
+							<bx:if !isNull( maxRows ) && maxRows lt var.len()>#maxRows#/</bx:if>#var.len()#
 						</strong>
 					</caption>
 				</bx:if>
@@ -38,16 +38,14 @@
 			<tbody
 				<bx:if !expandRoot>class="d-none"</bx:if>
 			>
-					<bx:set index = 1>
 					<bx:set keys = structKeyArray( var )>
 					<!--- If this isn't some sort of sorted or linked struct, then sort the keys for dumping --->
 					<bx:if !('LINKED_CASE_SENSITIVE,LINKED,SORTED'.listFindNoCase(var.getType().toString()))>
 					  <bx:set keys = keys.sort("textnocase")>
 					</bx:if>
-					<bx:loop array="#keys#" item="key">
-						<bx:if  !isNull( top ) and index++ GT top >
-							<bx:break>
-						</bx:if>
+					<bx:set maxItems = isNull( maxRows ) ? keys.len() : min( maxRows, keys.len() )>
+					<bx:loop from="1" to="#maxItems#" index="idx">
+						<bx:set key = keys[idx]>
 						<bx:if NOT isCustomFunction( var[ key ] ) >
 							<tr>
 								<th
@@ -61,7 +59,7 @@
 								</th>
 								<td>
 									<div class="bx-onoff">
-										<bx:set dump( var : var[ key ], top : ( isNull( top ) ? null : top - 1 ), expand : expand ?: null, output : "buffer", format : format ) >
+										<bx:set dump( var : var[ key ], depth : ( isNull( depth ) ? null : depth - 1 ), maxRows : maxRows, expand : expand ?: null, output : "buffer", format : format ) >
 									</div>
 								</td>
 							</tr>

--- a/src/main/resources/dump/html/XML.bxm
+++ b/src/main/resources/dump/html/XML.bxm
@@ -41,7 +41,7 @@
 								</th>
 								<td>
 									<div class="bx-onoff">
-										<bx:set dump( var : theCollection[ key ], top : isNull( top ) ? null : top - 1, expand : expand ?: null, output : "buffer", format : format ) >
+										<bx:set dump( var : theCollection[ key ], depth : isNull( depth ) ? null : depth - 1, maxRows : maxRows, expand : expand ?: null, output : "buffer", format : format ) >
 									</div>
 								</td>
 							</tr>

--- a/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
+++ b/src/test/java/ortus/boxlang/compiler/CFTranspilerTest.java
@@ -16,6 +16,9 @@ package ortus.boxlang.compiler;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -755,6 +758,81 @@ public class CFTranspilerTest {
 
 		assertThat( variables.getAsString( result ) ).contains( "brad" );
 		assertThat( variables.getAsString( result ) ).contains( "result" );
+	}
+
+	private static final String NESTED_STRUCT_SOURCE = """
+	                                                   data = { "alpha": "a",
+	                                                   		"beta" : {
+	                                                   			"charlie": "c",
+	                                                   			"delta": "d"
+	                                                   		},
+	                                                   		"echo" : {
+	                                                   			"foxtrot" : {
+	                                                   				"golf" : "g",
+	                                                   				"hotel" : "h"
+	                                                   			}
+	                                                   		}
+	                                                   	};
+	                                                   """;
+
+	@DisplayName( "It transpiles writeDump( top=value ) to writeDump( depth=value-1 )" )
+	@Test
+	public void testWriteDumpTopTranspilesToDepthMinusOne() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		context.getRequestContext().setOut( new PrintStream( baos, true ) );
+		// @formatter:off
+		instance.executeSource(
+		    NESTED_STRUCT_SOURCE + """
+		    writeDump( var = data, top = 3, format = "html" );
+		    """,
+		    context, BoxSourceType.CFSCRIPT );
+		// @formatter:on
+		String output = baos.toString();
+		// top=3 -> depth=2: recurse one level in
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "foxtrot" );
+		assertThat( output ).doesNotContain( "golf" );
+	}
+
+	@DisplayName( "It transpiles writeDump( top=1 ) to writeDump( depth=0 ), showing nothing" )
+	@Test
+	public void testWriteDumpTopOneTranspilesToDepthZero() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		context.getRequestContext().setOut( new PrintStream( baos, true ) );
+		// @formatter:off
+		instance.executeSource(
+		    NESTED_STRUCT_SOURCE + """
+		    writeDump( var = data, top = 1, format = "html" );
+		    """,
+		    context, BoxSourceType.CFSCRIPT );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "Depth Limit reached" );
+		assertThat( output ).doesNotContain( "alpha" );
+	}
+
+	@DisplayName( "It transpiles <cfdump top=value> to <bx:dump depth=value-1>" )
+	@Test
+	public void testCfDumpTopTranspilesToDepthMinusOne() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		context.getRequestContext().setOut( new PrintStream( baos, true ) );
+		// @formatter:off
+		instance.executeSource(
+		    """
+		    <cfscript>
+		    """ + NESTED_STRUCT_SOURCE + """
+		    </cfscript>
+		    <cfdump var="#data#" top="3" format="html">
+		    """,
+		    context, BoxSourceType.CFTEMPLATE );
+		// @formatter:on
+		String output = baos.toString();
+		// top=3 -> depth=2: recurse one level in
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "foxtrot" );
+		assertThat( output ).doesNotContain( "golf" );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
@@ -973,10 +973,33 @@ public class DumpTest {
 		// @formatter:on
 		String output = baos.toString();
 		assertThat( output ).contains( "alpha" );
+		// alpha's value is a plain scalar string with nothing further to recurse into, so it must
+		// still render fully even though depth=1 blocks recursion into the *container* values (beta/echo)
+		assertThat( output ).contains( ">a<" );
 		assertThat( output ).contains( "beta" );
 		assertThat( output ).contains( "echo" );
 		assertThat( output ).doesNotContain( "charlie" );
 		assertThat( output ).doesNotContain( "golf" );
+	}
+
+	@DisplayName( "It does not hide scalar leaf values behind the depth limit, only containers" )
+	@Test
+	public void testDepthDoesNotHideScalarLeafValues() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = { "name": "Brad", "age": 42, "active": true };
+			dump( var = val, format = "html", depth = 1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		// depth=1 means "top level, no recursion into containers" - but these are all scalars with
+		// nothing to recurse into, so their actual values must be shown rather than "Depth Limit reached"
+		assertThat( output ).doesNotContain( "Depth Limit reached" );
+		assertThat( output ).contains( "Brad" );
+		assertThat( output ).contains( "42" );
+		assertThat( output ).contains( "true" );
 	}
 
 	@DisplayName( "It recurses one level in when depth is 2" )

--- a/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
@@ -1214,4 +1214,60 @@ public class DumpTest {
 		assertThat( output ).contains( "bravo" );
 		assertThat( output ).doesNotContain( "charlie" );
 	}
+
+	@DisplayName( "It still accepts the deprecated top argument on the BIF, folding it into maxRows" )
+	@Test
+	public void testDeprecatedTopFoldsIntoMaxRowsOnBIF() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+			dump( var = val, format = "html", top = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
+
+	@DisplayName( "It still accepts the deprecated top attribute on the dump component/tag, folding it into maxRows" )
+	@Test
+	public void testDeprecatedTopFoldsIntoMaxRowsOnComponent() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+				<bx:script>
+					val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+				</bx:script>
+				<bx:dump var="#val#" format="html" top="2">
+			""",
+			context, BoxSourceType.BOXTEMPLATE );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
+
+	@DisplayName( "It prefers an explicit maxRows over the deprecated top when both are passed" )
+	@Test
+	public void testMaxRowsTakesPrecedenceOverDeprecatedTop() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+			dump( var = val, format = "html", top = 1, maxRows = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
 }

--- a/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
+++ b/src/test/java/ortus/boxlang/runtime/components/system/DumpTest.java
@@ -887,4 +887,308 @@ public class DumpTest {
 		assertThat( output ).doesNotContain( "caseSensitive" );
 		assertThat( output ).doesNotContain( "synchronized" );
 	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * depth / maxRows
+	 * --------------------------------------------------------------------------
+	 * depth limits recursion (1-based): -1 (default) is unlimited, 0 shows nothing,
+	 * 1 shows the top level with no recursion, 2 recurses once, 3 recurses twice, etc.
+	 * maxRows limits the number of rows/items shown per level (1-based) with the same
+	 * -1/0/N semantics, independently of depth.
+	 */
+	private static final String NESTED_STRUCT_SOURCE = """
+	                                                   val = { "alpha": "a",
+	                                                   		"beta" : {
+	                                                   			"charlie": "c",
+	                                                   			"delta": "d"
+	                                                   		},
+	                                                   		"echo" : {
+	                                                   			"foxtrot" : {
+	                                                   				"golf" : "g",
+	                                                   				"hotel" : "h"
+	                                                   			}
+	                                                   		}
+	                                                   	};
+	                                                   """;
+
+	@DisplayName( "It defaults depth and maxRows to unlimited (-1) when omitted" )
+	@Test
+	public void testDepthAndMaxRowsDefaultToUnlimited() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html" );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "golf" );
+	}
+
+	@DisplayName( "It treats an explicit depth of -1 the same as the default (unlimited)" )
+	@Test
+	public void testDepthNegativeOneIsUnlimited() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html", depth = -1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "golf" );
+	}
+
+	@DisplayName( "It shows nothing when depth is 0" )
+	@Test
+	public void testDepthZeroShowsNothing() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html", depth = 0 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "Depth Limit reached" );
+		assertThat( output ).doesNotContain( "alpha" );
+		assertThat( output ).doesNotContain( "charlie" );
+		assertThat( output ).doesNotContain( "golf" );
+	}
+
+	@DisplayName( "It shows only the top level with no recursion when depth is 1" )
+	@Test
+	public void testDepthOneShowsNoRecursion() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html", depth = 1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "beta" );
+		assertThat( output ).contains( "echo" );
+		assertThat( output ).doesNotContain( "charlie" );
+		assertThat( output ).doesNotContain( "golf" );
+	}
+
+	@DisplayName( "It recurses one level in when depth is 2" )
+	@Test
+	public void testDepthTwoRecursesOnce() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html", depth = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "foxtrot" );
+		assertThat( output ).doesNotContain( "golf" );
+	}
+
+	@DisplayName( "It recurses two levels in when depth is 3" )
+	@Test
+	public void testDepthThreeRecursesTwice() {
+		// @formatter:off
+		instance.executeSource(
+			NESTED_STRUCT_SOURCE + """
+			dump( var = val, format = "html", depth = 3 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "foxtrot" );
+		assertThat( output ).contains( "golf" );
+		assertThat( output ).contains( "hotel" );
+	}
+
+	@DisplayName( "It shows nothing when maxRows is 0" )
+	@Test
+	public void testMaxRowsZeroShowsNothing() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+			dump( var = val, format = "html", maxRows = 0 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "0/3" );
+		assertThat( output ).doesNotContain( "alpha" );
+		assertThat( output ).doesNotContain( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
+
+	@DisplayName( "It limits the number of struct keys shown per level with maxRows" )
+	@Test
+	public void testMaxRowsLimitsStructKeys() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+			dump( var = val, format = "html", maxRows = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
+
+	@DisplayName( "It limits the number of array items shown per level with maxRows" )
+	@Test
+	public void testMaxRowsLimitsArrayItems() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = [ "alpha", "bravo", "charlie", "delta" ];
+			dump( var = val, format = "html", maxRows = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/4" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+		assertThat( output ).doesNotContain( "delta" );
+	}
+
+	@DisplayName( "It treats an explicit maxRows of -1 the same as the default (unlimited)" )
+	@Test
+	public void testMaxRowsNegativeOneIsUnlimited() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = [ "alpha", "bravo", "charlie", "delta" ];
+			dump( var = val, format = "html", maxRows = -1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).contains( "delta" );
+		assertThat( output ).doesNotContain( "4/4" );
+	}
+
+	@DisplayName( "It limits the number of query rows shown per level with maxRows" )
+	@Test
+	public void testMaxRowsLimitsQueryRows() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			qry = queryNew( "id", "integer" );
+			queryAddRow( qry, [ { id: 1 }, { id: 2 }, { id: 3 } ] );
+			dump( var = qry, format = "html", maxRows = 1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "1/3" );
+	}
+
+	@DisplayName( "It combines depth and maxRows together" )
+	@Test
+	public void testDepthAndMaxRowsCombined() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+				val = { "alpha": "a",
+						"beta" : {
+							"charlie": "c",
+							"delta": "d"
+						},
+						"echo" : {
+							"foxtrot" : {
+								"golf" : "g",
+								"hotel" : "h"
+							}
+						},
+						"india" : "i"
+					};
+
+				dump( var = val, format = "html", depth = 2, maxRows = 3 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "3/4" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "beta" );
+		assertThat( output ).contains( "echo" );
+		assertThat( output ).contains( "charlie" );
+		assertThat( output ).doesNotContain( "golf" );
+		assertThat( output ).doesNotContain( "india" );
+	}
+
+	@DisplayName( "It limits the number of Set items shown per level with maxRows" )
+	@Test
+	public void testMaxRowsLimitsSetItems() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = setNew( type = "linked", values = [ "alpha", "bravo", "charlie" ] );
+			dump( var = val, format = "html", maxRows = 2 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
+
+	@DisplayName( "It limits recursion into Set items with depth" )
+	@Test
+	public void testDepthLimitsSetRecursion() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			val = setOf( { "nested" : "value" } );
+			dump( var = val, format = "html", depth = 1 );
+			""",
+			context );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "Depth Limit reached" );
+		assertThat( output ).doesNotContain( "nested" );
+	}
+
+	@DisplayName( "It supports depth and maxRows on the dump component/tag" )
+	@Test
+	public void testDepthAndMaxRowsOnComponent() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+				<bx:script>
+					val = { "alpha": "a", "bravo": "b", "charlie": "c" };
+				</bx:script>
+				<bx:dump var="#val#" format="html" maxRows="2">
+			""",
+			context, BoxSourceType.BOXTEMPLATE );
+		// @formatter:on
+		String output = baos.toString();
+		assertThat( output ).contains( "2/3" );
+		assertThat( output ).contains( "alpha" );
+		assertThat( output ).contains( "bravo" );
+		assertThat( output ).doesNotContain( "charlie" );
+	}
 }

--- a/workbench/samples/bifs/system/Dump.md
+++ b/workbench/samples/bifs/system/Dump.md
@@ -21,3 +21,36 @@ writeDump( var=getTimeZoneInfo(), label="Tag label" );
 ```
 
 
+### Limit recursion depth
+
+Prevents dumping deeply nested structures by limiting how many levels are recursed into.
+`depth` is 1-based: `-1` (the default) is unlimited, `0` shows nothing, `1` shows the top
+level with no recursion, `2` recurses once, etc.
+
+```java
+writeDump( var=complexObject, depth=3 );
+
+```
+
+### Limit the number of rows/items shown
+
+Limits how many keys, array elements, or query rows are shown per level, independently of
+recursion depth. Same 1-based semantics as `depth`.
+
+```java
+writeDump( var=bigArray, maxRows=10 );
+
+```
+
+### Deprecated: top
+
+`top` is deprecated in favor of `maxRows` and `depth` above. For backwards compatibility it is
+still accepted and, when `maxRows` is not also passed, its value is used as `maxRows`. A
+deprecation warning is logged when it's used.
+
+```java
+writeDump( var=bigArray, top=10 );
+
+```
+
+

--- a/workbench/samples/components/system/Dump.md
+++ b/workbench/samples/components/system/Dump.md
@@ -14,12 +14,24 @@ Outputs structured debug information for any variable type.
 
 ```
 
-### Limit dump depth
+### Limit recursion depth
 
-Prevents dumping deeply nested structures by limiting the number of levels.
+Prevents dumping deeply nested structures by limiting how many levels are recursed into.
+`depth` is 1-based: `-1` (the default) is unlimited, `0` shows nothing, `1` shows the top
+level with no recursion, `2` recurses once, etc.
 
 ```java
-<bx:dump var="#complexObject#" top="3">
+<bx:dump var="#complexObject#" depth="3">
+
+```
+
+### Limit the number of rows/items shown
+
+Limits how many keys, array elements, or query rows are shown per level, independently of
+recursion depth. Same 1-based semantics as `depth`.
+
+```java
+<bx:dump var="#bigArray#" maxRows="10">
 
 ```
 

--- a/workbench/samples/components/system/Dump.md
+++ b/workbench/samples/components/system/Dump.md
@@ -35,6 +35,17 @@ recursion depth. Same 1-based semantics as `depth`.
 
 ```
 
+### Deprecated: top
+
+`top` is deprecated in favor of `maxRows` and `depth` above. For backwards compatibility it is
+still accepted and, when `maxRows` is not also passed, its value is used as `maxRows`. A
+deprecation warning is logged when it's used.
+
+```java
+<bx:dump var="#bigArray#" top="10">
+
+```
+
 ### Dump to console
 
 ```java

--- a/workbench/tests/dump-depth-maxrows/01-depth-struct.bxm
+++ b/workbench/tests/dump-depth-maxrows/01-depth-struct.bxm
@@ -1,0 +1,47 @@
+<bx:script>
+	nested = {
+		"alpha": "a",
+		"beta" : {
+			"charlie": "c",
+			"delta": "d"
+		},
+		"echo" : {
+			"foxtrot" : {
+				"golf" : "g",
+				"hotel" : "h"
+			}
+		}
+	};
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>01 - Recursion depth on nested Struct</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>01 - Recursion depth on nested Struct</h1>
+<p>Fixture: <code>alpha</code> (level 1) &rarr; <code>beta.charlie/delta</code> (level 2) &rarr; <code>echo.foxtrot.golf/hotel</code> (level 3)</p>
+
+<h2>depth = -1 (default / unlimited)</h2>
+<div class="expect">Expect: everything shown, including golf/hotel</div>
+<bx:dump var="#nested#" depth="-1">
+
+<h2>depth = 0 (shows nothing)</h2>
+<div class="expect">Expect: "Depth Limit reached" only</div>
+<bx:dump var="#nested#" depth="0">
+
+<h2>depth = 1 (top level only, no recursion)</h2>
+<div class="expect">Expect: alpha/beta/echo keys visible, nested values collapsed to "Depth Limit reached"</div>
+<bx:dump var="#nested#" depth="1">
+
+<h2>depth = 2 (recurse one level in)</h2>
+<div class="expect">Expect: charlie/delta/foxtrot visible, golf/hotel NOT visible</div>
+<bx:dump var="#nested#" depth="2">
+
+<h2>depth = 3 (recurse two levels in)</h2>
+<div class="expect">Expect: everything visible including golf/hotel</div>
+<bx:dump var="#nested#" depth="3">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/02-maxrows-struct.bxm
+++ b/workbench/tests/dump-depth-maxrows/02-maxrows-struct.bxm
@@ -1,0 +1,27 @@
+<bx:script>
+	flat = { "alpha": "a", "bravo": "b", "charlie": "c", "delta": "d", "echo": "e" };
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>02 - maxRows on a flat Struct</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>02 - Row limiting (maxRows) on a flat Struct</h1>
+<p>Fixture: 5 keys, alpha..echo</p>
+
+<h2>maxRows = -1 (default / unlimited)</h2>
+<div class="expect">Expect: caption shows plain "5", all 5 keys shown</div>
+<bx:dump var="#flat#" maxRows="-1">
+
+<h2>maxRows = 0 (shows nothing)</h2>
+<div class="expect">Expect: caption shows "0/5", no rows in the body</div>
+<bx:dump var="#flat#" maxRows="0">
+
+<h2>maxRows = 2</h2>
+<div class="expect">Expect: caption shows "2/5", only alpha + bravo shown</div>
+<bx:dump var="#flat#" maxRows="2">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/03-maxrows-array.bxm
+++ b/workbench/tests/dump-depth-maxrows/03-maxrows-array.bxm
@@ -1,0 +1,26 @@
+<bx:script>
+	arr = [ "alpha", "bravo", "charlie", "delta", "echo" ];
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>03 - maxRows on an Array</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>03 - Row limiting (maxRows) on an Array</h1>
+<p>Fixture: [alpha, bravo, charlie, delta, echo]</p>
+
+<h2>maxRows = -1 (default / unlimited)</h2>
+<bx:dump var="#arr#" maxRows="-1">
+
+<h2>maxRows = 3</h2>
+<div class="expect">Expect: caption "3/5", items 1-3 shown (alpha, bravo, charlie)</div>
+<bx:dump var="#arr#" maxRows="3">
+
+<h2>maxRows = 0</h2>
+<div class="expect">Expect: caption "0/5", no rows</div>
+<bx:dump var="#arr#" maxRows="0">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/04-maxrows-query.bxm
+++ b/workbench/tests/dump-depth-maxrows/04-maxrows-query.bxm
@@ -1,0 +1,28 @@
+<bx:script>
+	qry = queryNew( "id,name", "integer,varchar" );
+	queryAddRow( qry, [
+		{ id: 1, name: "Row One" },
+		{ id: 2, name: "Row Two" },
+		{ id: 3, name: "Row Three" },
+		{ id: 4, name: "Row Four" }
+	] );
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>04 - maxRows on a Query</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>04 - Row limiting (maxRows) on a Query</h1>
+<p>Fixture: 4-row query</p>
+
+<h2>maxRows = -1 (default / unlimited)</h2>
+<bx:dump var="#qry#" maxRows="-1">
+
+<h2>maxRows = 2</h2>
+<div class="expect">Expect: caption "2/4 rows", only rows 1-2 shown</div>
+<bx:dump var="#qry#" maxRows="2">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/05-set.bxm
+++ b/workbench/tests/dump-depth-maxrows/05-set.bxm
@@ -1,0 +1,31 @@
+<bx:script>
+	linkedSet = setNew( type = "linked", values = [ "alpha", "bravo", "charlie", "delta" ] );
+	nestedSet = setOf( { "inner": "value" } );
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>05 - depth / maxRows on a Set</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>05 - depth / maxRows on a Set</h1>
+<p>Fixture: linked Set of 4 strings, and a Set containing one nested Struct</p>
+
+<h2>maxRows = 2 on a 4-item linked Set</h2>
+<div class="expect">Expect: caption "2/4", only alpha + bravo shown</div>
+<bx:dump var="#linkedSet#" maxRows="2">
+
+<h2>maxRows = -1 (default / unlimited)</h2>
+<bx:dump var="#linkedSet#" maxRows="-1">
+
+<h2>depth = 1 on a Set containing a nested Struct</h2>
+<div class="expect">Expect: the Set itself renders, but the nested struct's own content collapses to "Depth Limit reached"</div>
+<bx:dump var="#nestedSet#" depth="1">
+
+<h2>depth = -1 (default / unlimited) on the same nested Set</h2>
+<div class="expect">Expect: "inner" / "value" fully visible</div>
+<bx:dump var="#nestedSet#" depth="-1">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/06-combined.bxm
+++ b/workbench/tests/dump-depth-maxrows/06-combined.bxm
@@ -1,0 +1,24 @@
+<bx:script>
+	val = {
+		"alpha": "a",
+		"beta" : { "charlie": "c", "delta": "d" },
+		"echo" : { "foxtrot" : { "golf" : "g", "hotel" : "h" } },
+		"india" : "i"
+	};
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>06 - depth + maxRows combined</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>06 - depth + maxRows combined</h1>
+<p>Fixture: 4 top-level keys (alpha, beta, echo, india), with beta/echo nesting further</p>
+
+<h2>depth = 2, maxRows = 3</h2>
+<div class="expect">Expect: caption "3/4" (india dropped by maxRows); alpha/beta/echo shown; charlie/delta/foxtrot visible (depth 2); golf/hotel NOT visible</div>
+<bx:dump var="#val#" depth="2" maxRows="3">
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/07-component-tag.bxm
+++ b/workbench/tests/dump-depth-maxrows/07-component-tag.bxm
@@ -1,0 +1,21 @@
+<bx:script>
+	val = { "one": 1, "two": 2, "three": 3, "four": 4 };
+</bx:script>
+<!DOCTYPE html>
+<html>
+<head><title>07 - bx:dump component tag vs writeDump() BIF</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>07 - &lt;bx:dump&gt; component tag vs writeDump() BIF</h1>
+<p>Both should render identically for the same depth/maxRows attributes.</p>
+
+<h2>&lt;bx:dump var="#val#" maxRows="2"&gt; (component/tag)</h2>
+<bx:dump var="#val#" maxRows="2">
+
+<h2>#writeDump( var=val, maxRows=2 )# (BIF)</h2>
+<bx:output>#writeDump( var = val, maxRows = 2, output = "buffer", format = "html" )#</bx:output>
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/08-cf-compat.cfm
+++ b/workbench/tests/dump-depth-maxrows/08-cf-compat.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+	nested = {
+		"alpha": "a",
+		"beta" : {
+			"charlie": "c",
+			"delta": "d"
+		},
+		"echo" : {
+			"foxtrot" : {
+				"golf" : "g",
+				"hotel" : "h"
+			}
+		}
+	};
+</cfscript>
+<!DOCTYPE html>
+<html>
+<head><title>08 - CF-compat cfdump top= transpiled to depth</title>
+<style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:30px auto;padding:0 20px;} h2{border-bottom:2px solid #333;padding-bottom:4px;margin-top:40px;} .expect{background:#fffbe6;border-left:4px solid #e0a800;padding:8px 12px;margin:8px 0;}</style>
+</head>
+<body>
+<p><a href="index.bxm">&larr; back</a></p>
+<h1>08 - CF-compat: &lt;cfdump top=&gt; transpiled to depth=value-1</h1>
+<p>This is a real <code>.cfm</code> file, so it goes through the CF-compat transpiler. Same fixture as page 01.</p>
+
+<h2>&lt;cfdump var="#nested#" top="1"&gt;</h2>
+<div class="expect">top=1 -&gt; depth=0. Expect: "Depth Limit reached" only.</div>
+<cfdump var="#nested#" top="1">
+
+<h2>&lt;cfdump var="#nested#" top="3"&gt;</h2>
+<div class="expect">top=3 -&gt; depth=2. Expect: charlie/delta/foxtrot visible, golf/hotel NOT visible (same as depth=2 on page 01).</div>
+<cfdump var="#nested#" top="3">
+
+<h2>writeDump( var=nested, top=3 ) as a cfscript BIF call</h2>
+<div class="expect">Same top=3 -&gt; depth=2 mapping, via the writeDump() BIF instead of the tag.</div>
+<cfoutput>#writeDump( var = nested, top = 3, output = "buffer", format = "html" )#</cfoutput>
+
+</body>
+</html>

--- a/workbench/tests/dump-depth-maxrows/README.md
+++ b/workbench/tests/dump-depth-maxrows/README.md
@@ -1,0 +1,56 @@
+# dump() depth / maxRows manual test pages
+
+Manual/visual test pages for the `dump()` / `writeDump()` / `<bx:dump>` `depth` and `maxRows`
+parameters (recursion-depth limiting vs. row/item-count limiting), including the CF-compat
+`<cfdump top=>` → `depth=value-1` transpiler mapping and Set support.
+
+Each page states what it expects inline, so you can eyeball correctness directly in the browser.
+
+- `index.bxm` - links to all pages below
+- `01-depth-struct.bxm` - `depth` at -1/0/1/2/3 on a 3-level nested Struct
+- `02-maxrows-struct.bxm` - `maxRows` at -1/0/2 on a flat Struct
+- `03-maxrows-array.bxm` - `maxRows` on an Array
+- `04-maxrows-query.bxm` - `maxRows` on a Query
+- `05-set.bxm` - `depth` / `maxRows` on a `Set` (linked Set + a Set containing a nested Struct)
+- `06-combined.bxm` - `depth` + `maxRows` used together
+- `07-component-tag.bxm` - `<bx:dump>` tag vs. `writeDump()` BIF parity
+- `08-cf-compat.cfm` - real CFML file exercising `<cfdump top=>` and `writeDump(top=)` through
+  the CF-compat transpiler
+
+## Running against a local build
+
+`boxlang-miniserver` and `boxlang-web-support` each look for a locally built runtime jar at
+`../boxlang/build/libs/boxlang-<version>.jar` relative to themselves (see each project's
+`build.gradle`) and use it automatically if present, instead of downloading a published one.
+This lets you exercise runtime changes from this checkout before they're published.
+
+That relative path means **your clone of this repo must be at a sibling directory literally
+named `boxlang`** (lowercase) alongside the other two - rename/move it or add a symlink
+(`ln -s /path/to/this/checkout ../boxlang`) if it's checked out under a different name.
+
+```bash
+# Directory layout expected by the sibling projects:
+#   somewhere/boxlang/               <- this repo (must be named exactly "boxlang")
+#   somewhere/boxlang-web-support/
+#   somewhere/boxlang-miniserver/
+
+# 1. Build this repo's runtime jar
+cd boxlang
+./gradlew shadowJar -x test
+
+# 2. Clone the sibling projects (once), next to this checkout
+cd ..
+git clone https://github.com/ortus-boxlang/boxlang-web-support
+git clone https://github.com/ortus-boxlang/boxlang-miniserver
+
+# 3. Build boxlang-web-support and boxlang-miniserver - both will find and use
+#    ../boxlang/build/libs/boxlang-<version>.jar automatically
+cd boxlang-web-support && ./gradlew shadowJar jar -x test && cd ..
+cd boxlang-miniserver && ./gradlew shadowJar -x test && cd ..
+
+# 4. Run the MiniServer against this test folder
+java -jar boxlang-miniserver/build/distributions/boxlang-miniserver-*.jar \
+    --port 8085 --webroot boxlang/workbench/tests/dump-depth-maxrows
+
+# 5. Open http://localhost:8085/index.bxm
+```

--- a/workbench/tests/dump-depth-maxrows/index.bxm
+++ b/workbench/tests/dump-depth-maxrows/index.bxm
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>BoxLang Dump depth/maxRows Integration Test</title>
+	<style>
+		body { font-family: system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; }
+		h1 { font-size: 1.4rem; }
+		ul { line-height: 2; }
+		a { color: #0066cc; }
+	</style>
+</head>
+<body>
+	<h1>BoxLang <code>dump()</code> depth / maxRows Integration Test</h1>
+	<p>Live server built from branch <code>claude/boxlang-dump-depth-maxrows-itk5qz</code>.</p>
+	<ul>
+		<li><a href="01-depth-struct.bxm">01 - Recursion depth on nested Struct</a></li>
+		<li><a href="02-maxrows-struct.bxm">02 - Row limiting (maxRows) on a flat Struct</a></li>
+		<li><a href="03-maxrows-array.bxm">03 - Row limiting (maxRows) on an Array</a></li>
+		<li><a href="04-maxrows-query.bxm">04 - Row limiting (maxRows) on a Query</a></li>
+		<li><a href="05-set.bxm">05 - depth / maxRows on a Set</a></li>
+		<li><a href="06-combined.bxm">06 - depth + maxRows combined</a></li>
+		<li><a href="07-component-tag.bxm">07 - &lt;bx:dump&gt; component tag attributes</a></li>
+		<li><a href="08-cf-compat.cfm">08 - CF-compat &lt;cfdump top&gt; transpiled to depth</a></li>
+	</ul>
+</body>
+</html>


### PR DESCRIPTION
## Description

Redesigns the `dump()` / `writeDump()` / `<bx:dump>` `top` parameter into two independent, 1-based parameters, following the existing precedent of `maxRows` on `<cfoutput>`/`<cfloop>`:

- **`maxRows`** - limits the number of rows/items shown per collection level (no CF equivalent)
- **`depth`** - limits recursion into nested structures (maps from CF's `top` in the CF-compat transpiler)

Semantics for both, matching the agreed design: `-1` (default) is unlimited, `0` shows nothing, `1` shows the top level with no recursion, `2` recurses once, etc.

`top` itself is **kept as a deprecated argument**, not removed - existing BoxLang code may already call `dump(top=...)` directly. When `maxRows` isn't also passed, `top`'s value is folded into `maxRows` (an explicit `maxRows` always wins), and a deprecation warning is logged. This is separate from the CF-compat transpiler, which still rewrites `writeDump(top=value)` / `<cfdump top=value>` to `depth=value-1` for real CFML, since CF's `top` has no `maxRows` equivalent for `dump()` and this preserves prior recursion-limiting behavior for existing CF code.

Applied to all dump templates: Array, Struct, Map, List, Query, Function, BoxClass, XML, and **Set** (`BoxSet.bxm` - `maxRows`/`depth` support extended to the newer `Set` type).

### Bugs found and fixed along the way

Surfaced while building out test coverage and a live MiniServer integration check (see the manual test pages added in this PR):

1. `Array.bxm`/`BoxSet.bxm`'s nested `dump()` calls never passed `output`/`format`, so nested array/set items silently fell back to console/text output instead of recursing inline in HTML - this broke depth-limiting for arrays and sets entirely.
2. The recursive-reference and depth-limit early-return paths in `DumpUtil.generateDumpHTML()` skipped cleaning up the thread-local "already dumped" tracking set when triggered at the outermost call, permanently breaking every later `dump()` call on that thread/request.
3. The depth-limit check applied uniformly to *every* value, including plain scalars (strings, numbers, booleans) with nothing to recurse into - e.g. `depth=1` on `{ name: "Brad" }` showed "Depth Limit reached" instead of `"Brad"`. Now only container/complex values are gated by `depth` (`IsSimpleValue.isSimpleValue()` bypasses the check).

## Jira Issues

Closes [BL-1862](https://ortussolutions.atlassian.net/browse/BL-1862) - Discrepancy in dump() between Lucee and Boxlang in key depth

> Bug Tracker: https://ortussolutions.atlassian.net/browse/BL/issues

## Type of change

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (`top` is kept working as a deprecated alias for `maxRows`, so existing BoxLang code calling `dump(top=...)` directly keeps working; CF-compat code continues to transpile as before)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project (`./gradlew spotlessApply`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`workbench/samples/components/system/Dump.md`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing

- Full `DumpTest`/`CFTranspilerTest` suites plus the broader `bifs.global.*`/`components.system.*`/`compiler.*` suites (3162 tests) pass, aside from one pre-existing unrelated environment flake in `SystemExecuteTest`.
- Live-verified against a locally built `boxlang-miniserver` (see `workbench/tests/dump-depth-maxrows/`, a reusable set of manual test pages covering every `depth`/`maxRows` scenario, the `<bx:dump>` tag vs. `writeDump()` BIF, and the CF-compat `<cfdump top=>` mapping) with real browser screenshots.


[BL-1862]: https://ortussolutions.atlassian.net/browse/BL-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ