### PR TITLE
BL-2661: Upgrade HikariCP to 7.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ dependencies {
 	// https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
 	implementation 'ch.qos.logback:logback-classic:1.6.1'
 	// https://mvnrepository.com/artifact/com.zaxxer/HikariCP
-	implementation 'com.zaxxer:HikariCP:6.3.0'
+	implementation 'com.zaxxer:HikariCP:7.1.0'
 	// https://mvnrepository.com/artifact/org.ow2.asm/asm-tree
 	implementation 'org.ow2.asm:asm-tree:9.10.1'
 	// https://mvnrepository.com/artifact/org.ow2.asm/asm-util

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -181,9 +181,11 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 	private List<Key>				RESERVED_CONNECTION_PROPERTIES	= List.of(
 	    Key.leakDetectionThreshold,
 	    Key.autoCommit,
+	    Key.connectionLimit,
 	    Key.connectionString,
 	    Key.connectionTestQuery,
 	    Key.connectionTimeout,
+	    Key.custom,
 	    Key.driver,
 	    Key.dsn,
 	    Key.healthCheckRegistry,
@@ -198,6 +200,7 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 	    Key.password,
 	    Key.poolName,
 	    Key.port,
+	    Key.registerMbeans,
 	    Key.username );
 
 	/**
@@ -695,6 +698,9 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 		}
 		if ( properties.containsKey( Key.initializationFailTimeout ) ) {
 			result.setInitializationFailTimeout( LongCaster.cast( properties.getOrDefault( Key.initializationFailTimeout, 1 ) ) );
+		}
+		if ( properties.containsKey( Key.registerMbeans ) ) {
+			result.setRegisterMbeans( properties.getAsBoolean( Key.registerMbeans ) );
 		}
 
 		// ADD NON-RESERVED PROPERTIES

--- a/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
+++ b/src/main/java/ortus/boxlang/runtime/config/segments/DatasourceConfig.java
@@ -178,7 +178,7 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 	// List of keys to NOT set dynamically. All keys not in this list will use
 	// `addDataSourceProperty` to set the property and pass it to the JDBC driver.
 	// Please use the hikariConfig setters for any hikari-specific properties.
-	private List<Key>				RESERVED_CONNECTION_PROPERTIES	= List.of(
+	private static final List<Key>	RESERVED_CONNECTION_PROPERTIES	= List.of(
 	    Key.leakDetectionThreshold,
 	    Key.autoCommit,
 	    Key.connectionLimit,
@@ -705,9 +705,13 @@ public class DatasourceConfig implements Comparable<DatasourceConfig>, IConfigSe
 
 		// ADD NON-RESERVED PROPERTIES
 		// as Hikari properties
+		// Note: HikariCP 7.x forwards these to the JDBC driver as-is, preserving the original
+		// Java type instead of stringifying them ( as 6.x did ). We stringify here ourselves so
+		// stricter JDBC drivers ( e.g. Derby ) don't choke on a non-String property value.
 		properties.entrySet().stream()
 		    .filter( entry -> !RESERVED_CONNECTION_PROPERTIES.contains( entry.getKey() ) )
-		    .forEach( entry -> result.addDataSourceProperty( entry.getKey().getName(), entry.getValue() ) );
+		    .filter( entry -> entry.getValue() != null )
+		    .forEach( entry -> result.addDataSourceProperty( entry.getKey().getName(), entry.getValue().toString() ) );
 
 		return result;
 	}

--- a/src/main/java/ortus/boxlang/runtime/scopes/Key.java
+++ b/src/main/java/ortus/boxlang/runtime/scopes/Key.java
@@ -1151,6 +1151,7 @@ public class Key implements Comparable<Key>, Serializable {
 	public static final Key		minimumIdle							= Key.of( "minimumIdle" );
 	public static final Key		poolName							= Key.of( "poolName" );
 	public static final Key		initializationFailTimeout			= Key.of( "initializationFailTimeout" );
+	public static final Key		registerMbeans						= Key.of( "registerMbeans" );
 
 	// Transaction events
 	public static final Key		onTransactionBegin					= Key.of( "onTransactionBegin" );

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -50,6 +50,37 @@ class DatasourceConfigTest {
 		assertThat( hikariConfig.getJdbcUrl() ).isEqualTo( "jdbc:postgresql://localhost:5432/foo" );
 	}
 
+	@DisplayName( "It applies the registerMbeans default to the HikariConfig instead of forwarding it as a raw JDBC property" )
+	@Test
+	void testItAppliesRegisterMbeansToHikariConfig() {
+		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
+		    "connectionString", "jdbc:derby:memory:Foo;create=true"
+		) );
+		HikariConfig		hikariConfig	= datasource.toHikariConfig();
+
+		assertThat( hikariConfig.isRegisterMbeans() ).isTrue();
+		assertThat( hikariConfig.getDataSourceProperties().containsKey( "registerMbeans" ) ).isFalse();
+	}
+
+	@DisplayName( "It does not forward reserved connection properties as raw JDBC dataSourceProperties" )
+	@Test
+	void testReservedPropertiesAreNotForwardedAsDataSourceProperties() {
+		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
+		    "connectionString", "jdbc:derby:memory:Foo;create=true",
+		    "connectionLimit", -1
+		) );
+		HikariConfig		hikariConfig	= datasource.toHikariConfig();
+
+		// Every value handed to the JDBC driver as a raw dataSourceProperty must be a String:
+		// Hikari 7.x no longer stringifies dataSourceProperties for us, so a stray non-String
+		// value ( e.g. a Boolean or Integer default that was never wired to a HikariConfig
+		// setter ) will NPE inside stricter JDBC drivers like Derby.
+		hikariConfig.getDataSourceProperties().forEach( ( key, value ) -> assertThat( value ).isInstanceOf( String.class ) );
+		assertThat( hikariConfig.getDataSourceProperties().containsKey( "custom" ) ).isFalse();
+		assertThat( hikariConfig.getDataSourceProperties().containsKey( "connectionLimit" ) ).isFalse();
+		assertThat( hikariConfig.getMaximumPoolSize() ).isEqualTo( Integer.MAX_VALUE );
+	}
+
 	@DisplayName( "It supports plaintext datasource passwords" )
 	@Test
 	void testPlaintextDatasourcePassword() {

--- a/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
+++ b/src/test/java/ortus/boxlang/runtime/config/segments/DatasourceConfigTest.java
@@ -67,7 +67,9 @@ class DatasourceConfigTest {
 	void testReservedPropertiesAreNotForwardedAsDataSourceProperties() {
 		DatasourceConfig	datasource		= new DatasourceConfig( Key.of( "Foo" ), Struct.of(
 		    "connectionString", "jdbc:derby:memory:Foo;create=true",
-		    "connectionLimit", -1
+		    "connectionLimit", -1,
+		    "someVendorFlag", true,
+		    "someVendorTimeout", 42
 		) );
 		HikariConfig		hikariConfig	= datasource.toHikariConfig();
 
@@ -76,6 +78,8 @@ class DatasourceConfigTest {
 		// value ( e.g. a Boolean or Integer default that was never wired to a HikariConfig
 		// setter ) will NPE inside stricter JDBC drivers like Derby.
 		hikariConfig.getDataSourceProperties().forEach( ( key, value ) -> assertThat( value ).isInstanceOf( String.class ) );
+		assertThat( hikariConfig.getDataSourceProperties().get( "someVendorFlag" ) ).isEqualTo( "true" );
+		assertThat( hikariConfig.getDataSourceProperties().get( "someVendorTimeout" ) ).isEqualTo( "42" );
 		assertThat( hikariConfig.getDataSourceProperties().containsKey( "custom" ) ).isFalse();
 		assertThat( hikariConfig.getDataSourceProperties().containsKey( "connectionLimit" ) ).isFalse();
 		assertThat( hikariConfig.getMaximumPoolSize() ).isEqualTo( Integer.MAX_VALUE );


### PR DESCRIPTION
Jira: [BL-2661](https://ortussolutions.atlassian.net/browse/BL-2661)

## Summary

- Bumps `com.zaxxer:HikariCP` from `6.3.0` to `7.1.0` in `build.gradle`.
- Fixes a latent bug that HikariCP 7.x's stricter property handling exposed: HikariCP 6.3.0 stringified every `dataSourceProperties` value with `.toString()` before handing it to the JDBC driver; as of 6.3.1/7.x, `HikariConfig` forwards them via `Properties.putAll()`, preserving the original Java type. BoxLang's `DatasourceConfig.toHikariConfig()` was leaking a few internal/reserved keys into those raw driver properties:
  - `custom` — an `IStruct`, always present after config normalization.
  - `registerMbeans` — a `Boolean` applied as a global default to every datasource, but **never actually wired to `HikariConfig#setRegisterMbeans()`** — a pre-existing dormant no-op.
  - `connectionLimit` — an `Integer`, a CFConfig alias for `maxConnections` that was copied over but never stripped from the properties map.
  
  Under 6.3.0 this was silently harmless (everything got stringified into some throwaway string). Under 7.1.0, stricter drivers (Apache Derby, used throughout our JDBC test suite) throw a `NullPointerException` inside `Properties.put()` when handed a non-String property value, so **every** pooled Derby datasource failed to initialize.

## Fix

- Added `custom`, `registerMbeans`, and `connectionLimit` to `RESERVED_CONNECTION_PROPERTIES` so they're never forwarded as raw JDBC driver properties.
- Wired `registerMbeans` to `HikariConfig#setRegisterMbeans()` so the setting actually takes effect.
- Added a `Key.registerMbeans` constant.
- Added regression tests in `DatasourceConfigTest` asserting reserved properties never leak into `HikariConfig#getDataSourceProperties()`, that every forwarded dataSourceProperty value is a `String`, and that `registerMbeans` is applied to the pool config.

## Test plan

- [x] `./gradlew compileJava` — compiles clean against HikariCP 7.1.0.
- [x] Full JDBC/datasource test suite (25 test classes covering `DataSource`, `DatasourceConfig`, transactions, connection manager, JDBC BIFs/components, the Derby module, and JDBC-backed caching) — 0 failures.
- [x] Added new unit tests covering the exact regression (reserved properties leaking as non-String JDBC driver properties).
- [x] `./gradlew spotlessApply` — formatting clean.
- [x] Full project test suite (`./gradlew test`, ~9700 tests) — only 4 pre-existing failures, all unrelated to this change and specific to this sandboxed CI environment (an outbound `box install` network call, a proxy env var leaking into subprocess stdout assertions, and an external HTTP status-code test) — confirmed unrelated by inspecting each failure's stack trace.



[BL-2661]: https://ortussolutions.atlassian.net/browse/BL-2661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ