### PR TITLE
Add hotfix branch CI and manual snapshot-to-S3 publish workflow

### DIFF
--- a/.github/workflows/hotfix-snapshot.yml
+++ b/.github/workflows/hotfix-snapshot.yml
@@ -1,0 +1,39 @@
+# Manually-triggered snapshot build for hotfix branches.
+# Builds the project and publishes ONLY to S3 as a snapshot: no version bump, no git
+# tag, no GitHub Release, no GitHub Packages publish, no Maven Central publish, and
+# tests are not re-run here (the hotfix branch's push-triggered CI already ran them).
+name: Hotfix Snapshot
+
+on:
+  workflow_dispatch:
+
+#Cancel running builds if another push to branch is made while this build is running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Verify Hotfix Branch
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Ensure this workflow only runs from a hotfix/* branch
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" != hotfix/* ]]; then
+            echo "::error::This workflow can only be dispatched from a hotfix/* branch. Current branch: $REF_NAME"
+            exit 1
+          fi
+
+  build:
+    name: Build & Publish Hotfix Snapshot
+    needs: guard
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      snapshot: true
+      skipEvergreen: true

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,20 +1,13 @@
-name: Pull Requests
+name: Hotfix Branches
 
 on:
   push:
-    branches-ignore:
-      - "main"
-      - "development"
-      - "releases/**"
-      - "hotfix/**"
-  pull_request:
     branches:
-      - development
-      - "releases/**"
+      - "hotfix/**"
 
 #Cancel running builds if another push to branch is made while this build is running
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      skipEvergreen:
+        description: "Skip the evergreen 'latest snapshot' S3 upload (used by hotfix snapshots)"
+        required: false
+        default: false
+        type: boolean
 
   # Manual Trigger for LTS Releases
   workflow_dispatch:
@@ -59,20 +64,27 @@ jobs:
         id: current_version
         run: |
           TMPVERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
-          if [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
+
+          if [[ "$SNAPSHOT" == "true" ]]; then
             # Replace existing prerelease identifier with -snapshot or append -snapshot if none exists
-            TMPVERSION=$(echo $TMPVERSION | sed 's/-.*$//')-snapshot
+            TMPVERSION=$(echo $TMPVERSION | sed 's/-.*$//')
+            if [[ "$GITHUB_REF" == "refs/heads/development" ]]; then
+              TMPVERSION="${TMPVERSION}-snapshot"
+            else
+              # Non-development snapshot (e.g. hotfix/*): branch-scoped suffix so it
+              # never collides with development's version-keyed S3 path.
+              SAFE_BRANCH=$(echo "${GITHUB_REF#refs/heads/}" | tr -c 'a-zA-Z0-9' '-' | tr -s '-' | sed 's/^-//;s/-$//')
+              TMPVERSION="${TMPVERSION}-${SAFE_BRANCH}-snapshot"
+            fi
           fi
           echo "VERSION=$TMPVERSION" >> $GITHUB_ENV
 
           # Branche
           echo "Github Ref is $GITHUB_REF"
-          echo "BRANCH=main" >> $GITHUB_ENV
-
-          # Snapshot
-          if [ $GITHUB_REF == 'refs/heads/development' ]
-          then
+          if [[ "$SNAPSHOT" == "true" ]]; then
             echo "BRANCH=development" >> $GITHUB_ENV
+          else
+            echo "BRANCH=main" >> $GITHUB_ENV
           fi
 
       - name: Update changelog [unreleased] with latest version
@@ -126,6 +138,7 @@ jobs:
           DEST_DIR: "ortussolutions/boxlang/${{ env.VERSION }}"
 
       - name: Upload Evergreen Distributions to S3
+        if: inputs.skipEvergreen != true
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read
@@ -196,7 +209,7 @@ jobs:
   ##########################################################################################
   prep_next_release:
     name: Prep Next Release
-    if: github.ref != 'refs/heads/development'
+    if: inputs.snapshot != true
     runs-on: ubuntu-latest
     needs: [build]
     permissions:


### PR DESCRIPTION
# Description

Adds CI support for a `hotfix/*` branch workflow:

1. **`hotfix.yml`** (new) — runs the full test suite + `spotlessCheck` formatting check on every push to a `hotfix/*` branch, mirroring what `pr.yml` already does for other branches.
2. **`hotfix-snapshot.yml`** (new) — a `workflow_dispatch`-only workflow, guarded to only run from a `hotfix/*` branch, that builds the project and publishes a **snapshot to S3 only**: no version bump, no git tag, no GitHub Release, no GitHub Packages publish, no Maven Central publish, no changelog commit. Tests are intentionally skipped here since the branch's push-triggered CI (`hotfix.yml`) already validated the commit.

While wiring this up, found and fixed a root-cause bug in the existing release pipeline:

- **`release.yml`** — the logic that decides whether a build counts as a "snapshot" (both the S3 path/version string in this workflow, and the actual build artifact version computed in `build.gradle`) was hardcoded to a literal `github.ref == 'refs/heads/development'` check instead of the `snapshot` boolean input that already exists for exactly this purpose. This happened to work only because the one existing caller (`snapshot.yml`) always runs on `development`. Calling the pipeline from a `hotfix/*` branch would silently skip the `-snapshot` suffix and the release-only steps' guard. Fixed by keying the version-suffix and `BRANCH` env logic off the `snapshot` input directly, with a branch-scoped suffix (e.g. `1.17.0-hotfix-foo-snapshot`) for any non-`development` snapshot so a hotfix snapshot's S3 path can never collide with `development`'s.
- **`release.yml`** — `prep_next_release`'s job-level `if:` was also keyed off the same literal ref check (`github.ref != 'refs/heads/development'`), which would have incorrectly run for a hotfix snapshot build, checking out `development` and bumping its minor version as an unwanted side effect. Fixed to key off `inputs.snapshot` instead (the `env` context isn't valid in a job-level `if:`, so this uses the `inputs` context, which is available at job level for both `workflow_call` and `workflow_dispatch`).
- **`release.yml`** — added a new `skipEvergreen` boolean input (default `false`, backward compatible) to skip the "Upload Evergreen Distributions to S3" step, which uploads to a non-version-keyed path holding `development`'s shared "latest snapshot" alias files (`boxlang-snapshot.zip`/`.jar`). `hotfix-snapshot.yml` passes `skipEvergreen: true` so it never clobbers those.
- **`pr.yml`** — added `hotfix/**` to the `push.branches-ignore` list, since it wasn't excluded before and would otherwise double-trigger alongside the new `hotfix.yml` on every hotfix push.

All changes were traced against every existing trigger path (`push` to `main`/`master`, and `snapshot.yml`'s `workflow_call` from `development`) to confirm zero behavior change for the existing stable-release and development-snapshot flows — see the PR diff for `release.yml` for the exact conditionals.

No new secrets are required — `hotfix-snapshot.yml` reuses the existing AWS credentials (`secrets.AWS_ACCESS_KEY` / `secrets.AWS_ACCESS_SECRET`) via `secrets: inherit`.

## Jira Issues

No BoxLang Jira issue was created for this internal CI/tooling change — happy to add one if the team wants it tracked there.

## Type of change

- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project (workflow YAML validated, no Java changes in this PR)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective (not applicable — these are CI/CD workflow files; verification steps below)
- [x] New and existing unit tests pass locally with my changes (no application code changed)

## Verification performed

- Validated YAML syntax of all 4 changed/added workflow files.
- Simulated the version-suffix bash logic locally against all three trigger paths (`push main/master`, `snapshot.yml` on `development`, and a new `hotfix-snapshot.yml` dispatch from `hotfix/*`) to confirm correct `VERSION`/`BRANCH` output and no collisions.

## Suggested manual verification after merge
- Push to a `hotfix/*` branch and confirm `hotfix.yml` fires (and `pr.yml` does not double-fire).
- Manually dispatch `hotfix-snapshot.yml` from a `hotfix/*` branch and confirm it builds, skips tests, and uploads only to the version-keyed S3 paths (not the evergreen alias).
- Manually dispatch `hotfix-snapshot.yml` from a non-`hotfix/*` branch and confirm the `guard` job fails fast.


---
_Generated by [Claude Code](https://claude.ai/code/session_017UDXprEUiPmcHq75kq4iq5)_