### PR TITLE
BL-2633: Align every()+startOnTime()/between() to the next period boundary

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
+++ b/src/main/java/ortus/boxlang/runtime/async/tasks/ScheduledTask.java
@@ -642,6 +642,13 @@ public class ScheduledTask implements Runnable {
 			}
 		}
 
+		// If this is an interval-based (every()) task with an explicit daily start time and no
+		// initial delay was set some other way, align the first execution to the next period
+		// boundary counted from that start time instead of firing immediately on registration.
+		if ( this.period > 0 && this.initialDelay == 0 && this.startTime.length() > 0 ) {
+			calculateStartTimeAlignedDelay();
+		}
+
 		// Log it
 		debugLog(
 		    "start",
@@ -2122,6 +2129,36 @@ public class ScheduledTask implements Runnable {
 	 */
 	private void setInitialDelayPeriodAndTimeUnit( LocalDateTime now, LocalDateTime nextRun ) {
 		setInitialDelayPeriodAndTimeUnit( now, nextRun, TimeUnit.DAYS, 1 );
+	}
+
+	/**
+	 * When an interval-based task ( every() ) has an explicit daily start time
+	 * ( startOnTime() / between() ) but no initial delay was set some other way, this
+	 * calculates an initial delay that aligns the first execution to the next period
+	 * boundary counted from that start time, instead of firing immediately on registration.
+	 */
+	private void calculateStartTimeAlignedDelay() {
+		LocalDateTime	now				= getNow();
+		LocalDateTime	anchor			= now
+		    .withHour( Integer.parseInt( this.startTime.split( ":" )[ 0 ] ) )
+		    .withMinute( Integer.parseInt( this.startTime.split( ":" )[ 1 ] ) )
+		    .withSecond( 0 )
+		    .withNano( 0 );
+		long			periodSeconds	= this.timeUnit.toSeconds( this.period );
+
+		if ( periodSeconds <= 0 ) {
+			return;
+		}
+
+		long elapsedSeconds = Duration.between( anchor, now ).getSeconds();
+		if ( elapsedSeconds > 0 ) {
+			long periodsElapsed = ( elapsedSeconds / periodSeconds ) + 1;
+			anchor = anchor.plusSeconds( periodsElapsed * periodSeconds );
+		}
+
+		this.initialDelay			= this.timeUnit.convert( Duration.between( now, anchor ) );
+		this.initialDelayTimeUnit	= this.timeUnit;
+		this.stats.put( "nextRun", anchor );
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
+++ b/src/test/java/ortus/boxlang/runtime/async/tasks/ScheduledTaskTest.java
@@ -254,6 +254,37 @@ class ScheduledTaskTest {
 			assertThat( t.getTimeUnit().toString().toLowerCase() ).isEqualTo( "seconds" );
 		}
 
+		@DisplayName( "can align every() + startOnTime() to the next period boundary instead of firing immediately" )
+		@Test
+		void testEveryWithStartOnTimeAlignsToBoundary() throws InvalidAttributeValueException {
+			var t = task.every( 1800, TimeUnit.SECONDS );
+			t.startOnTime( "00:00" );
+			t.start();
+
+			assertThat( t.getInitialDelay() ).isGreaterThan( 0L );
+			assertThat( t.getInitialDelay() ).isAtMost( 1800L );
+		}
+
+		@DisplayName( "every() without startOnTime() still fires immediately (unchanged behavior)" )
+		@Test
+		void testEveryWithoutStartOnTimeStillFiresImmediately() {
+			var t = task.every( 1800, TimeUnit.SECONDS );
+			t.start();
+
+			assertThat( t.getInitialDelay() ).isEqualTo( 0L );
+		}
+
+		@DisplayName( "explicit delay() takes precedence over startOnTime() alignment" )
+		@Test
+		void testExplicitDelayOverridesStartTimeAlignment() throws InvalidAttributeValueException {
+			var t = task.every( 1800, TimeUnit.SECONDS );
+			t.startOnTime( "00:00" );
+			t.delay( 5, TimeUnit.SECONDS, true );
+			t.start();
+
+			assertThat( t.getInitialDelay() ).isEqualTo( 5L );
+		}
+
 	}
 
 	@Nested


### PR DESCRIPTION
## Summary

- Fixes [BL-2633](https://ortussolutions.atlassian.net/browse/BL-2633): scheduled tasks combining `every(period)` with `startOnTime()`/`between()` fired **immediately** on scheduler registration (server/container startup) instead of waiting for the next period boundary counted from the daily start time.
- `every()` leaves `initialDelay` at its default of `0`, and `startOnTime()`/`between()` only ever acted as a runtime gate in `isConstrained()` (never as an anchor for the first execution) — unlike the "smart" methods (`everyDayAt()`, `everyHourAt()`, `everyWeekOn()`, `cron()`, etc.) which already roll forward to the next future boundary.
- `ScheduledTask.start()` now computes an initial delay aligned to the next period boundary from the start time when `every()` + `startOnTime()`/`between()` are combined and no other delay was explicitly set (`.delay()` and the smart `every*At()`/`cron()` methods are unaffected).

## Test plan

- [x] Added `testEveryWithStartOnTimeAlignsToBoundary`, `testEveryWithoutStartOnTimeStillFiresImmediately`, and `testExplicitDelayOverridesStartTimeAlignment` in `ScheduledTaskTest`
- [x] `./gradlew test --tests "ortus.boxlang.runtime.async.tasks.ScheduledTaskTest"` — all pass
- [x] `./gradlew test --tests "ortus.boxlang.runtime.async.tasks.SchedulerTest" --tests "ortus.boxlang.runtime.services.SchedulerServiceTest" --tests "ortus.boxlang.runtime.bifs.global.scheduler.SchedulersTest"` — all pass, no regressions
- [x] `./gradlew spotlessApply` — clean

## Note

This is a behavior change for anyone currently relying on the old "fire immediately at registration, then gated by the daily window for later ticks" semantics for `every()+startOnTime()`/`between()`. Worth calling out in release notes.

---

Claude-Session: https://claude.ai/code/session_017dPzwiurpWaDV4b34VryNM

[BL-2633]: https://ortussolutions.atlassian.net/browse/BL-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ