### PR TITLE
BL-2523 structFindKey now descends into arrays

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/types/util/StructUtil.java
+++ b/src/main/java/ortus/boxlang/runtime/types/util/StructUtil.java
@@ -842,8 +842,18 @@ public class StructUtil {
 			}
 
 			// If the value is a struct, recursively search it
-			if ( value instanceof IStruct ) {
-				findKeyRecursive( rootStruct, ( IStruct ) value, searchKey, fullPath, results );
+			if ( value instanceof IStruct nestedStruct ) {
+				findKeyRecursive( rootStruct, nestedStruct, searchKey, fullPath, results );
+			} else if ( value instanceof List<?> list ) {
+				// Structs nested inside an array are part of the same object graph, so descend into them too.
+				// Paths carry a 1-based array index, matching findValue().
+				int index = 1;
+				for ( Object item : list ) {
+					if ( item instanceof Map ) {
+						findKeyRecursive( rootStruct, StructCaster.cast( item ), searchKey, fullPath + "[" + index + "]", results );
+					}
+					index++;
+				}
 			}
 		}
 	}

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructFindKeyTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructFindKeyTest.java
@@ -418,7 +418,7 @@ public class StructFindKeyTest {
 		assertEquals( "This is an advisory", match.getAsStruct( Key.owner ).getAsString( Key.of( "text" ) ) );
 	}
 
-	@DisplayName( "It finds keys across multiple array entries and nested arrays - BL-2523" )
+	@DisplayName( "It finds keys across multiple array entries and nested structs - BL-2523" )
 	@Test
 	public void testFindsKeysAcrossMultipleArrayEntries() {
 		//@formatter:off

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructFindKeyTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/struct/StructFindKeyTest.java
@@ -385,4 +385,62 @@ public class StructFindKeyTest {
 
 	}
 
+	@DisplayName( "It finds keys inside structs nested in arrays - BL-2523" )
+	@Test
+	public void testFindsKeysWithinArrays() {
+		//@formatter:off
+		instance.executeSource(
+		    """
+		    myResponse = {
+		        "advisories": [
+		            {
+		                "code": 3780,
+		                "errorLevel": 5,
+		                "text": "This is an advisory",
+		                "message": "",
+		                "textCode": ""
+		            }
+		        ]
+		    };
+		    result = structFindKey( myResponse, "code", "all" );
+		    """,
+		    context );
+		//@formatter:on
+
+		Array found = variables.getAsArray( result );
+		assertEquals( 1, found.size() );
+
+		IStruct match = StructCaster.cast( found.get( 0 ) );
+		assertEquals( 3780, match.get( Key.value ) );
+		// Path carries the 1-based array index, matching structFindValue()
+		assertEquals( ".advisories[1].code", match.getAsString( Key.path ) );
+		// The owner is the struct inside the array, not the outer response
+		assertEquals( "This is an advisory", match.getAsStruct( Key.owner ).getAsString( Key.of( "text" ) ) );
+	}
+
+	@DisplayName( "It finds keys across multiple array entries and nested arrays - BL-2523" )
+	@Test
+	public void testFindsKeysAcrossMultipleArrayEntries() {
+		//@formatter:off
+		instance.executeSource(
+		    """
+		    myResponse = {
+		        "advisories": [
+		            { "code": 1, "detail": { "code": 2 } },
+		            { "code": 3 }
+		        ],
+		        "code": 0
+		    };
+		    result = structFindKey( myResponse, "code", "all" );
+		    single = structFindKey( myResponse, "code" );
+		    """,
+		    context );
+		//@formatter:on
+
+		// Top level, both array entries, and the struct nested under an array entry
+		assertEquals( 4, variables.getAsArray( result ).size() );
+		// "one" scope still returns a single match
+		assertEquals( 1, variables.getAsArray( Key.of( "single" ) ).size() );
+	}
+
 }


### PR DESCRIPTION
# Description

`findKeyRecursive` only recursed when a value was an `IStruct`, so keys inside structs nested in an array were never visited and `structFindKey` returned nothing for them — the case in BL-2523.

`structFindValue` already handles this via `extractValuesFromArrays`. This brings `findKey` in line and uses the same 1-based array index in the returned path, so `.advisories[1].code` matches what `structFindValue` produces for the same graph.

Two tests added: the exact repro from the ticket (asserting value, path and owner), and one covering multiple array entries plus a struct nested under an array entry to pin the `all` vs `one` scope behaviour.

## Jira Issues

BL-2523

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
