### PR TITLE
loadTemplateRelative() cannot resolve unmapped absolute paths — regression in 1.17.0

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
+++ b/src/main/java/ortus/boxlang/runtime/runnables/RunnableLoader.java
@@ -371,7 +371,14 @@ public class RunnableLoader {
 	 * @return The BoxTemplate instance
 	 */
 	public BoxTemplate loadTemplateRelative( IBoxContext context, String path, boolean externalOnly ) {
-		// Make absolute. Force this to be relative given the method we're in. Absolute paths would need to use loadTemplateAbsolute()
+		// Absolute paths are routed to loadTemplateAbsolute() directly: expandPath()'s forceRelative=true
+		// path below never checks whether the incoming string is actually absolute (it assumes relative-
+		// to-mappings/closest-template resolution is always wanted), so a genuinely absolute path that
+		// matches no registered mapping was previously unresolvable even when the file exists on disk.
+		if ( Path.of( path ).isAbsolute() ) {
+			return loadTemplateAbsolute( context, FileSystemUtil.expandPath( context, path, externalOnly ) );
+		}
+		// Make absolute. Force this to be relative given the method we're in.
 		return loadTemplateAbsolute( context,
 		    FileSystemUtil.expandPath(
 		        context.getConfig().getAsStruct( Key.mappings ),

--- a/src/test/java/TestCases/phase2/IncludeTest.java
+++ b/src/test/java/TestCases/phase2/IncludeTest.java
@@ -76,6 +76,26 @@ public class IncludeTest {
 		assertThat( variables.get( result ) ).isEqualTo( "found the value before wood" );
 	}
 
+	@DisplayName( "can include file via a fully-resolved absolute path" )
+	@Test
+	public void testCanIncludeFileAbsolute() {
+		// A caller that already resolved and validated an absolute filesystem path itself (e.g. a web
+		// framework doing its own path-traversal check before rendering a view) should still be able to
+		// include it verbatim, without needing a registered mapping for it. Regression test for the case
+		// where loadTemplateRelative()'s forceRelative=true call into expandPath() never checked whether
+		// the incoming path was actually absolute, making any unmapped absolute path unresolvable.
+		String absolutePath = Paths.get( "src/test/java/TestCases/phase2/myInclude.cfs" ).toAbsolutePath().toString().replace( "\\", "\\\\" );
+		instance.executeSource(
+		    """
+		    myVar = "before"
+		       include "%s";
+		    result = fromInclude & " " & brad();
+		       """.formatted( absolutePath ),
+		    context );
+
+		assertThat( variables.get( result ) ).isEqualTo( "found the value before wood" );
+	}
+
 	@DisplayName( "can include file relative" )
 	@Test
 	public void testCanIncludeFileRelative() {


### PR DESCRIPTION
# Description

`RunnableLoader.loadTemplateRelative()` was changed to call the new mapping-aware `FileSystemUtil.expandPath(IStruct, String, ResolvedFilePath, boolean, boolean)` overload with `forceRelative` hardcoded `true`. Inside `expandPath`, when `forceRelative` is `true`, the method never checks whether the incoming path is actually absolute:

```java
boolean isAbsolute = forceRelative ? false : originalPathPath.isAbsolute();
```

The branch further down that resolves a genuinely absolute path that exists on disk depends on that same (forced-false) flag, so it's unreachable from `loadTemplateRelative()` — a fully absolute path that matches no registered `mappings` entry becomes unresolvable, even though the file is right there on disk. This is a regression: `loadTemplateRelative()` previously called a much simpler `expandPath` overload with no mapping/forced-relative logic at all.

This breaks any caller that pre-resolves an absolute path itself and passes it to a plain `include` statement — for example, [boxlang-express](https://github.com/ortus-boxlang/boxlang-express)'s `Response.render()` builds an absolute, validated view path (its own path-traversal check) and does `include "#templatePath#"`. Under this version, every single `res.render()` call fails, for every view, on every request:

```
The template path [/app/views/main/index.bxm] could not be found.
```

## Fix

Route genuinely absolute paths to `loadTemplateAbsolute()` directly in `loadTemplateRelative()`, which is exactly what the method's own existing comment already says should happen ("Absolute paths would need to use `loadTemplateAbsolute()`") — it just wasn't actually implemented:

```java
public BoxTemplate loadTemplateRelative( IBoxContext context, String path, boolean externalOnly ) {
    if ( Path.of( path ).isAbsolute() ) {
        return loadTemplateAbsolute( context, FileSystemUtil.expandPath( context, path, externalOnly ) );
    }
    return loadTemplateAbsolute( context,
        FileSystemUtil.expandPath(
            context.getConfig().getAsStruct( Key.mappings ),
            path,
            context.findClosestTemplate(),
            externalOnly,
            true
        )
    );
}
```

This leaves the new relative-to-closest-template/mapping resolution behavior fully intact for genuinely relative paths — it only restores the previously-working fallback for a path that is truly absolute.

## Testing

Added `IncludeTest.testCanIncludeFileAbsolute()`, which builds a real absolute filesystem path (no registered mapping covers it) and includes it verbatim. Verified:
- Fails on unpatched `development` with the exact reported error (`could not be found`)
- Passes with this fix
- Full `IncludeTest` suite (16 tests) and `spotlessJavaCheck` both pass with the fix applied

## Jira Issues

https://ortussolutions.atlassian.net/browse/BL-2650

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project (`spotlessJavaCheck` passes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
