### PR TITLE
Isolate async BIFs from caller's transaction context

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/async/BoxFuture.java
+++ b/src/main/java/ortus/boxlang/runtime/async/BoxFuture.java
@@ -37,6 +37,7 @@ import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.async.executors.BoxExecutor;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.context.RequestBoxContext;
+import ortus.boxlang.runtime.context.ThreadBoxContext;
 import ortus.boxlang.runtime.dynamic.Attempt;
 import ortus.boxlang.runtime.logging.BoxLangLogger;
 import ortus.boxlang.runtime.scopes.Key;
@@ -887,17 +888,16 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 		List<CompletableFuture<Object>>	futures		= array
 		    .stream()
 		    .map( item -> {
-				RequestBoxContext.registerDependentThread( context );
-				return CompletableFuture.supplyAsync( () -> {
+				return CompletableFuture.supplyAsync( () -> ThreadBoxContext.runInContext( context, true, ctx -> {
 						try {
 							// Apply the mapper function directly to each item
-							return new ortus.boxlang.runtime.interop.proxies.Function<>( mapper, context, null ).apply( item );
+							return new ortus.boxlang.runtime.interop.proxies.Function<>( mapper, ctx, null ).apply( item );
 						} catch ( Exception e ) {
 							allLogger.error( "Error executing mapper function on item", e );
 							// Handle error with error handler if provided, otherwise return exception struct
 							if ( errorHandler != null ) {
 								try {
-									return new ortus.boxlang.runtime.interop.proxies.Function<>( errorHandler, context, null ).apply( e );
+									return new ortus.boxlang.runtime.interop.proxies.Function<>( errorHandler, ctx, null ).apply( e );
 								} catch ( Exception handlerError ) {
 									allLogger.error( "Error in error handler", handlerError );
 									return ExceptionUtil.throwableToStruct( handlerError );
@@ -907,10 +907,8 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 							else {
 								return ExceptionUtil.throwableToStruct( e );
 							}
-						} finally {
-							RequestBoxContext.unregisterDependentThread( context );
 						}
-					},
+					} ),
 						// Bound the executor to the CompletableFuture
 						executor != null ? executor.executor() : ForkJoinPool.commonPool()
 					);
@@ -985,14 +983,13 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 			// and return a key-value pair with the processed value
 			// If an error occurs, it will return the key with an error struct
 		    .map( entry -> {
-				RequestBoxContext.registerDependentThread( context );
 				CompletableFuture<Map.Entry<Key, Object>> future = CompletableFuture
-					.supplyAsync( () -> {
+					.supplyAsync( () -> ( Map.Entry<Key, Object> ) ThreadBoxContext.runInContext( context, true, ctx -> {
 							try {
 								// Create key-value struct for the mapper function
 								IStruct itemStruct = Struct.of( Key.key, entry.getKey(), Key.value, entry.getValue() );
 								// Apply the mapper function to the itemStruct
-								Object mappedResult = (IStruct) new ortus.boxlang.runtime.interop.proxies.Function<>( mapper, context, null ).apply( itemStruct );
+								Object mappedResult = (IStruct) new ortus.boxlang.runtime.interop.proxies.Function<>( mapper, ctx, null ).apply( itemStruct );
 								if( !( mappedResult instanceof IStruct ) ) {
 									allLogger.error("Mapper function did not return an instance of IStruct. Returned: " + TypeUtil.getObjectName( mappedResult ));
 									throw new BoxRuntimeException( "Mapper function must return a struct, but it returned a: " + TypeUtil.getObjectName( mappedResult ) );
@@ -1008,7 +1005,7 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 								// Handle error with error handler if provided
 								if ( errorHandler != null ) {
 									try {
-										errorResult = new ortus.boxlang.runtime.interop.proxies.Function<>( errorHandler, context, null ).apply( e );
+										errorResult = new ortus.boxlang.runtime.interop.proxies.Function<>( errorHandler, ctx, null ).apply( e );
 									} catch ( Exception handlerError ) {
 										allLogger.error( "Error in error handler", handlerError );
 										errorResult = ExceptionUtil.throwableToStruct( handlerError );
@@ -1018,10 +1015,8 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 								}
 								// Return the key-error pair
 								return new AbstractMap.SimpleEntry<>( entry.getKey(), errorResult );
-							} finally {
-								RequestBoxContext.unregisterDependentThread( context );
 							}
-						},
+						} ),
 					executor != null ? executor.executor() : ForkJoinPool.commonPool()
 				);
 				return future;
@@ -1093,7 +1088,10 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 			    }
 			    // If it's a function, then wrap it in a Proxy Supplier
 			    else if ( future instanceof ortus.boxlang.runtime.types.Function castedFunction ) {
-				    targetFuture = run( new ortus.boxlang.runtime.interop.proxies.Supplier<>( castedFunction, context, null ), executorRecord.executor() );
+				    targetFuture = run(
+				        wrapSupplier( new ortus.boxlang.runtime.interop.proxies.Supplier<>( castedFunction, context, null ), context ),
+				        executorRecord.executor()
+				    );
 			    } else {
 				    throw new BoxRuntimeException(
 				        "Invalid future type: " + future.getClass().getSimpleName() +
@@ -1121,24 +1119,21 @@ public class BoxFuture<T> extends CompletableFuture<T> {
 	}
 
 	/**
-	 * Wraps a supplier with dependent thread tracking on the request context.
-	 * Registers the dependent thread immediately on the calling thread, and
-	 * unregisters it in a finally block when the supplier completes.
+	 * Wraps a supplier so it executes in a fresh, isolated {@link ThreadBoxContext}
+	 * when it runs on the executor thread. This gives the supplier its own
+	 * {@code ConnectionManager}/transaction state instead of sharing whatever
+	 * connection/transaction is active on the calling thread, matching the
+	 * isolation the {@code thread} component already provides.
+	 * Dependent thread tracking is handled by {@link ThreadBoxContext#runInContext}.
 	 *
 	 * @param supplier The supplier to wrap
-	 * @param context  The context to track dependent threads on
+	 * @param context  The calling context to use as the parent of the isolated context
 	 *
-	 * @return A wrapped supplier that handles thread registration
+	 * @return A wrapped supplier that runs in an isolated context
 	 */
+	@SuppressWarnings( "unchecked" )
 	public static <T> Supplier<T> wrapSupplier( Supplier<T> supplier, IBoxContext context ) {
-		RequestBoxContext.registerDependentThread( context );
-		return () -> {
-			try {
-				return supplier.get();
-			} finally {
-				RequestBoxContext.unregisterDependentThread( context );
-			}
-		};
+		return () -> ( T ) ThreadBoxContext.runInContext( context, true, ctx -> supplier.get() );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/async/AsyncTransactionIsolationTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/async/AsyncTransactionIsolationTest.java
@@ -1,0 +1,107 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.runtime.bifs.global.async;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.bifs.global.jdbc.BaseJDBCTest;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.Query;
+
+/**
+ * Verifies that {@code runAsync()}, {@code asyncAll()} and {@code asyncAllApply()} each execute
+ * with their own, isolated JDBC connection/transaction, instead of sharing the transaction that
+ * is active on the calling thread. This matches the behavior already provided by the {@code thread}
+ * component and other parallel BIFs (e.g. {@code arrayEach( parallel = true )}).
+ *
+ * @see <a href="https://ortussolutions.atlassian.net/browse/BL-2659">BL-2659</a>
+ */
+public class AsyncTransactionIsolationTest extends BaseJDBCTest {
+
+	static Key result = new Key( "result" );
+
+	@DisplayName( "runAsync() does not inherit the caller's transaction" )
+	@Test
+	public void testRunAsyncIsolatesTransaction() {
+		getInstance().executeSource(
+		    """
+		    transaction {
+		    	variables.inTransaction = isInTransaction();
+		    	variables.result = runAsync( () => isInTransaction() ).get();
+		    }
+		    """,
+		    getContext() );
+
+		assertThat( getVariables().get( Key.of( "inTransaction" ) ) ).isEqualTo( true );
+		assertThat( getVariables().get( result ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "asyncAll() does not inherit the caller's transaction" )
+	@Test
+	public void testAsyncAllIsolatesTransaction() {
+		getInstance().executeSource(
+		    """
+		    transaction {
+		    	variables.inTransaction = isInTransaction();
+		    	variables.result = asyncAll( [ () => isInTransaction() ] ).get();
+		    }
+		    """,
+		    getContext() );
+
+		assertThat( getVariables().get( Key.of( "inTransaction" ) ) ).isEqualTo( true );
+		Array asyncResults = ( Array ) getVariables().get( result );
+		assertThat( asyncResults.get( 0 ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "asyncAllApply() does not inherit the caller's transaction" )
+	@Test
+	public void testAsyncAllApplyIsolatesTransaction() {
+		getInstance().executeSource(
+		    """
+		    transaction {
+		    	variables.inTransaction = isInTransaction();
+		    	variables.result = asyncAllApply( [ 1 ], ( i ) => isInTransaction() );
+		    }
+		    """,
+		    getContext() );
+
+		assertThat( getVariables().get( Key.of( "inTransaction" ) ) ).isEqualTo( true );
+		Array asyncResults = ( Array ) getVariables().get( result );
+		assertThat( asyncResults.get( 0 ) ).isEqualTo( false );
+	}
+
+	@DisplayName( "runAsync() can still run its own query on a fresh connection outside of a transaction" )
+	@Test
+	public void testRunAsyncCanStillQuery() {
+		// The isolated context runAsync() executes in doesn't inherit the test datasource that
+		// BaseJDBCTest wires up as a per-instance default, so pass it explicitly here. A real
+		// application's `defaultDatasource` (Application.bx/boxlang.json) is looked up via the
+		// context chain and is unaffected by this isolation.
+		getInstance().executeSource(
+		    String.format(
+		        """
+		        variables.result = runAsync( () => queryExecute( "SELECT * FROM developers", {}, { datasource: "%s" } ) ).get();
+		        """, getDatasource().getConfiguration().getOriginalName() ),
+		    getContext() );
+
+		Query theResult = ( Query ) getVariables().get( result );
+		assertThat( theResult.size() ).isEqualTo( 4 );
+	}
+
+}


### PR DESCRIPTION
# Description

This change ensures that `runAsync()`, `asyncAll()`, and `asyncAllApply()` execute with their own isolated JDBC connection/transaction state, rather than inheriting the transaction active on the calling thread. This matches the behavior already provided by the `thread` component and other parallel BIFs (e.g., `arrayEach(parallel = true)`).

## Changes Made

- **BoxFuture.java**: Refactored async execution to use `ThreadBoxContext.runInContext()` instead of manual `RequestBoxContext` dependent thread tracking. This provides proper transaction isolation by executing async tasks in a fresh context.
  - Updated `allApplyArray()` to wrap supplier execution in isolated context
  - Updated `allApplyStruct()` to wrap supplier execution in isolated context  
  - Updated `all()` to use new `wrapSupplier()` helper for function-based futures
  - Simplified `wrapSupplier()` to use `ThreadBoxContext.runInContext()` for consistent isolation

- **AsyncTransactionIsolationTest.java** (new): Added comprehensive test suite verifying transaction isolation:
  - `testRunAsyncIsolatesTransaction()`: Verifies `runAsync()` doesn't inherit caller's transaction
  - `testAsyncAllIsolatesTransaction()`: Verifies `asyncAll()` doesn't inherit caller's transaction
  - `testAsyncAllApplyIsolatesTransaction()`: Verifies `asyncAllApply()` doesn't inherit caller's transaction
  - `testRunAsyncCanStillQuery()`: Confirms async tasks can still execute queries on fresh connections

## Jira Issues

> [BL-2659](https://ortussolutions.atlassian.net/browse/BL-2659)

## Type of change

- [x] Bug Fix
- [x] Improvement

## Testing

Added unit tests in `AsyncTransactionIsolationTest` that verify all three async BIFs properly isolate their execution context from the caller's transaction state. Tests confirm that:
1. Async tasks execute outside of any active transaction
2. Async tasks can still execute queries independently on fresh connections
3. The isolation behavior is consistent across all three async BIFs

https://claude.ai/code/session_01MmBYZo6gYTxm791LcA7HiF

[BL-2659]: https://ortussolutions.atlassian.net/browse/BL-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ