### PR TITLE
BL-2569 Java exception message is an empty string, not null

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
+++ b/src/main/java/ortus/boxlang/runtime/interop/DynamicInteropService.java
@@ -2192,7 +2192,10 @@ public class DynamicInteropService {
 		} else if ( targetInstance instanceof Throwable t && exceptionKeys.contains( name ) ) {
 			// Throwable.message always delegates through to the message field
 			if ( name.equals( Key.message ) ) {
-				return t.getMessage();
+				// A raw Java exception can carry a null message, but CFML always exposes an empty string,
+				// matching the empty string returned for the other exception keys below
+				String message = t.getMessage();
+				return message == null ? "" : message;
 			} else if ( name.equals( Key.cause ) ) {
 				return t.getCause();
 			} else if ( name.equals( Key.stackTrace ) ) {

--- a/src/test/java/ortus/boxlang/runtime/interop/DynamicInteropServiceTest.java
+++ b/src/test/java/ortus/boxlang/runtime/interop/DynamicInteropServiceTest.java
@@ -1540,4 +1540,43 @@ public class DynamicInteropServiceTest {
 		assertThat( result ).isEqualTo( "brad" );
 	}
 
+	@DisplayName( "A Java exception with a null message exposes an empty string - BL-2569" )
+	@Test
+	void testJavaExceptionNullMessageIsEmptyString() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			try {
+				throw( createObject( "java", "java.lang.RuntimeException" ).init() );
+			} catch( any e ) {
+				result = e.message;
+				wasNull = isNull( e.message );
+				concatenated = "[" & e.message & "]";
+			}
+			""", context);
+		// @formatter:on
+
+		// Lucee and ACF always surface an empty string here, never null
+		assertThat( variables.get( Key.result ) ).isEqualTo( "" );
+		assertThat( variables.get( Key.of( "wasNull" ) ) ).isEqualTo( false );
+		assertThat( variables.get( Key.of( "concatenated" ) ) ).isEqualTo( "[]" );
+	}
+
+	@DisplayName( "A Java exception with a real message still passes it through - BL-2569" )
+	@Test
+	void testJavaExceptionMessageStillPassesThrough() {
+		// @formatter:off
+		instance.executeSource(
+			"""
+			try {
+				throw( createObject( "java", "java.lang.RuntimeException" ).init( "boom" ) );
+			} catch( any e ) {
+				result = e.message;
+			}
+			""", context);
+		// @formatter:on
+
+		assertThat( variables.get( Key.result ) ).isEqualTo( "boom" );
+	}
+
 }


### PR DESCRIPTION
# Description

Dereferencing `message` on a raw Java exception returned `Throwable.getMessage()` straight through, which is `null` for exceptions constructed without a message. Lucee and ACF always surface an empty string, so `e.message` was null-safe on those engines and not here.

The other keys in `exceptionKeys` already return `""` when absent — `message` was the odd one out.

Two tests: a `java.lang.RuntimeException` thrown with no message now yields `""` (and `isNull()` is false, and it concatenates cleanly), and one asserting a real message still passes through untouched.

## Jira Issues

BL-2569

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
