### PR TITLE
BL-2676 Fix numeric coercion of JDBC parameter metadata

### DIFF
--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryParameter.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryParameter.java
@@ -105,7 +105,7 @@ public class QueryParameter {
 		this.value		= this.isNullParam ? null : v;
 		this.sqltype	= RegexBuilder.of( sqltype, RegexBuilder.CF_SQL ).replaceAllAndGet( "" ).toUpperCase().trim();
 		this.type		= QueryColumnType.fromString( this.sqltype );
-		this.maxLength	= param.getAsInteger( Key.maxLength );
+		this.maxLength	= param.get( Key.maxLength ) == null ? null : IntegerCaster.cast( param.get( Key.maxLength ) );
 		this.scale		= param.get( Key.scale ) == null ? null : IntegerCaster.cast( param.get( Key.scale ) );
 	}
 

--- a/src/main/java/ortus/boxlang/runtime/jdbc/QueryParameter.java
+++ b/src/main/java/ortus/boxlang/runtime/jdbc/QueryParameter.java
@@ -17,6 +17,7 @@ package ortus.boxlang.runtime.jdbc;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.CastAttempt;
+import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.scopes.Key;
@@ -105,7 +106,7 @@ public class QueryParameter {
 		this.sqltype	= RegexBuilder.of( sqltype, RegexBuilder.CF_SQL ).replaceAllAndGet( "" ).toUpperCase().trim();
 		this.type		= QueryColumnType.fromString( this.sqltype );
 		this.maxLength	= param.getAsInteger( Key.maxLength );
-		this.scale		= param.getAsInteger( Key.scale );
+		this.scale		= param.get( Key.scale ) == null ? null : IntegerCaster.cast( param.get( Key.scale ) );
 	}
 
 	/**

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.List;
 
@@ -48,6 +49,28 @@ import tools.JDBCTestUtils;
 public class QueryExecuteTest extends BaseJDBCTest {
 
 	static Key result = new Key( "result" );
+
+	@DisplayName( "It inserts decimal bindings with a Double scale" )
+	@Test
+	public void testDecimalBindingWithNumericScale() {
+		this.variables.put( Key.scale, 2.0D );
+		this.variables.put( Key.value, new BigDecimal( "12.50" ) );
+		instance.executeSource(
+		    """
+		    queryExecute( "CREATE TABLE decimal_scale_test (amount DECIMAL(12, 2))" );
+		    try {
+		        queryExecute( "INSERT INTO decimal_scale_test (amount) VALUES (:amount)",
+		            { amount: { value: value, sqltype: "decimal", scale: scale } } );
+		        result = queryExecute( "SELECT amount FROM decimal_scale_test" );
+		    } finally {
+		        queryExecute( "DROP TABLE decimal_scale_test" );
+		    }
+		    """,
+		    this.context );
+		Query query = this.variables.getAsQuery( result );
+		assertThat( query.size() ).isEqualTo( 1 );
+		assertThat( query.getRowAsStruct( 0 ).get( "amount" ) ).isEqualTo( new BigDecimal( "12.50" ) );
+	}
 
 	@DisplayName( "It can execute a query with no bindings on the default datasource" )
 	@Test

--- a/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
+++ b/src/test/java/ortus/boxlang/runtime/bifs/global/jdbc/QueryExecuteTest.java
@@ -50,6 +50,21 @@ public class QueryExecuteTest extends BaseJDBCTest {
 
 	static Key result = new Key( "result" );
 
+	@DisplayName( "It executes a query with a Double maxLength in a raw parameter struct" )
+	@Test
+	public void testStringBindingWithNumericMaxLength() {
+		this.variables.put( Key.maxLength, 13.0D );
+		instance.executeSource(
+		    """
+		    result = queryExecute( "SELECT id FROM developers WHERE name = :name",
+		        { name: { value: "Eric Peterson", sqltype: "varchar", maxLength: maxLength } } );
+		    """,
+		    this.context );
+		Query query = this.variables.getAsQuery( result );
+		assertThat( query.size() ).isEqualTo( 1 );
+		assertThat( query.getRowAsStruct( 0 ).get( "id" ) ).isEqualTo( 42 );
+	}
+
 	@DisplayName( "It inserts decimal bindings with a Double scale" )
 	@Test
 	public void testDecimalBindingWithNumericScale() {

--- a/src/test/java/ortus/boxlang/runtime/jdbc/QueryParameterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/QueryParameterTest.java
@@ -1,0 +1,67 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.runtime.jdbc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.exceptions.BoxCastException;
+
+public class QueryParameterTest {
+
+	static Stream<Object> numericScales() {
+		return Stream.of( ( byte ) 2, ( short ) 2, 2, 2L, 2.0F, 2.0D, new BigInteger( "2" ), new BigDecimal( "2.00" ), "2.0" );
+	}
+
+	@ParameterizedTest
+	@MethodSource( "numericScales" )
+	void testNumericScaleCoercion( Object scale ) {
+		QueryParameter parameter = QueryParameter.fromAny( Struct.of( Key.value, new BigDecimal( "12.50" ), Key.sqltype, "decimal", Key.scale, scale ) );
+		assertThat( parameter.getScaleOrLength() ).isEqualTo( 2 );
+	}
+
+	static Stream<Object> invalidScales() {
+		return Stream.of( 2.5D, 2.5F, new BigDecimal( "2.5" ), "2.5", "invalid", Double.NaN, Double.POSITIVE_INFINITY,
+		    Double.NEGATIVE_INFINITY, 2147483648L, -2147483649L, new BigInteger( "2147483648" ), new BigDecimal( "2147483648" ) );
+	}
+
+	@ParameterizedTest
+	@MethodSource( "invalidScales" )
+	void testInvalidScaleRejected( Object scale ) {
+		assertThrows( BoxCastException.class,
+		    () -> QueryParameter.fromAny( Struct.of( Key.value, 12.5, Key.sqltype, "decimal", Key.scale, scale ) ) );
+	}
+
+	@Test
+	void testOptionalScale() {
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, 12.5, Key.sqltype, "decimal" ) ).getScaleOrLength() ).isNull();
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, 12.5, Key.sqltype, "decimal", Key.scale, null ) ).getScaleOrLength() ).isNull();
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, 12, Key.sqltype, "decimal", Key.scale, 0.0D ) ).getScaleOrLength() ).isEqualTo( 0 );
+	}
+}

--- a/src/test/java/ortus/boxlang/runtime/jdbc/QueryParameterTest.java
+++ b/src/test/java/ortus/boxlang/runtime/jdbc/QueryParameterTest.java
@@ -35,24 +35,24 @@ import ortus.boxlang.runtime.types.exceptions.BoxCastException;
 
 public class QueryParameterTest {
 
-	static Stream<Object> numericScales() {
+	static Stream<Object> numericMetadataValues() {
 		return Stream.of( ( byte ) 2, ( short ) 2, 2, 2L, 2.0F, 2.0D, new BigInteger( "2" ), new BigDecimal( "2.00" ), "2.0" );
 	}
 
 	@ParameterizedTest
-	@MethodSource( "numericScales" )
+	@MethodSource( "numericMetadataValues" )
 	void testNumericScaleCoercion( Object scale ) {
 		QueryParameter parameter = QueryParameter.fromAny( Struct.of( Key.value, new BigDecimal( "12.50" ), Key.sqltype, "decimal", Key.scale, scale ) );
 		assertThat( parameter.getScaleOrLength() ).isEqualTo( 2 );
 	}
 
-	static Stream<Object> invalidScales() {
+	static Stream<Object> invalidMetadataValues() {
 		return Stream.of( 2.5D, 2.5F, new BigDecimal( "2.5" ), "2.5", "invalid", Double.NaN, Double.POSITIVE_INFINITY,
 		    Double.NEGATIVE_INFINITY, 2147483648L, -2147483649L, new BigInteger( "2147483648" ), new BigDecimal( "2147483648" ) );
 	}
 
 	@ParameterizedTest
-	@MethodSource( "invalidScales" )
+	@MethodSource( "invalidMetadataValues" )
 	void testInvalidScaleRejected( Object scale ) {
 		assertThrows( BoxCastException.class,
 		    () -> QueryParameter.fromAny( Struct.of( Key.value, 12.5, Key.sqltype, "decimal", Key.scale, scale ) ) );
@@ -64,4 +64,26 @@ public class QueryParameterTest {
 		assertThat( QueryParameter.fromAny( Struct.of( Key.value, 12.5, Key.sqltype, "decimal", Key.scale, null ) ).getScaleOrLength() ).isNull();
 		assertThat( QueryParameter.fromAny( Struct.of( Key.value, 12, Key.sqltype, "decimal", Key.scale, 0.0D ) ).getScaleOrLength() ).isEqualTo( 0 );
 	}
+
+	@ParameterizedTest
+	@MethodSource( "numericMetadataValues" )
+	void testNumericMaxLengthCoercion( Object maxLength ) {
+		QueryParameter parameter = QueryParameter.fromAny( Struct.of( Key.value, "ab", Key.sqltype, "varchar", Key.maxLength, maxLength ) );
+		assertThat( parameter.getScaleOrLength() ).isEqualTo( 2 );
+	}
+
+	@ParameterizedTest
+	@MethodSource( "invalidMetadataValues" )
+	void testInvalidMaxLengthRejected( Object maxLength ) {
+		assertThrows( BoxCastException.class,
+		    () -> QueryParameter.fromAny( Struct.of( Key.value, "ab", Key.sqltype, "varchar", Key.maxLength, maxLength ) ) );
+	}
+
+	@Test
+	void testOptionalMaxLength() {
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, "ab", Key.sqltype, "varchar" ) ).getScaleOrLength() ).isNull();
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, "ab", Key.sqltype, "varchar", Key.maxLength, null ) ).getScaleOrLength() ).isNull();
+		assertThat( QueryParameter.fromAny( Struct.of( Key.value, "", Key.sqltype, "varchar", Key.maxLength, 0.0D ) ).getScaleOrLength() ).isEqualTo( 0 );
+	}
+
 }


### PR DESCRIPTION
# Description

Coerce JDBC parameter `scale` and `maxLength` using BoxLang's non-truncating `IntegerCaster`. `queryExecute()` accepts raw parameter structs, so integral Java Double, Long, and BigDecimal metadata previously threw ClassCastException. For example, qb's inferred decimal scale could block an ordinary decimal insert. The queryparam tag already casts its attributes.

Missing/null metadata remains null. Fractional, non-numeric, non-finite and out-of-range values are rejected. Regression tests cover Java numeric representations, numeric strings, invalid values and optional metadata for both fields, plus actual Derby queries using a Double scale and Double maxLength.

## Jira Issues

[BL-2676](https://ortussolutions.atlassian.net/browse/BL-2676)

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project (spotlessApply and spotlessCheck).
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.

## Validation

Clean full suite (`./gradlew clean test spotlessCheck`): 9,712 passed, 210 skipped, zero failures/errors. `spotlessApply` passed. An earlier incremental run had missing generated module service descriptors and a concurrent-query failure; the clean rebuild and full rerun passed.

Both the decimal INSERT and varchar query reproduced the strict Java cast failure before their respective fixes. Isolated qb scale inference on BoxLang 1.17.3+62 passed 137/137 tests without the library workaround after installing the corrected QueryParameter class (136 passes/1 error before). The local qb javacast workaround was removed.


[BL-2676]: https://ortussolutions.atlassian.net/browse/BL-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ