### PR TITLE
Fix CLI: -h/--help/--version only global when passed alone

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -942,21 +942,6 @@ public class BoxRunner {
 		List<String>	cliArgs			= new ArrayList<>();
 		String			actionCommand	= null;
 
-		// Global help/version: only recognized when they are the SOLE cli argument
-		// (e.g. `boxlang -h`, `boxlang --help`, `boxlang -v`, `boxlang --version`).
-		// If anything else is present - a module, a template, another flag - these
-		// tokens are left alone so a module or script can interpret them itself
-		// (e.g. `boxlang bxSites --help` must reach the bxSites module, not BoxLang's
-		// own help screen).
-		if ( args.length == 1 ) {
-			String onlyArgument = args[ 0 ];
-			if ( onlyArgument.equalsIgnoreCase( "--help" ) || onlyArgument.equalsIgnoreCase( "-h" ) ) {
-				showHelp = true;
-			} else if ( onlyArgument.equalsIgnoreCase( "--version" ) || onlyArgument.equalsIgnoreCase( "-v" ) ) {
-				showVersion = true;
-			}
-		}
-
 		// Pre-parse pass: extract the runtime startup flags (--bx-debug, --bx-config,
 		// --bx-home) from ANYWHERE in the argument list, including after a module: or
 		// template argument. These flags must ALWAYS be honored for runtime startup
@@ -964,7 +949,7 @@ public class BoxRunner {
 		// Once extracted, they are removed from the list so the main parse loop below
 		// never sees them. Both the space-separated (--bx-config /path) and equals
 		// (--bx-config=/path) forms are supported.
-		List<String> argsList = new ArrayList<>();
+		List<String>	argsList		= new ArrayList<>();
 		for ( int i = 0; i < args.length; i++ ) {
 			String arg = args[ i ];
 
@@ -1003,6 +988,22 @@ public class BoxRunner {
 			}
 
 			argsList.add( arg );
+		}
+
+		// Global help/version: only recognized when they are the SOLE remaining cli
+		// argument, AFTER the startup flags above (--bx-debug, --bx-config, --bx-home)
+		// have been extracted (e.g. `boxlang --bx-debug --help` still shows help).
+		// If anything else is present - a module, a template, another flag - these
+		// tokens are left alone so a module or script can interpret them itself
+		// (e.g. `boxlang bxSites --help` must reach the bxSites module, not BoxLang's
+		// own help screen).
+		if ( argsList.size() == 1 ) {
+			String onlyArgument = argsList.get( 0 );
+			if ( onlyArgument.equalsIgnoreCase( "--help" ) || onlyArgument.equalsIgnoreCase( "-h" ) ) {
+				showHelp = true;
+			} else if ( onlyArgument.equalsIgnoreCase( "--version" ) || onlyArgument.equalsIgnoreCase( "-v" ) ) {
+				showVersion = true;
+			}
 		}
 
 		// Consume args in order via the `current` variable

--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -942,6 +942,21 @@ public class BoxRunner {
 		List<String>	cliArgs			= new ArrayList<>();
 		String			actionCommand	= null;
 
+		// Global help/version: only recognized when they are the SOLE cli argument
+		// (e.g. `boxlang -h`, `boxlang --help`, `boxlang -v`, `boxlang --version`).
+		// If anything else is present - a module, a template, another flag - these
+		// tokens are left alone so a module or script can interpret them itself
+		// (e.g. `boxlang bxSites --help` must reach the bxSites module, not BoxLang's
+		// own help screen).
+		if ( args.length == 1 ) {
+			String onlyArgument = args[ 0 ];
+			if ( onlyArgument.equalsIgnoreCase( "--help" ) || onlyArgument.equalsIgnoreCase( "-h" ) ) {
+				showHelp = true;
+			} else if ( onlyArgument.equalsIgnoreCase( "--version" ) || onlyArgument.equalsIgnoreCase( "-v" ) ) {
+				showVersion = true;
+			}
+		}
+
 		// Pre-parse pass: extract the runtime startup flags (--bx-debug, --bx-config,
 		// --bx-home) from ANYWHERE in the argument list, including after a module: or
 		// template argument. These flags must ALWAYS be honored for runtime startup
@@ -949,7 +964,7 @@ public class BoxRunner {
 		// Once extracted, they are removed from the list so the main parse loop below
 		// never sees them. Both the space-separated (--bx-config /path) and equals
 		// (--bx-config=/path) forms are supported.
-		List<String>	argsList		= new ArrayList<>();
+		List<String> argsList = new ArrayList<>();
 		for ( int i = 0; i < args.length; i++ ) {
 			String arg = args[ i ];
 
@@ -1003,18 +1018,11 @@ public class BoxRunner {
 				break;
 			}
 
-			// Help Flag, we find and break off. Set the flag and let _main() handle
-			// printing help so we never call System.exit() outside of main().
-			if ( currentArgument.equalsIgnoreCase( "--help" ) || currentArgument.equalsIgnoreCase( "-h" ) ) {
-				showHelp = true;
-				break;
-			}
-
-			// ShowVersion mode Flag, we find and break off
-			if ( currentArgument.equalsIgnoreCase( "--version" ) ) {
-				showVersion = true;
-				break;
-			}
+			// NOTE: -h/--help/-v/--version are intentionally NOT special-cased here.
+			// They are only treated as global help/version when they are the SOLE cli
+			// argument (checked above, before this loop runs). Otherwise they fall
+			// through to the generic positional-argument branch below so they reach
+			// whatever module, action command, or template they were meant for.
 
 			// Print AST Flag, we find and continue to the next argument
 			if ( currentArgument.equalsIgnoreCase( "--bx-printAST" ) ) {
@@ -1105,12 +1113,15 @@ public class BoxRunner {
 	 */
 	static CLIOptions resolveExecutionTarget( CLIOptions options, Predicate<String> isModuleName ) {
 		// If a target was already resolved during parsing (module:, template, code or
-		// action command) or there are no positional arguments, there's nothing to do
+		// action command), there are no positional arguments, or the sole cli argument
+		// was the global -h/--help/-v/--version flag, there's nothing to do
 		if ( options.targetModule() != null
 		    || options.templatePath() != null
 		    || options.code() != null
 		    || options.actionCommand() != null
-		    || options.cliArgs().isEmpty() ) {
+		    || options.cliArgs().isEmpty()
+		    || Boolean.TRUE.equals( options.showHelp() )
+		    || Boolean.TRUE.equals( options.showVersion() ) ) {
 			return options;
 		}
 
@@ -1325,8 +1336,8 @@ public class BoxRunner {
 		System.out.println( "  java -jar boxlang.jar [OPTIONS] [FILE]        # 🐍 Using Java JAR" );
 		System.out.println();
 		System.out.println( "🔧 GLOBAL OPTIONS:" );
-		System.out.println( "  -h, --help                      ❓ Show this help message and exit" );
-		System.out.println( "      --version                   📋 Show version information and exit" );
+		System.out.println( "  -h, --help                      ❓ Show this help message and exit (only when passed alone)" );
+		System.out.println( "  -v, --version                   📋 Show version information and exit (only when passed alone)" );
 		System.out.println( "      --bx-debug                  🐛 Enable debug mode with timing information" );
 		System.out.println( "      --bx-config <PATH>          ⚙️  Use custom configuration file" );
 		System.out.println( "      --bx-home <PATH>           🏠 Set BoxLang runtime home directory" );

--- a/src/main/java/ortus/boxlang/runtime/BoxRunner.java
+++ b/src/main/java/ortus/boxlang/runtime/BoxRunner.java
@@ -173,13 +173,6 @@ public class BoxRunner {
 		// Parse CLI options with Env Overrides
 		CLIOptions	options	= parseEnvironmentVariables( parseCommandLineOptions( args ) );
 
-		// Show help? Handle this BEFORE starting the runtime so we never spin one up
-		// just to print usage.
-		if ( Boolean.TRUE.equals( options.showHelp() ) ) {
-			printHelp();
-			return 0;
-		}
-
 		// Debug mode?
 		if ( options.isDebugMode() ) {
 			System.out.println( "+++ Debug mode enabled!" );
@@ -212,13 +205,20 @@ public class BoxRunner {
 		try {
 			// Now that the runtime is loaded, resolve the first positional argument to
 			// its execution target: registered module > template > shebang script >
-			// module failsafe. The module registry is only available after startup, so
-			// this can't happen during arg parsing.
+			// global help/version > module failsafe. The module registry is only
+			// available after startup, so this can't happen during arg parsing - this
+			// also means a bare `-h`/`--version` now pays for runtime startup instead
+			// of short-circuiting before it, so a module/script literally named one of
+			// those strings can still claim it.
 			final BoxRuntime resolvedRuntime = boxRuntime;
 			options = resolveExecutionTarget( options, name -> resolvedRuntime.getModuleService().hasModule( Key.of( name ) ) );
 
+			// Show help
+			if ( Boolean.TRUE.equals( options.showHelp() ) ) {
+				printHelp();
+			}
 			// Execute a Module — modules trump ALL other execution modes
-			if ( options.targetModule() != null ) {
+			else if ( options.targetModule() != null ) {
 				System.setProperty( "boxlang.cliModule", options.targetModule() );
 				boxRuntime.executeModule( options.targetModule(), options.cliArgs().toArray( new String[ 0 ] ) );
 			}
@@ -990,22 +990,6 @@ public class BoxRunner {
 			argsList.add( arg );
 		}
 
-		// Global help/version: only recognized when they are the SOLE remaining cli
-		// argument, AFTER the startup flags above (--bx-debug, --bx-config, --bx-home)
-		// have been extracted (e.g. `boxlang --bx-debug --help` still shows help).
-		// If anything else is present - a module, a template, another flag - these
-		// tokens are left alone so a module or script can interpret them itself
-		// (e.g. `boxlang bxSites --help` must reach the bxSites module, not BoxLang's
-		// own help screen).
-		if ( argsList.size() == 1 ) {
-			String onlyArgument = argsList.get( 0 );
-			if ( onlyArgument.equalsIgnoreCase( "--help" ) || onlyArgument.equalsIgnoreCase( "-h" ) ) {
-				showHelp = true;
-			} else if ( onlyArgument.equalsIgnoreCase( "--version" ) || onlyArgument.equalsIgnoreCase( "-v" ) ) {
-				showVersion = true;
-			}
-		}
-
 		// Consume args in order via the `current` variable
 		while ( !argsList.isEmpty() ) {
 			currentArgument = argsList.remove( 0 );
@@ -1020,10 +1004,10 @@ public class BoxRunner {
 			}
 
 			// NOTE: -h/--help/-v/--version are intentionally NOT special-cased here.
-			// They are only treated as global help/version when they are the SOLE cli
-			// argument (checked above, before this loop runs). Otherwise they fall
-			// through to the generic positional-argument branch below so they reach
-			// whatever module, action command, or template they were meant for.
+			// They fall through to the generic positional-argument branch below like
+			// any other token; resolveExecutionTarget() decides later - once the
+			// module registry is available - whether they resolve to a real module,
+			// template, or script, or fall back to BoxLang's own global help/version.
 
 			// Print AST Flag, we find and continue to the next argument
 			if ( currentArgument.equalsIgnoreCase( "--bx-printAST" ) ) {
@@ -1091,11 +1075,17 @@ public class BoxRunner {
 	 * Priority:
 	 * <ol>
 	 * <li><strong>Registered module</strong> — the predicate reports this name
-	 * exists, so it's a module execution. This prevents the shebang and template
-	 * checks from hijacking a module execution.</li>
+	 * exists, so it's a module execution. This prevents the shebang, template, and
+	 * help/version checks from hijacking a module execution.</li>
 	 * <li><strong>Executable template</strong> — a valid template file on disk.</li>
 	 * <li><strong>Shebang script</strong> — a file whose first line starts with
 	 * {@code #!}.</li>
+	 * <li><strong>Global help/version</strong> — the first arg is
+	 * {@code -h}/{@code --help} or {@code -v}/{@code --version} and nothing concrete
+	 * (module, template, script) claims that name, so it's treated as a request for
+	 * BoxLang's own help/version screen rather than an attempted module execution.
+	 * A module, template, or script can still be literally named one of these and
+	 * win, since this check runs after 1-3.</li>
 	 * <li><strong>Module failsafe</strong> — nothing matched, so assume it's a
 	 * module name anyway. Preserves the historical end-of-parse behavior.</li>
 	 * </ol>
@@ -1114,15 +1104,12 @@ public class BoxRunner {
 	 */
 	static CLIOptions resolveExecutionTarget( CLIOptions options, Predicate<String> isModuleName ) {
 		// If a target was already resolved during parsing (module:, template, code or
-		// action command), there are no positional arguments, or the sole cli argument
-		// was the global -h/--help/-v/--version flag, there's nothing to do
+		// action command) or there are no positional arguments, there's nothing to do
 		if ( options.targetModule() != null
 		    || options.templatePath() != null
 		    || options.code() != null
 		    || options.actionCommand() != null
-		    || options.cliArgs().isEmpty()
-		    || Boolean.TRUE.equals( options.showHelp() )
-		    || Boolean.TRUE.equals( options.showVersion() ) ) {
+		    || options.cliArgs().isEmpty() ) {
 			return options;
 		}
 
@@ -1145,7 +1132,17 @@ public class BoxRunner {
 			return withTarget( options, getSheBangScript( firstArg ), rest );
 		}
 
-		// 4. Failsafe: treat the first arg as a module name
+		// 4. Global help/version - only once nothing concrete (module, template,
+		// script) has claimed the name, so a module/script literally named "-h" or
+		// "--version" still wins via checks 1-3 above.
+		if ( firstArg.equalsIgnoreCase( "--help" ) || firstArg.equalsIgnoreCase( "-h" ) ) {
+			return withShowHelp( options );
+		}
+		if ( firstArg.equalsIgnoreCase( "--version" ) || firstArg.equalsIgnoreCase( "-v" ) ) {
+			return withShowVersion( options );
+		}
+
+		// 5. Failsafe: treat the first arg as a module name
 		return withTargetModule( options, firstArg, rest );
 	}
 
@@ -1198,6 +1195,54 @@ public class BoxRunner {
 		    cliArgs,
 		    options.cliArgsRaw(),
 		    module,
+		    options.actionCommand() );
+	}
+
+	/**
+	 * Build a new CLIOptions with showHelp set and any target/positional args cleared.
+	 *
+	 * @param options The options to base the new options on
+	 *
+	 * @return A new CLIOptions instance
+	 */
+	private static CLIOptions withShowHelp( CLIOptions options ) {
+		return new CLIOptions(
+		    null,
+		    options.debug(),
+		    options.code(),
+		    options.configFile(),
+		    options.printAST(),
+		    options.transpile(),
+		    options.runtimeHome(),
+		    options.showVersion(),
+		    true,
+		    List.of(),
+		    options.cliArgsRaw(),
+		    null,
+		    options.actionCommand() );
+	}
+
+	/**
+	 * Build a new CLIOptions with showVersion set and any target/positional args cleared.
+	 *
+	 * @param options The options to base the new options on
+	 *
+	 * @return A new CLIOptions instance
+	 */
+	private static CLIOptions withShowVersion( CLIOptions options ) {
+		return new CLIOptions(
+		    null,
+		    options.debug(),
+		    options.code(),
+		    options.configFile(),
+		    options.printAST(),
+		    options.transpile(),
+		    options.runtimeHome(),
+		    true,
+		    options.showHelp(),
+		    List.of(),
+		    options.cliArgsRaw(),
+		    null,
 		    options.actionCommand() );
 	}
 

--- a/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
@@ -101,28 +101,13 @@ public class BoxRunnerParseTest {
 		assertThat( options.cliArgs() ).containsExactly( "arg1" ).inOrder();
 	}
 
-	@DisplayName( "It sets showHelp for --help" )
+	@DisplayName( "parseCommandLineOptions alone never sets showHelp/showVersion - that's resolveExecutionTarget's job" )
 	@Test
-	void testHelpFlag() {
+	void testHelpVersionNotSetByParseAlone() {
 		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--help" } );
 
-		assertThat( options.showHelp() ).isTrue();
-	}
-
-	@DisplayName( "It sets showVersion for --version" )
-	@Test
-	void testVersionFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--version" } );
-
-		assertThat( options.showVersion() ).isTrue();
-	}
-
-	@DisplayName( "It sets showVersion for the -v short form" )
-	@Test
-	void testVersionShortFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-v" } );
-
-		assertThat( options.showVersion() ).isTrue();
+		assertThat( options.showHelp() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "--help" );
 	}
 
 	@DisplayName( "It sets the code for --bx-code" )
@@ -213,81 +198,6 @@ public class BoxRunnerParseTest {
 		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-transpile" } );
 
 		assertThat( options.transpile() ).isTrue();
-	}
-
-	@DisplayName( "It sets showHelp for the -h short form" )
-	@Test
-	void testHelpShortFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-h" } );
-
-		assertThat( options.showHelp() ).isTrue();
-	}
-
-	@DisplayName( "Neither help nor version fire when both are present together (not the sole argument)" )
-	@Test
-	void testHelpAndVersionTogetherAreNotGlobal() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--help", "--version" } );
-
-		assertThat( options.showHelp() ).isFalse();
-		assertThat( options.showVersion() ).isFalse();
-		assertThat( options.cliArgs() ).containsExactly( "--help", "--version" ).inOrder();
-	}
-
-	@DisplayName( "--help does not trigger global help when other args are present" )
-	@Test
-	void testHelpNotGlobalWithOtherArgs() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--help", "extra" } );
-
-		assertThat( options.showHelp() ).isFalse();
-		assertThat( options.cliArgs() ).containsExactly( "--help", "extra" ).inOrder();
-	}
-
-	@DisplayName( "-h does not trigger global help when other args are present" )
-	@Test
-	void testHelpShortFlagNotGlobalWithOtherArgs() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-h", "extra" } );
-
-		assertThat( options.showHelp() ).isFalse();
-		assertThat( options.cliArgs() ).containsExactly( "-h", "extra" ).inOrder();
-	}
-
-	@DisplayName( "-v does not trigger global version when other args are present" )
-	@Test
-	void testVersionShortFlagNotGlobalWithOtherArgs() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-v", "extra" } );
-
-		assertThat( options.showVersion() ).isFalse();
-		assertThat( options.cliArgs() ).containsExactly( "-v", "extra" ).inOrder();
-	}
-
-	@DisplayName( "--help still shows global help when combined only with a startup flag like --bx-debug" )
-	@Test
-	void testHelpStillGlobalWithStartupFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-debug", "--help" } );
-
-		assertThat( options.showHelp() ).isTrue();
-		assertThat( options.isDebugMode() ).isTrue();
-		assertThat( options.targetModule() ).isNull();
-	}
-
-	@DisplayName( "--version still shows global version when combined only with a startup flag like --bx-home=" )
-	@Test
-	void testVersionStillGlobalWithStartupFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-home=/x", "--version" } );
-
-		assertThat( options.showVersion() ).isTrue();
-		assertThat( options.runtimeHome() ).isEqualTo( "/x" );
-		assertThat( options.targetModule() ).isNull();
-	}
-
-	@DisplayName( "-h still shows global help when combined only with a space-separated startup flag" )
-	@Test
-	void testHelpShortFlagStillGlobalWithStartupFlag() {
-		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-config", "/path/config.json", "-h" } );
-
-		assertThat( options.showHelp() ).isTrue();
-		assertThat( options.configFile() ).isEqualTo( "/path/config.json" );
-		assertThat( options.targetModule() ).isNull();
 	}
 
 	@DisplayName( "A bare module name receives a trailing -h instead of it triggering global help" )
@@ -496,7 +406,7 @@ public class BoxRunnerParseTest {
 		assertThat( options.cliArgs() ).containsExactly( "arg1" ).inOrder();
 	}
 
-	@DisplayName( "It does nothing when there are no positional args" )
+	@DisplayName( "It resolves a lone --version to global version instead of a module attempt" )
 	@Test
 	void testNoPositionals() {
 		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--version" } );
@@ -505,6 +415,118 @@ public class BoxRunnerParseTest {
 		assertThat( options.showVersion() ).isTrue();
 		assertThat( options.targetModule() ).isNull();
 		assertThat( options.templatePath() ).isNull();
+	}
+
+	@DisplayName( "It does nothing when there are no positional args at all" )
+	@Test
+	void testTrulyEmptyCliArgs() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--bx-debug" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isFalse();
+		assertThat( options.showVersion() ).isFalse();
+		assertThat( options.targetModule() ).isNull();
+		assertThat( options.templatePath() ).isNull();
+	}
+
+	@DisplayName( "It resolves --help to global help when nothing claims the name as a module/template/script" )
+	@Test
+	void testHelpResolvesGlobal() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--help" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "It resolves the -h short form to global help" )
+	@Test
+	void testHelpShortFlagResolvesGlobal() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "-h" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+	}
+
+	@DisplayName( "It resolves the -v short form to global version" )
+	@Test
+	void testVersionShortFlagResolvesGlobal() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "-v" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showVersion() ).isTrue();
+	}
+
+	@DisplayName( "--help still resolves to global help with trailing args, once nothing claims it as a target" )
+	@Test
+	void testHelpResolvesGlobalWithTrailingArgs() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--help", "extra" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+	}
+
+	@DisplayName( "The first of --help/--version wins when both are present and neither is a module" )
+	@Test
+	void testHelpWinsWhenFirst() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--help", "--version" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.showVersion() ).isFalse();
+	}
+
+	@DisplayName( "--version wins when it comes before --help instead" )
+	@Test
+	void testVersionWinsWhenFirst() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--version", "--help" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showVersion() ).isTrue();
+		assertThat( options.showHelp() ).isFalse();
+	}
+
+	@DisplayName( "--help still resolves to global help when combined only with a startup flag like --bx-debug" )
+	@Test
+	void testHelpStillGlobalWithStartupFlag() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--bx-debug", "--help" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.isDebugMode() ).isTrue();
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "--version still resolves to global version when combined only with a startup flag like --bx-home=" )
+	@Test
+	void testVersionStillGlobalWithStartupFlag() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--bx-home=/x", "--version" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showVersion() ).isTrue();
+		assertThat( options.runtimeHome() ).isEqualTo( "/x" );
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "-h still resolves to global help when combined only with a space-separated startup flag" )
+	@Test
+	void testHelpShortFlagStillGlobalWithStartupFlag() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "--bx-config", "/path/config.json", "-h" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> false );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.configFile() ).isEqualTo( "/path/config.json" );
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "A module registered under the exact name -h wins over global help" )
+	@Test
+	void testModuleNamedLikeHelpFlagWins() {
+		CLIOptions	parsed	= BoxRunner.parseCommandLineOptions( new String[] { "-h" } );
+		CLIOptions	options	= BoxRunner.resolveExecutionTarget( parsed, name -> name.equals( "-h" ) );
+
+		assertThat( options.targetModule() ).isEqualTo( "-h" );
+		assertThat( options.showHelp() ).isFalse();
 	}
 
 	@DisplayName( "A registered module wins over an existing file with the same name" )

--- a/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
@@ -117,6 +117,14 @@ public class BoxRunnerParseTest {
 		assertThat( options.showVersion() ).isTrue();
 	}
 
+	@DisplayName( "It sets showVersion for the -v short form" )
+	@Test
+	void testVersionShortFlag() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-v" } );
+
+		assertThat( options.showVersion() ).isTrue();
+	}
+
 	@DisplayName( "It sets the code for --bx-code" )
 	@Test
 	void testCodeFlag() {
@@ -215,13 +223,56 @@ public class BoxRunnerParseTest {
 		assertThat( options.showHelp() ).isTrue();
 	}
 
-	@DisplayName( "Help wins over version when both are present" )
+	@DisplayName( "Neither help nor version fire when both are present together (not the sole argument)" )
 	@Test
-	void testHelpWinsOverVersion() {
+	void testHelpAndVersionTogetherAreNotGlobal() {
 		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--help", "--version" } );
 
-		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.showHelp() ).isFalse();
 		assertThat( options.showVersion() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "--help", "--version" ).inOrder();
+	}
+
+	@DisplayName( "--help does not trigger global help when other args are present" )
+	@Test
+	void testHelpNotGlobalWithOtherArgs() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--help", "extra" } );
+
+		assertThat( options.showHelp() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "--help", "extra" ).inOrder();
+	}
+
+	@DisplayName( "-h does not trigger global help when other args are present" )
+	@Test
+	void testHelpShortFlagNotGlobalWithOtherArgs() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-h", "extra" } );
+
+		assertThat( options.showHelp() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "-h", "extra" ).inOrder();
+	}
+
+	@DisplayName( "-v does not trigger global version when other args are present" )
+	@Test
+	void testVersionShortFlagNotGlobalWithOtherArgs() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "-v", "extra" } );
+
+		assertThat( options.showVersion() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "-v", "extra" ).inOrder();
+	}
+
+	@DisplayName( "A bare module name receives a trailing -h instead of it triggering global help" )
+	@Test
+	void testBareModuleReceivesHelpFlag() {
+		CLIOptions parsed = BoxRunner.parseCommandLineOptions( new String[] { "bxSites", "-h" } );
+
+		assertThat( parsed.showHelp() ).isFalse();
+		assertThat( parsed.cliArgs() ).containsExactly( "bxSites", "-h" ).inOrder();
+
+		CLIOptions options = BoxRunner.resolveExecutionTarget( parsed, name -> name.equals( "bxSites" ) );
+
+		assertThat( options.targetModule() ).isEqualTo( "bxSites" );
+		assertThat( options.showHelp() ).isFalse();
+		assertThat( options.cliArgs() ).containsExactly( "-h" ).inOrder();
 	}
 
 	@DisplayName( "It throws when --bx-code is missing its value" )

--- a/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
+++ b/src/test/java/ortus/boxlang/runtime/BoxRunnerParseTest.java
@@ -260,6 +260,36 @@ public class BoxRunnerParseTest {
 		assertThat( options.cliArgs() ).containsExactly( "-v", "extra" ).inOrder();
 	}
 
+	@DisplayName( "--help still shows global help when combined only with a startup flag like --bx-debug" )
+	@Test
+	void testHelpStillGlobalWithStartupFlag() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-debug", "--help" } );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.isDebugMode() ).isTrue();
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "--version still shows global version when combined only with a startup flag like --bx-home=" )
+	@Test
+	void testVersionStillGlobalWithStartupFlag() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-home=/x", "--version" } );
+
+		assertThat( options.showVersion() ).isTrue();
+		assertThat( options.runtimeHome() ).isEqualTo( "/x" );
+		assertThat( options.targetModule() ).isNull();
+	}
+
+	@DisplayName( "-h still shows global help when combined only with a space-separated startup flag" )
+	@Test
+	void testHelpShortFlagStillGlobalWithStartupFlag() {
+		CLIOptions options = BoxRunner.parseCommandLineOptions( new String[] { "--bx-config", "/path/config.json", "-h" } );
+
+		assertThat( options.showHelp() ).isTrue();
+		assertThat( options.configFile() ).isEqualTo( "/path/config.json" );
+		assertThat( options.targetModule() ).isNull();
+	}
+
 	@DisplayName( "A bare module name receives a trailing -h instead of it triggering global help" )
 	@Test
 	void testBareModuleReceivesHelpFlag() {


### PR DESCRIPTION
# Description

`boxlang bxSites -h` (or `--help`) was printing BoxLang's own global help screen instead of routing to the `bxSites` module so it could show its own help.

Root cause: `-h`/`--help`/`--version` were matched as context-free flags anywhere in the CLI argument list, inside `BoxRunner.parseCommandLineOptions()`'s single left-to-right parse loop, decided before the runtime (and its module registry) even existed.

## Design

Rather than special-casing help/version during argument parsing, `-h`/`--help`/`-v`/`--version` are now resolved in `resolveExecutionTarget()` — the same place that already classifies the first CLI argument as a module, template, or shebang script, after the runtime has started. Priority order:

1. Registered module
2. Executable template file
3. Shebang script
4. **Global help/version** — only once nothing concrete (module/template/script) claims the name
5. Module failsafe (attempt module execution, error if not found)

So `boxlang -h` still shows BoxLang's help, `boxlang --version`/`-v` still shows the version, but a module (or template/script) can be literally named `-h`/`--version`/etc. and win instead — and `boxlang bxSites -h` correctly routes to the `bxSites` module, since `bxSites` (not `-h`) is the first argument being classified.

`parseCommandLineOptions()` no longer special-cases these flags at all — they flow through like any other token.

**Trade-off:** a bare `boxlang -h`/`--version` now starts the BoxLang runtime before showing help/version (needed to consult the module registry), instead of short-circuiting before runtime startup as before.

Also added `-v` as a short alias for `--version`, mirroring the existing `-h` alias for `--help`.

## Jira Issues

- https://ortussolutions.atlassian.net/browse/BL-2663

## Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) (ran `./gradlew spotlessApply`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`BoxRunnerParseTest`, 57/57 passing; also smoke-tested against a built jar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs6zUK8Shc5FXGnrPHa5Mx