### PR TITLE
BL-2640: Fix BoxCacheProvider.get() not updating per-entry hits/lastAccessed metadata

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.java
+++ b/src/main/java/ortus/boxlang/runtime/cache/providers/BoxCacheProvider.java
@@ -623,6 +623,15 @@ public class BoxCacheProvider extends AbstractCacheProvider {
 		// Record the hit
 		this.stats.recordHit();
 
+		// Update per-entry metadata tracking: hits, lastAccessed
+		cacheEntry
+		    .incrementHits()
+		    .touchLastAccessed();
+		// Is resetTimeoutOnAccess enabled? If so, jump up the creation time to increase the timeout
+		if ( BooleanCaster.cast( this.config.properties.get( Key.resetTimeoutOnAccess ) ) ) {
+			cacheEntry.resetCreated();
+		}
+
 		return cacheEntry.value();
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
+++ b/src/test/java/ortus/boxlang/runtime/cache/providers/BoxCacheProviderTest.java
@@ -292,4 +292,46 @@ public class BoxCacheProviderTest {
 		assertThat( boxCache.get( "testKey" ).get() ).isEqualTo( "test" );
 	}
 
+	@Test
+	@DisplayName( "It updates the per-entry hits metadata when calling get()" )
+	void testGetUpdatesHitsMetadata() {
+		boxCache.set( "testKey", "test" );
+		assertThat( boxCache.getCachedObjectMetadata( "testKey" ).get( "hits" ) ).isEqualTo( 0L );
+
+		boxCache.get( "testKey" );
+		boxCache.get( "testKey" );
+		boxCache.get( "testKey" );
+
+		assertThat( boxCache.getCachedObjectMetadata( "testKey" ).get( "hits" ) ).isEqualTo( 3L );
+	}
+
+	@Test
+	@DisplayName( "It updates the per-entry lastAccessed metadata when calling get()" )
+	void testGetUpdatesLastAccessedMetadata() throws InterruptedException {
+		boxCache.set( "testKey", "test" );
+		var originalLastAccessed = boxCache.getCachedObjectMetadata( "testKey" ).get( "lastAccessed" );
+
+		// Ensure the clock moves forward before the next access
+		Thread.sleep( 10 );
+		boxCache.get( "testKey" );
+
+		var updatedLastAccessed = boxCache.getCachedObjectMetadata( "testKey" ).get( "lastAccessed" );
+		assertThat( updatedLastAccessed ).isNotEqualTo( originalLastAccessed );
+	}
+
+	@Test
+	@DisplayName( "It does not update hits metadata when using quiet lookup/metadata accessors" )
+	void testQuietAccessorsDoNotUpdateHits() {
+		boxCache.set( "testKey", "test" );
+
+		// None of these should be tracked as a "hit" on the entry
+		boxCache.getCachedObjectMetadata( "testKey" );
+		boxCache.getQuiet( "testKey" );
+		boxCache.lookupQuiet( "testKey" );
+		boxCache.getCacheEntry( "testKey" );
+		boxCache.lookup( "testKey" );
+
+		assertThat( boxCache.getCachedObjectMetadata( "testKey" ).get( "hits" ) ).isEqualTo( 0L );
+	}
+
 }


### PR DESCRIPTION
# Description

`BoxCacheProvider.get(String key)` recorded a hit on the cache-wide aggregate stats (`stats.recordHit()`), but never updated the per-entry `ICacheEntry` metadata (`hits`, `lastAccessed`) exposed via `getCachedObjectMetadata(key)`. This left an entry's reported `hits` stuck at `0` forever, even after repeated `get()` calls, and its `lastAccessed` timestamp frozen at creation time — which would also make `useLastAccessTimeouts` idle-timeout eviction in `reap()` misbehave for active, frequently-read entries.

**Root cause:** `getCacheEntry(Key)` fetches entries via the object store's *quiet* accessor (`objectStore.getQuiet(key)`), which intentionally does not touch per-entry metadata. The object store's own tracking `get(Key)` variant (which does call `incrementHits()`/`touchLastAccessed()`, e.g. in `ConcurrentStore`, `ConcurrentSoftReferenceStore`, `FileSystemStore`, `JDBCStore`) is never actually invoked anywhere in `BoxCacheProvider` — it's effectively dead code today.

**Fix:** In `BoxCacheProvider.get(String key)`, after confirming the entry is present and not expired, mirror the same per-entry tracking behavior the object stores already implement: `cacheEntry.incrementHits().touchLastAccessed()`, plus honoring the `resetTimeoutOnAccess` config flag via `cacheEntry.resetCreated()`. `getCacheEntry()` itself is left untouched so the quiet call sites (`getCachedObjectMetadata()`, `getQuiet()`, `lookupQuiet()`) remain non-tracking, as intended. `lookup(String key)` was not touched since it already correctly records hits/misses on the aggregate stats and doesn't return entry metadata.

This is the root cause behind a ColdBox framework bug report (COLDBOX-1405) where repeatedly calling `.get()` on a cached key left `getCachedObjectMetadata(key).hits` stuck at 0 (reported against ColdBox, but the bug lives in the BoxLang cache engine).

Note: this is distinct from BL-1775 (already resolved), which was the opposite problem — `getCachedObjectMetadata()` incorrectly registering as a hit.

## Jira Issues

- https://ortussolutions.atlassian.net/browse/BL-2640

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project (`./gradlew spotlessApply` run)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (full `ortus.boxlang.runtime.cache.*` test package, 100+ tests, all green)
